### PR TITLE
Removed "on" prefix when describing events

### DIFF
--- a/spec/service_worker/index.html
+++ b/spec/service_worker/index.html
@@ -570,7 +570,7 @@ this.addEventListener("install", function(e) {
 });
 
 this.addEventListener("fetch", function(e) {
-  // No "onfetch" events are dispatched to the ServiceWorker until it
+  // No "fetch" events are dispatched to the ServiceWorker until it
   // successfully installs.
 
   // All operations on caches are async, including matching URLs, so we use


### PR DESCRIPTION
Per issue #214, removed what I believe to be the last instance of "on"
prefixing an event name.
