### PR TITLE
Add more Soft Update on functional events

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3414,7 +3414,12 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
         </ol>
       </li>
       <li>Let <var>activeWorker</var> be <var>registration</var>'s <a href="#dfn-active-worker">active worker</a>.</li>
-      <li>If <var>activeWorker</var>'s <a href="#dfn-set-of-event-types-to-handle">set of event types to handle</a> does not contain <code>fetch</code>, return null.
+      <li>If <var>activeWorker</var>'s <a href="#dfn-set-of-event-types-to-handle">set of event types to handle</a> does not contain <code>fetch</code>, then:
+        <ol>
+          <li>Return null and continue running these steps <a>in parallel</a>.</li>
+          <li>If <var>request</var> is a <a>non-subresource request</a>, or <var>request</var> is a <a>subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>'s <a href="#dfn-last-update-check-time">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.</li>
+          <li>Abort these steps.</li>
+        </ol>
         <p class="note">To avoid unnecessary delays, the Handle Fetch enforces early return when no event listeners have been deterministically added in the service worker's global during the very first script execution.</p>
       </li>
       <li>If <var>activeWorker</var>'s <a href="#dfn-state">state</a> is <em>activating</em>, wait for <var>activeWorker</var>'s <a href="#dfn-state">state</a> to become <em>activated</em>.</li>
@@ -3444,21 +3449,21 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
       <li>Wait for <var>task</var> to have executed or been discarded.</li>
       <li>If <var>respondWithEntered</var> is false, then:
         <ol>
-          <li>If <var>eventCanceled</var> is true, return a <a>network error</a> and continue running these substeps <a>in parallel</a>.</li>
-          <li>Else, return null and continue running these substeps <a>in parallel</a>.</li>
+          <li>If <var>eventCanceled</var> is true, return a <a>network error</a> and continue running these steps <a>in parallel</a>.</li>
+          <li>Else, return null and continue running these steps <a>in parallel</a>.</li>
           <li>If <var>request</var> is a <a>non-subresource request</a>, or <var>request</var> is a <a>subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>'s <a href="#dfn-last-update-check-time">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.</li>
           <li>Abort these steps.</li>
         </ol>
       </li>
       <li>If <var>handleFetchFailed</var> is true, then:
         <ol>
-          <li>Return a <a>network error</a> and continue running these substeps <a>in parallel</a>.</li>
+          <li>Return a <a>network error</a> and continue running these steps <a>in parallel</a>.</li>
           <li>If <var>request</var> is a <a>non-subresource request</a>, or <var>request</var> is a <a>subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>'s <a href="#dfn-last-update-check-time">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.</li>
         </ol>
       </li>
       <li>Else:
         <ol>
-          <li>Return <var>response</var> and continue running these substeps <a>in parallel</a>.</li>
+          <li>Return <var>response</var> and continue running these steps <a>in parallel</a>.</li>
           <li>If <var>request</var> is a <a>non-subresource request</a>, or <var>request</var> is a <a>subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>'s <a href="#dfn-last-update-check-time">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.</li>
         </ol>
       </li>
@@ -3578,7 +3583,12 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
       <li><a>Assert</a>: a <a>Record</a> with the \[[value]] equals to <var>registration</var> is contained in <a href="#dfn-scope-to-registration-map">scope to registration map</a>.</li>
       <li><a>Assert</a>: <var>registration</var>'s <a href="#dfn-active-worker">active worker</a> is not null.</li>
       <li>Let <var>activeWorker</var> be <var>registration</var>'s <a href="#dfn-active-worker">active worker</a>.</li>
-      <li>If <var>activeWorker</var>'s <a href="#dfn-set-of-event-types-to-handle">set of event types to handle</a> does not contain the event type for this functional event, return.
+      <li>If <var>activeWorker</var>'s <a href="#dfn-set-of-event-types-to-handle">set of event types to handle</a> does not contain the event type for this functional event, then:
+        <ol>
+          <li>Return and continue running these steps <a>in parallel</a>.</li>
+          <li>If the time difference in seconds calculated by the current time minus <var>registration</var>'s <a href="#dfn-last-update-check-time">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.</li>
+          <li>Abort these steps.</li>
+        </ol>
         <p class="note">To avoid unnecessary delays, the Handle Functional Event enforces early return when no event listeners have been deterministically added in the service worker's global during the very first script execution.</p>
       </li>
       <li>If <var>activeWorker</var>'s <a href="#dfn-state">state</a> is <em>activating</em>, wait for <var>activeWorker</var>'s <a href="#dfn-state">state</a> to become <em>activated</em>.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed 1.0.0" name="generator">
