### PR TITLE
Write a really simple Service Worker example.

### DIFF
--- a/examples/simple-demo/index.html
+++ b/examples/simple-demo/index.html
@@ -45,6 +45,12 @@
     function updateRegistered(registered) {
       window.registered = registered;
       updateSW('registered', window.registered);
+
+      if (registered) {
+        var channel = new MessageChannel;
+        channel.port1.onmessage = handleMessage;
+        window.registered.postMessage({port:channel.port2}, [channel.port2]);
+      }
     }
     function updateSW(name, sw) {
       if (sw) {
@@ -70,6 +76,19 @@
       console.error(msg);
     }
 
+    function handleMessage(e) {
+      console.log(e, 'Received');
+      if ('chat' in e.data) {
+        addChatRow('Received:', e.data.chat);
+      }
+      if ('error' in e.data) {
+        addChatRow('Error:', e.data.error);
+      }
+      if ('log' in e.data) {
+        addChatRow('Log:', e.data.log);
+      }
+    }
+
     $('#register').onclick = function(event) {
       navigator.serviceWorker.register('service-worker.js').then(function(result) {
           updateRegistered(result);
@@ -81,7 +100,7 @@
 
     $('#unregister').onclick = function(event) {
       navigator.serviceWorker.unregister('/*').then(function(result) {
-          updateRegistered(result);
+          updateRegistered(null);
           setResult(result);
         }, function(error) {
           setError(error);
@@ -112,15 +131,7 @@
         return;
       var message = $('#toSW').value;
       var channel = new MessageChannel;
-      channel.port1.onmessage = function(e) {
-        console.log(e, 'Received');
-        if ('chat' in e.data) {
-          addChatRow('Received:', e.data.chat);
-        }
-        if ('error' in e.data) {
-          addChatRow('Error:', e.data.error);
-        }
-      }
+      channel.port1.onmessage = handleMessage;
       window.registered.postMessage({chat: message, port:channel.port2}, [channel.port2]);
       addChatRow('Sent:', message);
       $('#toSW').value = '';

--- a/examples/simple-demo/service-worker.js
+++ b/examples/simple-demo/service-worker.js
@@ -1,14 +1,17 @@
-console.log('Not dead yet!');
+var Log = function(msg) {
+    if (self.lastPort)
+        self.lastPort.postMessage({log: msg});
+};
 
 oninstall = function(e) {
     e.replace();
 }
 
 onfetch = function(e) {
-    var origin = new URL(scope);
+    Log('Got a fetch event');
     var url = e.request.url;
-    console.log(url);
-    if (url == new URL("/generated.txt", origin)) {
+    Log(url);
+    if (url == new URL("/generated.txt", self.scope)) {
         return e.respondWith(new Response({
             statusCode: 200,
             headers: {


### PR DESCRIPTION
It seems useful to have a baseline SW demo in the repository, so that we can run it against the fledgling implementations to see what works.

At the moment, registration and unregistration control an entry in chrome://serviceworker-internals/, and the page can message back and forth and report errors, but not enough of the `FetchEvent` is filled in to handle fetches.
