### PR TITLE
Attempt to improve the readability of the opening paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## What's Going On Here?
 
-Service Workers are a new browsers feature that provides event-driven scripts that run independent of web pages. Unlike other Service Workers can be shut down at the end of events, not the lack of retained references from documents, and they have access to domain-wide events such as network fetches.
+Service Workers are a new browser feature that provide event-driven scripts that run independently of web pages. Unlike other workers Service Workers can be shut down at the end of events, note the lack of retained references from documents, and they have access to domain-wide events such as network fetches.
 
 ServiceWorkers also have scriptable caches. Along with the ability to respond to network requests from certain web pages via script, this provides a way for applications to "go offline".
 


### PR DESCRIPTION
The first paragraph may have typos.

I've changed:-
1. ... are a new **browsers feature** that **provides** » ... are a new **browser feature** that **provide** ...
2. ... run **independent** of web pages ... » ... run **independently** of web pages ...
3. Unlike other Service Workers can be ... » Unlike other **workers** Service Workers can be ...
4. **not** the lack of retained references ... » **note** the lack of retained references ...

Reasoning / uncertainty:-
1. _Think_ the verb "provide" should be in plural form to match "are".
2. Not sure about this one.   This _might_ be my personal preference rather than being wrong so I'd be happy to put this back.
3. Again not sure - maybe this needs comma? As in "Unlike other workers, Service Workers", also maybe should be "Workers"?
4. Really, really not sure what this sentence means.  Maybe "Unlike other workers, Service Workers can be shut down at the end of events, documents do not retain references to them, and they have ...." could be clearer (assuming I'm interpreting the meaning correctly)
