### PR TITLE
Fix incomplete link

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -8,7 +8,7 @@ Service workers are being developed to answer frequent questions and concerns ab
  * Difficulty in building offline-first web applications in a natural way
  * The lack of a background execution context which many proposed capabilities could make use of
 
-We also note that the long lineage of declarative-only solutions ([Google Gears, [Dojo Offline](http://www.sitepen.com/blog/category/dojo-offline/), and [HTML5 AppCache](http://alistapart.com/article/application-cache-is-a-douchebag)) have failed to deliver on their promise. Each successive declarative-only approach failed in many of the same ways, so the service worker effort has taken a different design approach: a largely-imperative system that puts developers firmly in control.
+We also note that the long lineage of declarative-only solutions ([Google Gears](https://gears.google.com), [Dojo Offline](http://www.sitepen.com/blog/category/dojo-offline/), and [HTML5 AppCache](http://alistapart.com/article/application-cache-is-a-douchebag)) have failed to deliver on their promise. Each successive declarative-only approach failed in many of the same ways, so the service worker effort has taken a different design approach: a largely-imperative system that puts developers firmly in control.
 
 The service worker is like a [shared worker](https://html.spec.whatwg.org/multipage/workers.html#sharedworker) in that it:
 


### PR DESCRIPTION
If “Google Gears” was supposed to be a link (just as Dojo Offline/AppCache are), now it is one. Otherwise, I’d suggest to remove the lonely opening square bracket. ;)
