### PR TITLE
Fix #380: Require a javascript content-type.

### DIFF
--- a/spec/service_worker/index.html
+++ b/spec/service_worker/index.html
@@ -1748,7 +1748,7 @@ enum <dfn id="context-enum" title="Context">Context</dfn> {
               <li>Abort these steps.</li>
             </ol>
           </li>
-          <li>Else if the Content-Type of the fetched script is not one of <code>application/x-javascript</code>, <code>text/javascript</code>, or <code>application/javascript</code>, then:
+          <li><a href="http://fetch.spec.whatwg.org/#concept-header-extract-mime-type">Extract a MIME type</a> from the header list of the fetch response. If this MIME type (ignoring parameters) is not one of <code>text/javascript</code>, <code>application/x-javascript</code>, or <code>application/javascript</code>, then:
             <ol>
               <li>Reject <var>promise</var> with a "<code><a href="http://dom.spec.whatwg.org/#securityerror">SecurityError</a></code>" exception.</li>
               <li>Set <var>registration</var>.<a href="#update-promise-internal-property">[[UpdatePromise]]</a> to null.</li>


### PR DESCRIPTION
I want to double-check that we want to omit the `*/ecmascript` content types defined by http://www.rfc-editor.org/rfc/rfc4329.txt. Nothing else from http://www.whatwg.org/specs/web-apps/current-work/multipage/scripting.html#scriptingLanguages looks like a good idea.
