### PR TITLE
Correcting file name in the first example to match the texts

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -42,7 +42,7 @@ ServiceWorkers are installed by web pages. A user must visit a page or app for t
   <head>
     <script>
       // scope defaults to "/"
-      navigator.serviceWorker.register("/assets/v1/serviceworker.js").then(
+      navigator.serviceWorker.register("/assets/v1/worker.js").then(
         function(registration) {
           console.log("success!");
           if (registration.installing) {


### PR DESCRIPTION
In all text, there is a explanation about a register file, but the cited name it's `worker.js` and in code `serviceworker.js`.
