### PR TITLE
Update to inline samples

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -41,12 +41,13 @@ ServiceWorkers are installed by web pages. A user must visit a page or app for t
 <html>
   <head>
     <script>
-      // scope defaults to "/*"
-      navigator.serviceWorker.register("/assets/v1/worker.js").then(
-        function(serviceWorker) {
+      // scope defaults to "/"
+      navigator.serviceWorker.register("/assets/v1/serviceworker.js").then(
+        function(registration) {
           console.log("success!");
-          serviceWorker.postMessage("Howdy from your installing page.");
-          // To use the serviceWorker immediately, you might call window.location.reload()
+          if (registration.installing) {
+            registration.installing.postMessage("Howdy from your installing page.");
+          }
         },
         function(why) {
           console.error("Installing the worker failed!:", why);

--- a/publish/service_worker/FPWD-service-workers-20140501/index.html
+++ b/publish/service_worker/FPWD-service-workers-20140501/index.html
@@ -193,7 +193,6 @@ navigator.serviceWorker.register("/assets/v1/serviceworker.js").then(
   function(serviceWorker) {
     console.log("success!");
     serviceWorker.postMessage("Howdy from your installing page.");
-    // To use the serviceWorker immediately, you might call window.location.reload()
   },
   function(why) {
     console.error("Installing the worker failed!:", why);

--- a/spec/service_worker/index.html
+++ b/spec/service_worker/index.html
@@ -192,7 +192,6 @@ navigator.serviceWorker.register("/assets/v1/serviceworker.js").then(
     console.log("success!");
     if (registration.installing) {
       registration.installing.postMessage("Howdy from your installing page.");
-      // To use the serviceWorker immediately, you might call window.location.reload()
     }
   },
   function(why) {


### PR DESCRIPTION
Removed the recommendation to call `window.location.reload()`.

Brought the example in `explainer.md` in sync with the example from the spec document.

Closes #450 
