### PR TITLE
It notes that this is very tightened to the use of promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Service Workers are a new browser feature that provide event-driven scripts that
 
 ServiceWorkers also have scriptable caches. Along with the ability to respond to network requests from certain web pages via script, this provides a way for applications to "go offline".
 
-Service Workers are meant to replace the ([oft maligned](http://alistapart.com/article/application-cache-is-a-douchebag)) [HTML5 Application Cache](//www.whatwg.org/specs/web-apps/current-work/multipage/offline.html). Unlike AppCache, Service Workers are comprised of scriptable primitives that make it possible for application developers to build URL-friendly, always-available applications in a sane and layered way.
+Service Workers are meant to replace the ([oft maligned](http://alistapart.com/article/application-cache-is-a-douchebag)) [HTML5 Application Cache](//www.whatwg.org/specs/web-apps/current-work/multipage/offline.html). Unlike AppCache, Service Workers are comprised of scriptable primitives with an extensive use of [Promises](//developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise) that make it possible for application developers to build URL-friendly, always-available applications in a sane and layered way.
 
 To understand the design and how you might build apps with ServiceWorkers, see the [explainer document](explainer.md).
 


### PR DESCRIPTION
Aim to alert developers and people reading that they must understand the use of Promises. 

App Cache may be a douchebag as you note here, but at least it does not force developers to new programming concepts.
