### PR TITLE
Editorial: more link-defaults and anchors cleanup

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -23,13 +23,6 @@ Markup Shorthands: css no
 
 <pre class=biblio>
 {
-  "promises-guide": {
-    "href": "https://www.w3.org/2001/tag/doc/promises-guide",
-    "title": "Writing Promise-Using Specifications",
-    "date": "24 July 2015",
-    "status": "Finding of the W3C TAG",
-    "publisher": "W3C TAG"
-  },
   "unsanctioned-tracking": {
     "href": "https://www.w3.org/2001/tag/doc/unsanctioned-tracking/",
     "title": "Unsanctioned Web Tracking",
@@ -41,13 +34,15 @@ Markup Shorthands: css no
 </pre>
 
 <pre class=link-defaults>
-spec: dom; type: interface; text: Document
-spec: html; type: element; text: link
-spec: url; type: dfn; text: is local
+spec: dom;
+    type: interface; text: Document
+spec: html;
+    type: element; text: link
+    type: dfn; text: task queues; for: /
 </pre>
 
 <pre class=anchors>
-spec: dom-ls; urlPrefix: https://dom.spec.whatwg.org/
+spec: DOM; urlPrefix: https://dom.spec.whatwg.org/
     type: dfn; text: ASCII case-insensitive; url: ascii-case-insensitive
 
 spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
@@ -67,29 +62,20 @@ spec: csp2; urlPrefix: https://w3c.github.io/webappsec-csp/2/
 
 spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
     type: dfn
-        text: basic filtered response; url: concept-filtered-response-basic
         text: cancel a ReadableStream; url: concept-cancel-readablestream
         text: close ReadableStream; url: concept-close-readablestream
         text: construct a ReadableStream; url: concept-construct-readablestream
-        text: CORS filtered response; url: concept-filtered-response-cors
         text: disturbed; url: concept-body-disturbed
         text: empty; url: concept-empty-readablestream
         text: enqueue a chunk to ReadableStream; url: concept-enqueue-readablestream
         text: error ReadableStream; url: concept-error-readablestream
         text: errored; url: concept-readablestream-errored
-        text: extract a mime type; url: concept-header-extract-mime-type
         text: fetch; url: concept-fetch
-        text: filtered response; url: concept-filtered-response
         text: get a reader; url: concept-get-reader
-        text: header; url: concept-header
         text: http fetch; url: concept-http-fetch
         text: HTTPS state value; url: concept-https-state-value
         text: internal response; url: concept-internal-response
         text: locked; url: concept-body-locked
-        text: navigation request
-        text: network error; url: concept-network-error
-        text: non-subresource request
-        text: ok status; url: ok-status
         text: opaque filtered response; url: concept-filtered-response-opaque
         text: opaque-redirect filtered response; url: concept-filtered-response-opaque-redirect
         text: potential-navigation-or-subresource request
@@ -102,8 +88,6 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
         text: response; for: fetch; url: concept-response
         text: skip service worker flag
         text: stream; url: concept-body-stream
-        text: subresource request
-        text: synchronous flag
         text: terminate; url: concept-fetch-terminate
         text: guard; for: headers; url: concept-headers-guard
         for: Body; urlPrefix: #concept-body-
@@ -112,67 +96,15 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
             text: name
             text: parsing; url: parse
         for: request; urlPrefix: #concept-request-
-            text: cache mode
-            text: client
-            text: destination
-            text: header list
-            text: initiator
-            text: method
-            text: origin
-            text: redirect mode
             text: request
-            text: reserved client
-            text: response tainting
-            text: target client id
-            text: url
+            text: origin
         for: response; urlPrefix: #concept-response-
-            text: body
-            text: cache state
-            text: CORS-exposed header-name list
-            text: header list
-            text: https state
             text: response
-            text: status
-            text: termination reason
-            text: type
-    type: interface
-        text: Headers
-        text: Request
-        text: RequestInfo
-        text: Response
-    type: attribute; for: Request
-        text: headers; url: dom-request-headers
-    type: method
-        text: get(name); for: Headers; url: dom-headers-get
-        text: fetch(input, init); for: GlobalFetch; url: dom-global-fetch
 
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     type: dfn
         urlPrefix: browsers.html
             text: origin; for: resource; url: origin-2
-        urlPrefix: infrastructure.html
-            text: inserted into a document; url: insert-an-element-into-a-document
-        urlPrefix: interaction.html
-            text: has focus steps
-        urlPrefix: semantics.html
-            text: external resource link
-        urlPrefix: webappapis.html
-            text: dom manipulation task source
-            text: environment
-            text: run a classic script
-            text: run a module script
-            text: task queue; for: event loop
-            for: environment; urlPrefix: #concept-environment-
-                text: active service worker
-                text: creation URL
-                text: id
-        urlPrefix: workers.html
-            text: shared workers
-            text: web worker; url: workers
-    type: event
-        urlPrefix: indices.html
-            text: DOMContentLoaded; for: Document; url: event-domcontentloaded
-            text: message; for: Window; url: event-message
 
 spec: page-visibility; urlPrefix: https://www.w3.org/TR/page-visibility/
     type: enum; text: VisibilityState; url: VisibilityState
@@ -184,11 +116,6 @@ spec: secure-contexts; urlPrefix: https://w3c.github.io/webappsec-secure-context
         text: potentially trustworthy url; url: potentially-trustworthy-url
         text: risks associated with insecure contexts; url: threat-risks
         text: secure context
-
-spec: promises-guide; urlPrefix: https://www.w3.org/2001/tag/doc/promises-guide#
-    type: dfn
-        text: waiting for all
-        text: transforming; url: transforming-by
 
 spec: quota-api; urlPrefix: http://www.w3.org/TR/quota-api/
     type: attribute; for: ServiceWorkerGlobalScope
@@ -272,7 +199,7 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
     <p>A <a href="#dfn-service-worker-registration">service worker registration</a> has an associated <dfn export id="dfn-active-worker">active worker</dfn> (a <a href="#dfn-service-worker">service worker</a> or null) whose <a href="#dfn-state">state</a> is either <em>activating</em> or <em>activated</em>. It is initially set to null.</p>
     <p>A <a href="#dfn-service-worker-registration">service worker registration</a> has an associated <dfn id="dfn-last-update-check-time">last update check time</dfn>. It is initially set to null.</p>
     <p>A <a href="#dfn-service-worker-registration">service worker registration</a> has an associated <dfn id="dfn-uninstalling-flag">uninstalling flag</dfn>. It is initially unset.</p>
-    <p>A <a href="#dfn-service-worker-registration">service worker registration</a> has one or more <dfn id="dfn-service-worker-registration-task-queue" for="service worker registration">task queues</dfn> that back up the <a>tasks</a> from its <a href="#dfn-active-worker">active worker</a>'s <a>event loop</a>'s corresponding <a for="event loop">task queues</a>. (The target task sources for this back up operation are the <a href="#dfn-handle-fetch-task-source">handle fetch task source</a> and the <a href="#dfn-handle-functional-event-task-source">handle functional event task source</a>.) The user agent dumps the <a href="#dfn-active-worker">active worker</a>'s <a>tasks</a> to the <a href="#dfn-service-worker-registration">service worker registration</a>'s <a for="service worker registration">task queues</a> when the <a href="#dfn-active-worker">active worker</a> is <a href="#terminate-service-worker-algorithm">terminated</a> and <a lt="queue a task">re-queues those tasks</a> to the <a href="#dfn-active-worker">active worker</a>'s <a>event loop</a>'s corresponding <a for="event loop">task queues</a> when the <a href="#dfn-active-worker">active worker</a> spins off. Unlike the <a for="event loop">task queues</a> owned by <a>event loops</a>, the <a href="#dfn-service-worker-registration">service worker registration</a>'s <a for="service worker registration">task queues</a> are not processed by any <a>event loops</a> in and of itself.</p>
+    <p>A <a href="#dfn-service-worker-registration">service worker registration</a> has one or more <dfn id="dfn-service-worker-registration-task-queue" for="service worker registration">task queues</dfn> that back up the <a>tasks</a> from its <a href="#dfn-active-worker">active worker</a>'s <a>event loop</a>'s corresponding <a for="/">task queues</a>. (The target task sources for this back up operation are the <a href="#dfn-handle-fetch-task-source">handle fetch task source</a> and the <a href="#dfn-handle-functional-event-task-source">handle functional event task source</a>.) The user agent dumps the <a href="#dfn-active-worker">active worker</a>'s <a>tasks</a> to the <a href="#dfn-service-worker-registration">service worker registration</a>'s <a for="service worker registration">task queues</a> when the <a href="#dfn-active-worker">active worker</a> is <a href="#terminate-service-worker-algorithm">terminated</a> and <a lt="queue a task">re-queues those tasks</a> to the <a href="#dfn-active-worker">active worker</a>'s <a>event loop</a>'s corresponding <a for="/">task queues</a> when the <a href="#dfn-active-worker">active worker</a> spins off. Unlike the <a for="/">task queues</a> owned by <a>event loops</a>, the <a href="#dfn-service-worker-registration">service worker registration</a>'s <a for="service worker registration">task queues</a> are not processed by any <a>event loops</a> in and of itself.</p>
 
     <section>
       <h4 id="service-worker-registration-lifetime">Lifetime</h4>
@@ -2019,12 +1946,12 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
         <tr>
           <td><dfn event id="service-worker-global-scope-fetch-event"><code>fetch</code></dfn></td>
           <td>{{FetchEvent}}</td>
-          <td>[<a href="#dfn-functional-events">Functional event</a>] The <a>http fetch</a> invokes <a href="#on-fetch-request-algorithm">Handle Fetch</a> with <var>request</var>. As a result of performing <a href="#on-fetch-request-algorithm">Handle Fetch</a>, the <a href="#dfn-service-worker-global-scope-service-worker">service worker</a> returns a <a for="fetch">response</a> to the <a>http fetch</a>. The <a for="fetch">response</a>, represented by a {{Response}} object, can be retrieved from a {{Cache}} object or directly from network using {{GlobalFetch/fetch(input, init)|self.fetch(input, init)}} method. (A custom {{Response}} object can be another option.)</td>
+          <td>[<a href="#dfn-functional-events">Functional event</a>] The <a>http fetch</a> invokes <a href="#on-fetch-request-algorithm">Handle Fetch</a> with <var>request</var>. As a result of performing <a href="#on-fetch-request-algorithm">Handle Fetch</a>, the <a href="#dfn-service-worker-global-scope-service-worker">service worker</a> returns a <a for="fetch">response</a> to the <a>http fetch</a>. The <a for="fetch">response</a>, represented by a {{Response}} object, can be retrieved from a {{Cache}} object or directly from network using {{WindowOrWorkerGlobalScope/fetch(input, init)|self.fetch(input, init)}} method. (A custom {{Response}} object can be another option.)</td>
         </tr>
         <tr>
           <td><dfn event id="service-worker-global-scope-foreignfetch-event"><code>foreignfetch</code></dfn></td>
           <td>{{FetchEvent}}</td>
-          <td>[<a href="#dfn-functional-events">Functional event</a>] The <a>http fetch</a> invokes [[#on-foreign-fetch-request-algorithm]] with <var>request</var>. As a result of performing [[#on-foreign-fetch-request-algorithm]], the <a for="ServiceWorkerGlobalScope">service worker</a> returns a <a for="fetch">response</a> to the <a>http fetch</a>. The <a for="fetch">response</a>, represented by a {{Response}} object, can be retrieved from a {{Cache}} object or directly from network using {{GlobalFetch/fetch(input, init)|self.fetch(input, init)}} method. (A custom {{Response}} object can be another option.)</td>
+          <td>[<a href="#dfn-functional-events">Functional event</a>] The <a>http fetch</a> invokes [[#on-foreign-fetch-request-algorithm]] with <var>request</var>. As a result of performing [[#on-foreign-fetch-request-algorithm]], the <a for="ServiceWorkerGlobalScope">service worker</a> returns a <a for="fetch">response</a> to the <a>http fetch</a>. The <a for="fetch">response</a>, represented by a {{Response}} object, can be retrieved from a {{Cache}} object or directly from network using {{WindowOrWorkerGlobalScope/fetch(input, init)|self.fetch(input, init)}} method. (A custom {{Response}} object can be another option.)</td>
         </tr>
         <tr>
           <td><dfn event id="service-worker-global-scope-message-event"><code>message</code></dfn></td>
@@ -3470,7 +3397,7 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
       <li>Set <var>workerGlobalScope</var>'s <a for="WorkerGlobalScope">referrer policy</a> to <var>serviceWorker</var>'s <a>script resource</a>'s <a href="#dfn-referrer-policy">referrer policy</a>.</li>
       <li>Set <var>workerGlobalScope</var>'s <a for="WorkerGlobalScope">type</a> to <var>serviceWorker</var>'s <a href="#dfn-type">type</a>.</li>
       <li>Create a new {{WorkerLocation}} object and associate it with <var>workerGlobalScope</var>.</li>
-      <li>If <var>serviceWorker</var> is an <a href="#dfn-active-worker">active worker</a>, and there are any <a>tasks</a> queued in <var>serviceWorker</var>'s <a href="#dfn-containing-service-worker-registration">containing service worker registration</a>'s <a for="service worker registration">task queues</a>, <a lt="queue a task">queue</a> them to <var>serviceWorker</var>'s <a>event loop</a>'s <a for="event loop">task queues</a> in the same order using their original <a>task sources</a>.</li>
+      <li>If <var>serviceWorker</var> is an <a href="#dfn-active-worker">active worker</a>, and there are any <a>tasks</a> queued in <var>serviceWorker</var>'s <a href="#dfn-containing-service-worker-registration">containing service worker registration</a>'s <a for="service worker registration">task queues</a>, <a lt="queue a task">queue</a> them to <var>serviceWorker</var>'s <a>event loop</a>'s <a for="/">task queues</a> in the same order using their original <a>task sources</a>.</li>
       <li>If <var>script</var> is a <a>classic script</a>, then <a lt="run a classic script">run the classic script</a> <var>script</var>. Otherwise, it is a <a>module script</a>; <a lt="run a module script">run the module script</a> <var>script</var>.
         <p class="note">In addition to the usual possibilities of returning a value or failing due to an exception, this could be prematurely aborted by the <a>kill a worker</a> or <a>terminate a worker</a> algorithms.</p>
       </li>
@@ -3500,7 +3427,7 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
       <li>If <var>serviceWorker</var> is not running, abort these steps.</li>
       <li>Let <var>serviceWorkerGlobalScope</var> be <var>serviceWorker</var>'s <a>environment settings object</a>'s <a for="environment settings object">global object</a>.</li>
       <li>Set <var>serviceWorkerGlobalScope</var>'s closing flag to true.</li>
-      <li>If there are any <a>tasks</a>, whose <a>task source</a> is either the <a href="#dfn-handle-fetch-task-source">handle fetch task source</a> or the <a href="#dfn-handle-functional-event-task-source">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>'s <a>event loop</a>'s <a for="event loop">task queues</a>, <a lt="queue a task">queue</a> them to <var>serviceWorker</var>'s <a href="#dfn-containing-service-worker-registration">containing service worker registration</a>'s corresponding <a for="service worker registration">task queues</a> in the same order using their original <a>task sources</a>, and discard all the <a>tasks</a> (including <a>tasks</a> whose <a>task source</a> is neither the <a href="#dfn-handle-fetch-task-source">handle fetch task source</a> nor the <a href="#dfn-handle-functional-event-task-source">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>'s <a>event loop</a>'s <a for="event loop">task queues</a> without processing them.
+      <li>If there are any <a>tasks</a>, whose <a>task source</a> is either the <a href="#dfn-handle-fetch-task-source">handle fetch task source</a> or the <a href="#dfn-handle-functional-event-task-source">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>'s <a>event loop</a>'s <a for="/">task queues</a>, <a lt="queue a task">queue</a> them to <var>serviceWorker</var>'s <a href="#dfn-containing-service-worker-registration">containing service worker registration</a>'s corresponding <a for="service worker registration">task queues</a> in the same order using their original <a>task sources</a>, and discard all the <a>tasks</a> (including <a>tasks</a> whose <a>task source</a> is neither the <a href="#dfn-handle-fetch-task-source">handle fetch task source</a> nor the <a href="#dfn-handle-functional-event-task-source">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>'s <a>event loop</a>'s <a for="/">task queues</a> without processing them.
         <p class="note">This effectively means that the fetch events and the other functional events such as push events are backed up by the registration's task queues while the other tasks including message events are discarded.</p>
       </li>
       <li>Abort the script currently running in <var>serviceWorker</var>.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3224,11 +3224,11 @@ pre.idl.highlight { color: #708090; }
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-fetch-event"><code>fetch</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#fetch-event-interface" id="ref-for-fetch-event-interface-4">FetchEvent</a></code>
-        <td>[<a href="#dfn-functional-events" id="ref-for-dfn-functional-events-5">Functional event</a>] The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a> invokes <a href="#on-fetch-request-algorithm" id="ref-for-on-fetch-request-algorithm-5">Handle Fetch</a> with <var>request</var>. As a result of performing <a href="#on-fetch-request-algorithm" id="ref-for-on-fetch-request-algorithm-6">Handle Fetch</a>, the <a href="#dfn-service-worker-global-scope-service-worker" id="ref-for-dfn-service-worker-global-scope-service-worker-19">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache-interface" id="ref-for-cache-interface-1">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
+        <td>[<a href="#dfn-functional-events" id="ref-for-dfn-functional-events-5">Functional event</a>] The <a data-link-type="dfn">http fetch</a> invokes <a href="#on-fetch-request-algorithm" id="ref-for-on-fetch-request-algorithm-5">Handle Fetch</a> with <var>request</var>. As a result of performing <a href="#on-fetch-request-algorithm" id="ref-for-on-fetch-request-algorithm-6">Handle Fetch</a>, the <a href="#dfn-service-worker-global-scope-service-worker" id="ref-for-dfn-service-worker-global-scope-service-worker-19">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache-interface" id="ref-for-cache-interface-1">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-foreignfetch-event"><code>foreignfetch</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#fetch-event-interface" id="ref-for-fetch-event-interface-5">FetchEvent</a></code>
-        <td>[<a href="#dfn-functional-events" id="ref-for-dfn-functional-events-6">Functional event</a>] The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a> invokes <a href="#on-foreign-fetch-request-algorithm" id="ref-for-on-foreign-fetch-request-algorithm-3">Handle Foreign Fetch</a> with <var>request</var>. As a result of performing <a href="#on-foreign-fetch-request-algorithm" id="ref-for-on-foreign-fetch-request-algorithm-4">Handle Foreign Fetch</a>, the <a data-link-type="dfn" href="#dfn-service-worker-global-scope-service-worker" id="ref-for-dfn-service-worker-global-scope-service-worker-20">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache-interface" id="ref-for-cache-interface-2">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
+        <td>[<a href="#dfn-functional-events" id="ref-for-dfn-functional-events-6">Functional event</a>] The <a data-link-type="dfn">http fetch</a> invokes <a href="#on-foreign-fetch-request-algorithm" id="ref-for-on-foreign-fetch-request-algorithm-3">Handle Foreign Fetch</a> with <var>request</var>. As a result of performing <a href="#on-foreign-fetch-request-algorithm" id="ref-for-on-foreign-fetch-request-algorithm-4">Handle Foreign Fetch</a>, the <a data-link-type="dfn" href="#dfn-service-worker-global-scope-service-worker" id="ref-for-dfn-service-worker-global-scope-service-worker-20">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache-interface" id="ref-for-cache-interface-2">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-message-event"><code>message</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#extendablemessage-event-interface" id="ref-for-extendablemessage-event-interface-4">ExtendableMessageEvent</a></code>
@@ -3281,7 +3281,7 @@ pre.idl.highlight { color: #708090; }
 <pre class="highlight">Link: &lt;/js/sw.js>; rel="serviceworker"; scope="/"
 </pre>
       <p>has more or less the same effect as a document being loaded in a secure context with the following <code>link</code> element:</p>
-<pre class="lang-html highlight"><span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"serviceworker"</span> <span class="na">href</span><span class="o">=</span><span class="s">"/js/sw.js"</span> <span class="na">scope</span><span class="o">=</span><span class="s">"/"</span><span class="p">></span>
+<pre class="lang-html highlight"><span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"serviceworker"</span> <span class="na">href=</span><span class="s">"/js/sw.js"</span> <span class="na">scope=</span><span class="s">"/"</span><span class="nt">></span>
 </pre>
       <p>which is more or less equivalent to the page containing javascript code like:</p>
 <pre class="lang-js highlight">navigator<span class="p">.</span>serviceworker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
@@ -3447,7 +3447,7 @@ pre.idl.highlight { color: #708090; }
       <ol>
        <li>Let <var>requests</var> be an array containing only <var>request</var>.
        <li>Set <var>responseArrayPromise</var> to the result of running the algorithm specified in <code class="idl"><a data-link-type="idl" href="#cache-addAll-method" id="ref-for-cache-addAll-method-2">addAll(requests)</a></code> passing <var>requests</var> as the argument.
-       <li>Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#transforming-by">transforming</a> <var>responseArrayPromise</var> with a fulfillment handler that returns undefined.
+       <li>Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#transforming-by">transforming</a> <var>responseArrayPromise</var> with a fulfillment handler that returns undefined.
       </ol>
      </section>
      <section class="algorithm" data-algorithm="cache-addAll">
@@ -3504,9 +3504,9 @@ pre.idl.highlight { color: #708090; }
           </ul>
          <li>Add <var>responsePromise</var> to <var>responsePromiseArray</var>.
         </ol>
-       <li>Let <var>p</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all">waiting for all</a> of <var>responsePromiseArray</var>.
+       <li>Let <var>p</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#waiting-for-all">waiting for all</a> of <var>responsePromiseArray</var>.
        <li>
-        Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#transforming-by">transforming</a> <var>p</var> with a fulfillment handler that, when called with argument <var>responseArray</var>, performs the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
+        Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#transforming-by">transforming</a> <var>p</var> with a fulfillment handler that, when called with argument <var>responseArray</var>, performs the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
         <ol>
          <li>Let <var>operations</var> be an empty array.
          <li>
@@ -3520,7 +3520,7 @@ pre.idl.highlight { color: #708090; }
           </ol>
          <li>Let <var>resultPromise</var> be the result of running <a href="#batch-cache-operations-algorithm">Batch Cache Operations</a> algorithm passing <var>operations</var> as the argument.
          <li>
-          Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#transforming-by">transforming</a> <var>resultPromise</var> with a fulfillment handler that, when called with argument <var>responses</var>, performs the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
+          Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#transforming-by">transforming</a> <var>resultPromise</var> with a fulfillment handler that, when called with argument <var>responses</var>, performs the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
           <ol>
            <li>Let <var>responseBodyPromiseArray</var> be an empty array.
            <li>
@@ -3561,8 +3561,8 @@ pre.idl.highlight { color: #708090; }
               </ol>
              <li>Add <var>responseBodyPromise</var> to <var>responseBodyPromiseArray</var>.
             </ol>
-           <li>Let <var>q</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all">waiting for all</a> of <var>responseBodyPromiseArray</var>.
-           <li>Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#transforming-by">transforming</a> <var>q</var> with a fulfillment handler that returns undefined.
+           <li>Let <var>q</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#waiting-for-all">waiting for all</a> of <var>responseBodyPromiseArray</var>.
+           <li>Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#transforming-by">transforming</a> <var>q</var> with a fulfillment handler that returns undefined.
           </ol>
         </ol>
       </ol>
@@ -3612,7 +3612,7 @@ pre.idl.highlight { color: #708090; }
        <li>Add <var>o</var> to <var>operations</var>.
        <li>Let <var>resultPromise</var> be the result of running <a href="#batch-cache-operations-algorithm">Batch Cache Operations</a> passing <var>operations</var> as the argument.
        <li>
-        Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#transforming-by">transforming</a> <var>resultPromise</var> with a fulfillment handler that, when called with argument <var>responses</var>, performs the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
+        Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#transforming-by">transforming</a> <var>resultPromise</var> with a fulfillment handler that, when called with argument <var>responses</var>, performs the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
         <ol>
          <li>Wait for either end-of-file to have been pushed to <var>responses</var>[0]'s associated <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">response</a> <var>r</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body">body</a> or for <var>r</var> to have a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-termination-reason">termination reason</a>.
          <li>
@@ -3669,7 +3669,7 @@ pre.idl.highlight { color: #708090; }
        <li>Add <var>o</var> to <var>operations</var>.
        <li>Let <var>resultPromise</var> be the result of running <a href="#batch-cache-operations-algorithm">Batch Cache Operations</a> passing <var>operations</var> as the argument.
        <li>
-        Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#transforming-by">transforming</a> <var>resultPromise</var> with a fulfillment handler, when called with argument <var>responseArray</var>, performs the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
+        Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#transforming-by">transforming</a> <var>resultPromise</var> with a fulfillment handler, when called with argument <var>responseArray</var>, performs the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
         <ol>
          <li>If <var>responseArray</var> is not null, return true.
          <li>Else, return false.
@@ -3767,7 +3767,7 @@ pre.idl.highlight { color: #708090; }
           For each <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a> {[[key]], [[value]]} <var>entry</var> of its <a href="#dfn-name-to-cache-map" id="ref-for-dfn-name-to-cache-map-5">name to cache map</a>, in key insertion order: 
           <ol>
            <li>
-            Set <var>p</var> to the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#transforming-by">transforming</a> itself with a fulfillment handler that, when called with argument <var>v</var>, performs the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
+            Set <var>p</var> to the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#transforming-by">transforming</a> itself with a fulfillment handler that, when called with argument <var>v</var>, performs the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
             <ol>
              <li>If <var>v</var> is not undefined, return <var>v</var>.
              <li>Return the result of running the algorithm specified in <code class="idl"><a data-link-type="idl" href="#cache-match-method" id="ref-for-cache-match-method-5">match(request, options)</a></code> method of <code class="idl"><a data-link-type="idl" href="#cache-interface" id="ref-for-cache-interface-18">Cache</a></code> interface with <var>request</var> and <var>options</var> as the arguments (providing <var>entry</var>.[[value]] as thisArgument to the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist">[[Call]]</a> internal method of <code class="idl"><a data-link-type="idl" href="#cache-match-method" id="ref-for-cache-match-method-6">match(request, options)</a></code>.)
@@ -3828,7 +3828,7 @@ pre.idl.highlight { color: #708090; }
       <ol>
        <li>Let <var>p</var> be the result of running the algorithm specified in <code class="idl"><a data-link-type="idl" href="#cache-storage-has-method" id="ref-for-cache-storage-has-method-3">has(cacheName)</a></code> method with <var>cacheName</var> as the argument.
        <li>
-        Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#transforming-by">transforming</a> <var>p</var> with a fulfillment handler that, when called with argument <var>cacheExists</var>, performs the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
+        Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#transforming-by">transforming</a> <var>p</var> with a fulfillment handler that, when called with argument <var>cacheExists</var>, performs the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
         <ol>
          <li>
           If <var>cacheExists</var> is true, then: 
@@ -4370,7 +4370,7 @@ pre.idl.highlight { color: #708090; }
           <em>WaitForAsynchronousExtensions</em>: Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
           <ol>
            <li>Wait until <var>e</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-5">extensions allowed flag</a> is unset.
-           <li>If the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all">waiting for all</a> of <var>e</var>’s <a data-link-type="dfn" href="#dfn-extend-lifetime-promises" id="ref-for-dfn-extend-lifetime-promises-13">extend lifetime promises</a> rejected, set <var>installFailed</var> to true.
+           <li>If the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#waiting-for-all">waiting for all</a> of <var>e</var>’s <a data-link-type="dfn" href="#dfn-extend-lifetime-promises" id="ref-for-dfn-extend-lifetime-promises-13">extend lifetime promises</a> rejected, set <var>installFailed</var> to true.
           </ol>
         </ol>
        <p>If <var>task</var> is discarded or the script has been aborted by the <a href="#terminate-service-worker-algorithm">termination</a> of <var>installingWorker</var>, set <var>installFailed</var> to true.</p>
@@ -5218,7 +5218,7 @@ pre.idl.highlight { color: #708090; }
       <ol>
        <li>Let <var>p</var> be a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolved with no value.
        <li>
-        Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#transforming-by">transforming</a> <var>p</var> with a fulfillment handler that performs the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
+        Return the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#transforming-by">transforming</a> <var>p</var> with a fulfillment handler that performs the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: 
         <ol>
          <li>Let <var>itemsCopy</var> be a new <a href="#dfn-request-to-response-map" id="ref-for-dfn-request-to-response-map-18">request to response map</a> that is a copy of its <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a href="#dfn-request-to-response-map" id="ref-for-dfn-request-to-response-map-19">request to response map</a>.
          <li>Let <var>addedRecords</var> be an empty array.
@@ -5821,6 +5821,7 @@ pre.idl.highlight { color: #708090; }
      <li><a href="https://dom.spec.whatwg.org/#event">Event</a>
      <li><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a>
      <li><a href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>
+     <li><a href="https://dom.spec.whatwg.org/#ascii-case-insensitive">ascii case-insensitive</a>
      <li><a href="https://dom.spec.whatwg.org/#canceled-flag">canceled flag</a>
      <li><a href="https://dom.spec.whatwg.org/#context-object">context object</a>
      <li><a href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a>
@@ -5833,11 +5834,6 @@ pre.idl.highlight { color: #708090; }
      <li><a href="https://dom.spec.whatwg.org/#concept-reflect">reflect</a>
      <li><a href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">stop immediate propagation flag</a>
      <li><a href="https://dom.spec.whatwg.org/#stop-propagation-flag">stop propagation flag</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[dom-ls]</a> defines the following terms:
-    <ul>
-     <li><a href="https://dom.spec.whatwg.org/#ascii-case-insensitive">ascii case-insensitive</a>
     </ul>
    <li>
     <a data-link-type="biblio">[ECMASCRIPT]</a> defines the following terms:
@@ -5884,7 +5880,6 @@ pre.idl.highlight { color: #708090; }
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-header-list">header list <small>(for request)</small></a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list <small>(for response)</small></a>
      <li><a href="https://fetch.spec.whatwg.org/#dom-request-headers">headers</a>
-     <li><a href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-response-https-state">https state</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-https-state-value">https state value</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-initiator">initiator</a>
@@ -6005,11 +6000,11 @@ pre.idl.highlight { color: #708090; }
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">run a module script</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">script</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#shared-workers">shared workers</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#shared-workers">shared worker</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#source-browsing-context">source browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">target browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queue</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">terminate a worker</a>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#the-worker&apos;s-documents">the worker's documents</a>
@@ -6032,8 +6027,8 @@ pre.idl.highlight { color: #708090; }
    <li>
     <a data-link-type="biblio">[promises-guide]</a> defines the following terms:
     <ul>
-     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide#transforming-by">transforming</a>
-     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all">waiting for all</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#transforming-by">transforming</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#waiting-for-all">waiting for all</a>
     </ul>
    <li>
     <a data-link-type="biblio">[quota-api]</a> defines the following terms:
@@ -6113,7 +6108,7 @@ pre.idl.highlight { color: #708090; }
    <dt id="biblio-page-visibility">[PAGE-VISIBILITY]
    <dd>Jatinder Mann; Arvind Jain. <a href="https://www.w3.org/TR/page-visibility/">Page Visibility (Second Edition)</a>. 29 October 2013. REC. URL: <a href="https://www.w3.org/TR/page-visibility/">https://www.w3.org/TR/page-visibility/</a>
    <dt id="biblio-promises-guide">[PROMISES-GUIDE]
-   <dd><a href="https://www.w3.org/2001/tag/doc/promises-guide">Writing Promise-Using Specifications</a>. 24 July 2015. Finding of the W3C TAG. URL: <a href="https://www.w3.org/2001/tag/doc/promises-guide">https://www.w3.org/2001/tag/doc/promises-guide</a>
+   <dd>Domenic Denicola. <a href="https://www.w3.org/2001/tag/doc/promises-guide">Writing Promise-Using Specifications</a>. 16 February 2016. Finding of the W3C TAG. URL: <a href="https://www.w3.org/2001/tag/doc/promises-guide">https://www.w3.org/2001/tag/doc/promises-guide</a>
    <dt id="biblio-quota-api">[QUOTA-API]
    <dd>Kinuko Yasuda. <a href="https://w3c.github.io/quota-api/">Quota Management API</a>. URL: <a href="https://w3c.github.io/quota-api/">https://w3c.github.io/quota-api/</a>
    <dt id="biblio-rfc2119">[RFC2119]


### PR DESCRIPTION
I extracted out some more safe changes from #995. As you can see from the .html diff, there's not much difference; it's mostly just removing anchors blocks.