### PR TITLE
Remove warning regarding Cache interface

### DIFF
--- a/spec/service_worker/index.html
+++ b/spec/service_worker/index.html
@@ -905,8 +905,6 @@ dictionary <dfn id="cache-batch-operation-dictionary" title="CacheBatchOperation
 
       <p>Each <code><a href="#cache-interface">Cache</a></code> object is associated with a <a href="#request-to-response-map-internal-interface">[[RequestToResponseMap]]</a>. Multiple separate objects implementing the <code><a href="#cache-interface">Cache</a></code> interface across <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#worker-environment">service worker environments</a> can all be associated with the same <a href="#request-to-response-map-internal-interface">[[RequestToResponseMap]]</a> simultaneously.</p>
 
-      <p class="fixme"><strong>Caveat: </strong>Implementers should note that the interface defined in this section is subject to change according to the <a href="https://github.com/slightlyoff/ServiceWorker/issues">ongoing discussion</a>. </p>
-
       <spec-section id="cache-match">
         <h1><code>match(<var>request</var>, <var>options</var>)</code></h1>
 


### PR DESCRIPTION
I assume that the discussion has setlle (the link isn't pointing to
anything specific). Tentatively removing the warning.
