### PR TITLE
Fix arguments to "fetch a classic worker script"

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3025,11 +3025,12 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
       <li>Let <var>httpsState</var> be "<code>none</code>".</li>
       <li>Let <var>referrerPolicy</var> be the empty string.</li>
       <li>Switching on <var>job</var>'s <a>worker type</a>, run these substeps with the following options:
+        <!-- TODO: reorganize algorithm so that the worker environment is created before fetching happens -->
         <dl>
         <dt><em>"<code>classic</code>"</em></dt>
-        <dd><p><a>Fetch a classic worker script</a> given <var>job</var>’s <a lt="URL serializer">serialized</a> <a href="#dfn-job-script-url">script url</a>, <var>job</var>’s <a href="#dfn-job-client">client</a>, and "<code>serviceworker</code>".</p></dd>
+        <dd><p><a>Fetch a classic worker script</a> given <var>job</var>’s <a lt="URL serializer">serialized</a> <a href="#dfn-job-script-url">script url</a>, <var>job</var>’s <a href="#dfn-job-client">client</a>, "<code>serviceworker</code>", and the to-be-created <a>environment settings object</a> for this service worker.</p></dd>
         <dt><em>"<code>module</code>"</em></dt>
-        <dd><p><a>Fetch a module worker script graph</a> given <var>job</var>’s <a lt="URL serializer">serialized</a> <a href="#dfn-job-script-url">script url</a>, <var>job</var>’s <a href="#dfn-job-client">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a>environment settings object</a> for this service worker.</p></dd> <!-- TODO: reorganize algorithm so that the worker environment is created before fetching happens -->
+        <dd><p><a>Fetch a module worker script graph</a> given <var>job</var>’s <a lt="URL serializer">serialized</a> <a href="#dfn-job-script-url">script url</a>, <var>job</var>’s <a href="#dfn-job-client">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a>environment settings object</a> for this service worker.</p></dd>
         </dl>
         <p>To <a for="fetching scripts">perform the fetch</a> given <var>request</var>, run the following steps if the <a for="fetching scripts">is top-level</a> flag is set:</p>
         <ol>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-21">21 November 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-11-22">22 November 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -4154,7 +4154,7 @@ pre.idl.highlight { color: #708090; }
         <dl>
          <dt><em>"<code>classic</code>"</em>
          <dd>
-          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a>, and "<code>serviceworker</code>".</p>
+          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a>, "<code>serviceworker</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
          <dt><em>"<code>module</code>"</em>
          <dd>
           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">Fetch a module worker script graph</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>


### PR DESCRIPTION
This follows the analogous fix in https://github.com/whatwg/html/pull/2077 for HTML.

Ideally this should be merged after the HTML pull request, but in practice it should be fine either way, as the HTML PR is pretty straightforward and will likely be merged forthwith.