+  <meta content="Bikeshed version 645534c1532bca4fdb4f3859efc66268a218d7c8" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-11">11 November 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-17">17 November 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -4525,7 +4525,12 @@ pre.idl.highlight { color: #708090; }
         </ol>
        <li>Let <var>activeWorker</var> be <var>registration</var>’s <a href="#dfn-active-worker" id="ref-for-dfn-active-worker-29">active worker</a>.
        <li>
-        If <var>activeWorker</var>’s <a href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-2">set of event types to handle</a> does not contain <code>fetch</code>, return null. 
+        If <var>activeWorker</var>’s <a href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-2">set of event types to handle</a> does not contain <code>fetch</code>, then: 
+        <ol>
+         <li>Return null and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
+         <li>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-4">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
+         <li>Abort these steps.
+        </ol>
         <p class="note" role="note">To avoid unnecessary delays, the Handle Fetch enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
        <li>If <var>activeWorker</var>’s <a href="#dfn-state" id="ref-for-dfn-state-10">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a href="#dfn-state" id="ref-for-dfn-state-11">state</a> to become <em>activated</em>.
        <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.
@@ -4555,22 +4560,22 @@ pre.idl.highlight { color: #708090; }
        <li>
         If <var>respondWithEntered</var> is false, then: 
         <ol>
-         <li>If <var>eventCanceled</var> is true, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> and continue running these substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
-         <li>Else, return null and continue running these substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
-         <li>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-4">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
+         <li>If <var>eventCanceled</var> is true, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
+         <li>Else, return null and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
+         <li>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-5">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
          <li>Abort these steps.
         </ol>
        <li>
         If <var>handleFetchFailed</var> is true, then: 
         <ol>
-         <li>Return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> and continue running these substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
-         <li>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-5">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
+         <li>Return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
+         <li>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-6">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
         </ol>
        <li>
         Else: 
         <ol>
-         <li>Return <var>response</var> and continue running these substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
-         <li>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-6">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
+         <li>Return <var>response</var> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
+         <li>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-7">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
         </ol>
       </ol>
      </section>
@@ -4684,7 +4689,12 @@ pre.idl.highlight { color: #708090; }
        <li><a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">Assert</a>: <var>registration</var>’s <a href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a> is not null.
        <li>Let <var>activeWorker</var> be <var>registration</var>’s <a href="#dfn-active-worker" id="ref-for-dfn-active-worker-31">active worker</a>.
        <li>
-        If <var>activeWorker</var>’s <a href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-3">set of event types to handle</a> does not contain the event type for this functional event, return. 
+        If <var>activeWorker</var>’s <a href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-3">set of event types to handle</a> does not contain the event type for this functional event, then: 
+        <ol>
+         <li>Return and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
+         <li>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-8">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
+         <li>Abort these steps.
+        </ol>
         <p class="note" role="note">To avoid unnecessary delays, the Handle Functional Event enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
        <li>If <var>activeWorker</var>’s <a href="#dfn-state" id="ref-for-dfn-state-14">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a href="#dfn-state" id="ref-for-dfn-state-15">state</a> to become <em>activated</em>.
        <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.
@@ -4692,7 +4702,7 @@ pre.idl.highlight { color: #708090; }
         <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to invoke <var>callbackSteps</var> with <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> as its argument. 
         <p>The <var>task</var> <em class="rfc2119" title="MUST">must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-4">handle functional event task source</a>.</p>
        <li>Wait for <var>task</var> to have executed or been discarded.
-       <li>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-7">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
+       <li>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-9">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
       </ol>
      </section>
      <section class="algorithm" data-algorithm="on-client-unload-algorithm">
@@ -6615,8 +6625,8 @@ pre.idl.highlight { color: #708090; }
    <b><a href="#dfn-last-update-check-time">#dfn-last-update-check-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-last-update-check-time-1">Update</a> <a href="#ref-for-dfn-last-update-check-time-2">(2)</a> <a href="#ref-for-dfn-last-update-check-time-3">(3)</a>
-    <li><a href="#ref-for-dfn-last-update-check-time-4">Handle Fetch</a> <a href="#ref-for-dfn-last-update-check-time-5">(2)</a> <a href="#ref-for-dfn-last-update-check-time-6">(3)</a>
-    <li><a href="#ref-for-dfn-last-update-check-time-7">Handle Functional Event</a>
+    <li><a href="#ref-for-dfn-last-update-check-time-4">Handle Fetch</a> <a href="#ref-for-dfn-last-update-check-time-5">(2)</a> <a href="#ref-for-dfn-last-update-check-time-6">(3)</a> <a href="#ref-for-dfn-last-update-check-time-7">(4)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time-8">Handle Functional Event</a> <a href="#ref-for-dfn-last-update-check-time-9">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-uninstalling-flag">

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -3087,7 +3087,12 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
         </ol>
       </li>
       <li>Let <var>activeWorker</var> be <var>registration</var>'s <a href="#dfn-active-worker">active worker</a>.</li>
-      <li>If <var>activeWorker</var>'s <a href="#dfn-set-of-event-types-to-handle">set of event types to handle</a> does not contain <code>fetch</code>, return null.
+      <li>If <var>activeWorker</var>'s <a href="#dfn-set-of-event-types-to-handle">set of event types to handle</a> does not contain <code>fetch</code>, then:
+        <ol>
+          <li>Return null and continue running these steps <a>in parallel</a>.</li>
+          <li>If <var>request</var> is a <a>non-subresource request</a>, or <var>request</var> is a <a>subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>'s <a href="#dfn-last-update-check-time">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.</li>
+          <li>Abort these steps.</li>
+        </ol>
         <p class="note">To avoid unnecessary delays, the Handle Fetch enforces early return when no event listeners have been deterministically added in the service worker's global during the very first script execution.</p>
       </li>
       <li>If <var>activeWorker</var>'s <a href="#dfn-state">state</a> is <em>activating</em>, wait for <var>activeWorker</var>'s <a href="#dfn-state">state</a> to become <em>activated</em>.</li>
@@ -3117,21 +3122,21 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
       <li>Wait for <var>task</var> to have executed or been discarded.</li>
       <li>If <var>respondWithEntered</var> is false, then:
         <ol>
-          <li>If <var>eventCanceled</var> is true, return a <a>network error</a> and continue running these substeps <a>in parallel</a>.</li>
-          <li>Else, return null and continue running these substeps <a>in parallel</a>.</li>
+          <li>If <var>eventCanceled</var> is true, return a <a>network error</a> and continue running these steps <a>in parallel</a>.</li>
+          <li>Else, return null and continue running these steps <a>in parallel</a>.</li>
           <li>If <var>request</var> is a <a>non-subresource request</a>, or <var>request</var> is a <a>subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>'s <a href="#dfn-last-update-check-time">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.</li>
           <li>Abort these steps.</li>
         </ol>
       </li>
       <li>If <var>handleFetchFailed</var> is true, then:
         <ol>
-          <li>Return a <a>network error</a> and continue running these substeps <a>in parallel</a>.</li>
+          <li>Return a <a>network error</a> and continue running these steps <a>in parallel</a>.</li>
           <li>If <var>request</var> is a <a>non-subresource request</a>, or <var>request</var> is a <a>subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>'s <a href="#dfn-last-update-check-time">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.</li>
         </ol>
       </li>
       <li>Else:
         <ol>
-          <li>Return <var>response</var> and continue running these substeps <a>in parallel</a>.</li>
+          <li>Return <var>response</var> and continue running these steps <a>in parallel</a>.</li>
           <li>If <var>request</var> is a <a>non-subresource request</a>, or <var>request</var> is a <a>subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>'s <a href="#dfn-last-update-check-time">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.</li>
         </ol>
       </li>
@@ -3152,7 +3157,12 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
       <li><a>Assert</a>: a <a>Record</a> with the \[[value]] equals to <var>registration</var> is contained in <a href="#dfn-scope-to-registration-map">scope to registration map</a>.</li>
       <li><a>Assert</a>: <var>registration</var>'s <a href="#dfn-active-worker">active worker</a> is not null.</li>
       <li>Let <var>activeWorker</var> be <var>registration</var>'s <a href="#dfn-active-worker">active worker</a>.</li>
-      <li>If <var>activeWorker</var>'s <a href="#dfn-set-of-event-types-to-handle">set of event types to handle</a> does not contain the event type for this functional event, return.
+      <li>If <var>activeWorker</var>'s <a href="#dfn-set-of-event-types-to-handle">set of event types to handle</a> does not contain the event type for this functional event, then:
+        <ol>
+          <li>Return and continue running these steps <a>in parallel</a>.</li>
+          <li>If the time difference in seconds calculated by the current time minus <var>registration</var>'s <a href="#dfn-last-update-check-time">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.</li>
+          <li>Abort these steps.</li>
+        </ol>
         <p class="note">To avoid unnecessary delays, the Handle Functional Event enforces early return when no event listeners have been deterministically added in the service worker's global during the very first script execution.</p>
       </li>
       <li>If <var>activeWorker</var>'s <a href="#dfn-state">state</a> is <em>activating</em>, wait for <var>activeWorker</var>'s <a href="#dfn-state">state</a> to become <em>activated</em>.</li>

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed 1.0.0" name="generator">
+  <meta content="Bikeshed version 645534c1532bca4fdb4f3859efc66268a218d7c8" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-11">11 November 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-17">17 November 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -4224,7 +4224,12 @@ pre.idl.highlight { color: #708090; }
         </ol>
        <li>Let <var>activeWorker</var> be <var>registration</var>’s <a href="#dfn-active-worker" id="ref-for-dfn-active-worker-29">active worker</a>.
        <li>
-        If <var>activeWorker</var>’s <a href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-2">set of event types to handle</a> does not contain <code>fetch</code>, return null. 
+        If <var>activeWorker</var>’s <a href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-2">set of event types to handle</a> does not contain <code>fetch</code>, then: 
+        <ol>
+         <li>Return null and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
+         <li>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-4">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
+         <li>Abort these steps.
+        </ol>
         <p class="note" role="note">To avoid unnecessary delays, the Handle Fetch enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
        <li>If <var>activeWorker</var>’s <a href="#dfn-state" id="ref-for-dfn-state-10">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a href="#dfn-state" id="ref-for-dfn-state-11">state</a> to become <em>activated</em>.
        <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.
@@ -4254,22 +4259,22 @@ pre.idl.highlight { color: #708090; }
        <li>
         If <var>respondWithEntered</var> is false, then: 
         <ol>
-         <li>If <var>eventCanceled</var> is true, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> and continue running these substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
-         <li>Else, return null and continue running these substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
-         <li>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-4">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
+         <li>If <var>eventCanceled</var> is true, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
+         <li>Else, return null and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
+         <li>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-5">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
          <li>Abort these steps.
         </ol>
        <li>
         If <var>handleFetchFailed</var> is true, then: 
         <ol>
-         <li>Return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> and continue running these substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
-         <li>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-5">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
+         <li>Return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
+         <li>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-6">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
         </ol>
        <li>
         Else: 
         <ol>
-         <li>Return <var>response</var> and continue running these substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
-         <li>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-6">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
+         <li>Return <var>response</var> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
+         <li>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-7">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
         </ol>
       </ol>
      </section>
@@ -4287,7 +4292,12 @@ pre.idl.highlight { color: #708090; }
        <li><a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">Assert</a>: <var>registration</var>’s <a href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a> is not null.
        <li>Let <var>activeWorker</var> be <var>registration</var>’s <a href="#dfn-active-worker" id="ref-for-dfn-active-worker-31">active worker</a>.
        <li>
-        If <var>activeWorker</var>’s <a href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-3">set of event types to handle</a> does not contain the event type for this functional event, return. 
+        If <var>activeWorker</var>’s <a href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-3">set of event types to handle</a> does not contain the event type for this functional event, then: 
+        <ol>
+         <li>Return and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.
+         <li>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-8">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
+         <li>Abort these steps.
+        </ol>
         <p class="note" role="note">To avoid unnecessary delays, the Handle Functional Event enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
        <li>If <var>activeWorker</var>’s <a href="#dfn-state" id="ref-for-dfn-state-12">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a href="#dfn-state" id="ref-for-dfn-state-13">state</a> to become <em>activated</em>.
        <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.
@@ -4295,7 +4305,7 @@ pre.idl.highlight { color: #708090; }
         <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to invoke <var>callbackSteps</var> with <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> as its argument. 
         <p>The <var>task</var> <em class="rfc2119" title="MUST">must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-4">handle functional event task source</a>.</p>
        <li>Wait for <var>task</var> to have executed or been discarded.
-       <li>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-7">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
+       <li>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-9">last update check time</a> is greater than 86400, invoke <a href="#soft-update-algorithm">Soft Update</a> algorithm with <var>registration</var>.
       </ol>
      </section>
      <section class="algorithm" data-algorithm="on-client-unload-algorithm">
@@ -6051,8 +6061,8 @@ pre.idl.highlight { color: #708090; }
    <b><a href="#dfn-last-update-check-time">#dfn-last-update-check-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-last-update-check-time-1">Update</a> <a href="#ref-for-dfn-last-update-check-time-2">(2)</a> <a href="#ref-for-dfn-last-update-check-time-3">(3)</a>
-    <li><a href="#ref-for-dfn-last-update-check-time-4">Handle Fetch</a> <a href="#ref-for-dfn-last-update-check-time-5">(2)</a> <a href="#ref-for-dfn-last-update-check-time-6">(3)</a>
-    <li><a href="#ref-for-dfn-last-update-check-time-7">Handle Functional Event</a>
+    <li><a href="#ref-for-dfn-last-update-check-time-4">Handle Fetch</a> <a href="#ref-for-dfn-last-update-check-time-5">(2)</a> <a href="#ref-for-dfn-last-update-check-time-6">(3)</a> <a href="#ref-for-dfn-last-update-check-time-7">(4)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time-8">Handle Functional Event</a> <a href="#ref-for-dfn-last-update-check-time-9">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-uninstalling-flag">


### PR DESCRIPTION
This changes Handle Fetch and Handle Functional Event to invoke Soft
Update even if the service worker doesn't have any event listener
registered for the event. (Note that the cases where the request falls
back to network still do not trigger Soft Update.)

Fixes #905.