### PR TITLE
Change the rest of the links to the new repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 ## Spec and API development
 
-For the nitty-gritty of the API, the [draft W3C specification](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/) is authoritative. For implementers and developers who seek a more stable version, [Service Workers 1](https://slightlyoff.github.io/ServiceWorker/spec/service_worker_1/) is a right document with which the contributors only focus on fixing bugs and resolving compatibility issues.
+For the nitty-gritty of the API, the [draft W3C specification](https://w3c.github.io/ServiceWorker/spec/service_worker/) is authoritative. For implementers and developers who seek a more stable version, [Service Workers 1](https://w3c.github.io/ServiceWorker/spec/service_worker_1/) is a right document with which the contributors only focus on fixing bugs and resolving compatibility issues.
 
-Spec development happens via [issues in this repository](https://github.com/slightlyoff/ServiceWorker/issues). For general discussion, please use the [public-webapps@w3.org mailing list](http://lists.w3.org/Archives/Public/public-webapps/) with a `Subject:` prefix of `[service-workers]`.
+Spec development happens via [issues in this repository](https://github.com/w3c/ServiceWorker/issues). For general discussion, please use the [public-webapps@w3.org mailing list](http://lists.w3.org/Archives/Public/public-webapps/) with a `Subject:` prefix of `[service-workers]`.
 
-Updates to the spec must reference [resolved issued marked `needs spec`](issues?labels=needs+spec&state=closed).
+Updates to the spec must reference [resolved issued marked `needs spec`](https://github.com/w3c/ServiceWorker/issues?q=is%3Aclosed+label%3A%22needs+spec%22).
 
 To edit the spec locally, you’ll need a copy of [the Web Components-based framework which it is built with](https://github.com/slightlyoff/web-spec-framework). To fetch it, clone the repo and run:
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ To understand the design and how you might build apps with service workers, see 
 
 ## Spec and API development
 
-For the nitty-gritty of the API, the [draft W3C specification](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/) is authoritative. For implementers and developers who seek a more stable version, [Service Workers 1](https://slightlyoff.github.io/ServiceWorker/spec/service_worker_1/) is a right document with which the contributors only focus on fixing bugs and resolving compatibility issues.
+For the nitty-gritty of the API, the [draft W3C specification](https://w3c.github.io/ServiceWorker/spec/service_worker/) is authoritative. For implementers and developers who seek a more stable version, [Service Workers 1](https://w3c.github.io/ServiceWorker/spec/service_worker_1/) is a right document with which the contributors only focus on fixing bugs and resolving compatibility issues.
 
-Spec development happens via [issues in this repository](https://github.com/slightlyoff/ServiceWorker/issues). For general discussion, please use the [public-webapps@w3.org mailing list](http://lists.w3.org/Archives/Public/public-webapps/) with a `Subject:` prefix of `[service-workers]`.
+Spec development happens via [issues in this repository](https://github.com/w3c/ServiceWorker/issues). For general discussion, please use the [public-webapps@w3.org mailing list](http://lists.w3.org/Archives/Public/public-webapps/) with a `Subject:` prefix of `[service-workers]`.
 
-Updates to the spec must reference [resolved issued marked `needs spec`](issues?labels=needs+spec&state=closed).
+Updates to the spec must reference [resolved issued marked `needs spec`](https://github.com/w3c/ServiceWorker/issues?q=is%3Aclosed+label%3A%22needs+spec%22).
 
 To edit the spec locally, you’ll need a copy of [the Web Components-based framework which it is built with](https://github.com/slightlyoff/web-spec-framework). To fetch it, clone the repo and run:
 

--- a/implementation_considerations.md
+++ b/implementation_considerations.md
@@ -6,7 +6,7 @@ Or
 
 So you’ve got a browser engine, are looking into this whole "Service Workers" thing and have some questions. Take heart, dear reader! Your friendly spec designers/authors are here to answer your (anticipated) questions. Want more answers? [File a bug](issues) and tag it `implementation-concern`.
 
-This doc looks first at key concepts then outlines the [areas of helpful built-in ambiguity ](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/) that provide opportunities to go fast. Each opportunity includes a list of strategies that implementations might explore to improve service worker performance.
+This doc looks first at key concepts then outlines the [areas of helpful built-in ambiguity ](https://w3c.github.io/ServiceWorker/spec/service_worker/) that provide opportunities to go fast. Each opportunity includes a list of strategies that implementations might explore to improve service worker performance.
 
 ## Key concepts
 


### PR DESCRIPTION
@jungkees This will complement https://github.com/w3c/ServiceWorker/commit/eb7b112ac7055ff6afb4bb5a97ed72c4ac6c5c23 and updates the rest of the links (`s/slightlyoff/w3c/`).
