### PR TITLE
Make cache example easier to understand

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -206,8 +206,8 @@ self.addEventListener('install', function(event) {
 
 self.addEventListener('fetch', function(event) {
   event.respondWith(
-    caches.match(event.request).then(function(response) {
-      return response || fetch(event.request);
+    caches.match(event.request).then(function(cachedResponse) {
+      return cachedResponse || fetch(event.request);
     })
   );
 });


### PR DESCRIPTION
I personally think that:

```js
return cachedResponse || fetch(event.request);
```
 makes it a lot more obvious what's going on as opposed to:

```js
return response || fetch(event.request);
```

I had to do a double take with `response` as at first glance it looked like the request was being made twice.