### PR TITLE
Add client.type

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -866,6 +866,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       interface Client {
         readonly attribute USVString url;
         readonly attribute DOMString id;
+        readonly attribute ClientType type;
         readonly attribute boolean reserved;
         void postMessage(any message, optional sequence&lt;object&gt; transfer = []);
       };
@@ -900,6 +901,16 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       <h4 id="client-id">{{Client/id}}</h4>
 
       The <dfn attribute for="Client"><code>id</code></dfn> attribute *must* return its associated [=Client/service worker client=]'s [=environment/id=].
+    </section>
+
+    <section>
+      <h4 id="client-type">{{Client/type}}</h4>
+
+      The <dfn attribute for="Client"><code>type</code></dfn> attribute *must* run these steps:
+
+        1. If the [=context object=]'s [=Client/service worker client=] is a type of [=environment=] or is a [=window client=], return {{ClientType/"window"}}.
+        1. Else if the [=context object=]'s [=Client/service worker client=] is a [=dedicated worker client=], return {{ClientType/"worker"}}.
+        1. Else if the [=context object=]'s [=Client/service worker client=] is a [=shared worker client=], return {{ClientType/"sharedworker"}}.
     </section>
 
     <section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-01">1 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-02">2 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1546,13 +1546,14 @@ pre.idl.highlight { color: #708090; }
        <ol class="toc">
         <li><a href="#client-url"><span class="secno">4.2.1</span> <span class="content"><code class="idl"><span>url</span></code></span></a>
         <li><a href="#client-id"><span class="secno">4.2.2</span> <span class="content"><code class="idl"><span>id</span></code></span></a>
-        <li><a href="#client-reserved"><span class="secno">4.2.3</span> <span class="content"><code class="idl"><span>reserved</span></code></span></a>
-        <li><a href="#client-postmessage"><span class="secno">4.2.4</span> <span class="content"><code class="idl"><span>postMessage(message, transfer)</span></code></span></a>
-        <li><a href="#client-visibilitystate"><span class="secno">4.2.5</span> <span class="content"><code class="idl"><span>visibilityState</span></code></span></a>
-        <li><a href="#client-focused"><span class="secno">4.2.6</span> <span class="content"><code class="idl"><span>focused</span></code></span></a>
-        <li><a href="#client-ancestororigins"><span class="secno">4.2.7</span> <span class="content"><code class="idl"><span>ancestorOrigins</span></code></span></a>
-        <li><a href="#client-focus"><span class="secno">4.2.8</span> <span class="content"><code class="idl"><span>focus()</span></code></span></a>
-        <li><a href="#client-navigate"><span class="secno">4.2.9</span> <span class="content"><code class="idl"><span>navigate(url)</span></code></span></a>
+        <li><a href="#client-type"><span class="secno">4.2.3</span> <span class="content"><code class="idl"><span>type</span></code></span></a>
+        <li><a href="#client-reserved"><span class="secno">4.2.4</span> <span class="content"><code class="idl"><span>reserved</span></code></span></a>
+        <li><a href="#client-postmessage"><span class="secno">4.2.5</span> <span class="content"><code class="idl"><span>postMessage(message, transfer)</span></code></span></a>
+        <li><a href="#client-visibilitystate"><span class="secno">4.2.6</span> <span class="content"><code class="idl"><span>visibilityState</span></code></span></a>
+        <li><a href="#client-focused"><span class="secno">4.2.7</span> <span class="content"><code class="idl"><span>focused</span></code></span></a>
+        <li><a href="#client-ancestororigins"><span class="secno">4.2.8</span> <span class="content"><code class="idl"><span>ancestorOrigins</span></code></span></a>
+        <li><a href="#client-focus"><span class="secno">4.2.9</span> <span class="content"><code class="idl"><span>focus()</span></code></span></a>
+        <li><a href="#client-navigate"><span class="secno">4.2.10</span> <span class="content"><code class="idl"><span>navigate(url)</span></code></span></a>
        </ol>
       <li>
        <a href="#clients-interface"><span class="secno">4.3</span> <span class="content"><code class="idl"><span>Clients</span></code></span></a>
@@ -2406,6 +2407,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="client">Client</dfn> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-client-url" id="ref-for-dom-client-url-1">url</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-client-id" id="ref-for-dom-client-id-1">id</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-clienttype" id="ref-for-enumdef-clienttype-1">ClientType</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="ClientType" href="#dom-client-type" id="ref-for-dom-client-type-1">type</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-client-reserved" id="ref-for-dom-client-reserved-1">reserved</a>;
   <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-client-postmessage" id="ref-for-dom-client-postmessage-1">postMessage</a>(<span class="kt">any</span> <dfn class="nv idl-code" data-dfn-for="Client/postMessage(message, transfer), Client/postMessage(message)" data-dfn-type="argument" data-export="" id="dom-client-postmessage-message-transfer-message">message<a class="self-link" href="#dom-client-postmessage-message-transfer-message"></a></dfn>, <span class="kt">optional</span> <span class="kt">sequence</span>&lt;<span class="kt">object</span>> <dfn class="nv idl-code" data-dfn-for="Client/postMessage(message, transfer), Client/postMessage(message)" data-dfn-type="argument" data-export="" id="dom-client-postmessage-message-transfer-transfer">transfer<a class="self-link" href="#dom-client-postmessage-message-transfer-transfer"></a></dfn> = []);
 };
@@ -2433,17 +2435,29 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Client" data-dfn-type="attribute" data-export="" id="dom-client-id"><code>id</code></dfn> attribute <em>must</em> return its associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-2">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id">id</a>.</p>
      </section>
      <section>
-      <h4 class="heading settled" data-level="4.2.3" id="client-reserved"><span class="secno">4.2.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-client-reserved" id="ref-for-dom-client-reserved-2">reserved</a></code></span><a class="self-link" href="#client-reserved"></a></h4>
+      <h4 class="heading settled" data-level="4.2.3" id="client-type"><span class="secno">4.2.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-client-type" id="ref-for-dom-client-type-2">type</a></code></span><a class="self-link" href="#client-type"></a></h4>
+      <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Client" data-dfn-type="attribute" data-export="" id="dom-client-type"><code>type</code></dfn> attribute <em>must</em> run these steps:</p>
+      <ol>
+       <li data-md="">
+        <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-3">service worker client</a> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a> or is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-1">window client</a>, return <code class="idl"><a data-link-type="idl" href="#dom-clienttype-window" id="ref-for-dom-clienttype-window-1">"window"</a></code>.</p>
+       <li data-md="">
+        <p>Else if the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-4">service worker client</a> is a <a data-link-type="dfn" href="#dfn-dedicatedworker-client" id="ref-for-dfn-dedicatedworker-client-2">dedicated worker client</a>, return <code class="idl"><a data-link-type="idl" href="#dom-clienttype-worker" id="ref-for-dom-clienttype-worker-1">"worker"</a></code>.</p>
+       <li data-md="">
+        <p>Else if the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-5">service worker client</a> is a <a data-link-type="dfn" href="#dfn-sharedworker-client" id="ref-for-dfn-sharedworker-client-2">shared worker client</a>, return <code class="idl"><a data-link-type="idl" href="#dom-clienttype-sharedworker" id="ref-for-dom-clienttype-sharedworker-1">"sharedworker"</a></code>.</p>
+      </ol>
+     </section>
+     <section>
+      <h4 class="heading settled" data-level="4.2.4" id="client-reserved"><span class="secno">4.2.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-client-reserved" id="ref-for-dom-client-reserved-2">reserved</a></code></span><a class="self-link" href="#client-reserved"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Client" data-dfn-type="attribute" data-export="" id="dom-client-reserved"><code>reserved</code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-reserved-state" id="ref-for-client-reserved-state-1">reserved state</a>.</p>
      </section>
      <section class="algorithm" data-algorithm="client-postmessage">
-      <h4 class="heading settled" data-level="4.2.4" id="client-postmessage"><span class="secno">4.2.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-client-postmessage" id="ref-for-dom-client-postmessage-2">postMessage(message, transfer)</a></code></span><a class="self-link" href="#client-postmessage"></a></h4>
+      <h4 class="heading settled" data-level="4.2.5" id="client-postmessage"><span class="secno">4.2.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-client-postmessage" id="ref-for-dom-client-postmessage-2">postMessage(message, transfer)</a></code></span><a class="self-link" href="#client-postmessage"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Client" data-dfn-type="method" data-export="" data-lt="postMessage(message, transfer)|postMessage(message)" id="dom-client-postmessage"><code>postMessage(<var>message</var>, <var>transfer</var>)</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
         <p>Let <var>sourceSettings</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>.</p>
        <li data-md="">
-        <p>Let <var>destination</var> be the <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-15">ServiceWorkerContainer</a></code> object whose <a data-link-type="dfn" href="#serviceworkercontainer-service-worker-client" id="ref-for-serviceworkercontainer-service-worker-client-7">service worker client</a> is the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-3">service worker client</a>.</p>
+        <p>Let <var>destination</var> be the <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-15">ServiceWorkerContainer</a></code> object whose <a data-link-type="dfn" href="#serviceworkercontainer-service-worker-client" id="ref-for-serviceworkercontainer-service-worker-client-7">service worker client</a> is the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-6">service worker client</a>.</p>
        <li data-md="">
         <p>If <var>destination</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" exception.</p>
        <li data-md="">
@@ -2473,19 +2487,19 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       </ol>
      </section>
      <section>
-      <h4 class="heading settled" data-level="4.2.5" id="client-visibilitystate"><span class="secno">4.2.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-visibilitystate" id="ref-for-dom-windowclient-visibilitystate-2">visibilityState</a></code></span><a class="self-link" href="#client-visibilitystate"></a></h4>
+      <h4 class="heading settled" data-level="4.2.6" id="client-visibilitystate"><span class="secno">4.2.6. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-visibilitystate" id="ref-for-dom-windowclient-visibilitystate-2">visibilityState</a></code></span><a class="self-link" href="#client-visibilitystate"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="WindowClient" data-dfn-type="attribute" data-export="" id="dom-windowclient-visibilitystate"><code>visibilityState</code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#dfn-service-worker-client-visibilitystate" id="ref-for-dfn-service-worker-client-visibilitystate-1">visibility state</a>.</p>
      </section>
      <section>
-      <h4 class="heading settled" data-level="4.2.6" id="client-focused"><span class="secno">4.2.6. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-focused" id="ref-for-dom-windowclient-focused-2">focused</a></code></span><a class="self-link" href="#client-focused"></a></h4>
+      <h4 class="heading settled" data-level="4.2.7" id="client-focused"><span class="secno">4.2.7. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-focused" id="ref-for-dom-windowclient-focused-2">focused</a></code></span><a class="self-link" href="#client-focused"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="WindowClient" data-dfn-type="attribute" data-export="" id="dom-windowclient-focused"><code>focused</code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#dfn-service-worker-client-focusstate" id="ref-for-dfn-service-worker-client-focusstate-1">focus state</a>.</p>
      </section>
      <section>
-      <h4 class="heading settled" data-level="4.2.7" id="client-ancestororigins"><span class="secno">4.2.7. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-ancestororigins" id="ref-for-dom-windowclient-ancestororigins-2">ancestorOrigins</a></code></span><a class="self-link" href="#client-ancestororigins"></a></h4>
-      <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="WindowClient" data-dfn-type="attribute" data-export="" id="dom-windowclient-ancestororigins"><code>ancestorOrigins</code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-4">service worker client</a>'s <a data-link-type="dfn" href="#windowclient-ancestor-origins-array" id="ref-for-windowclient-ancestor-origins-array-1">ancestor origins array</a>.</p>
+      <h4 class="heading settled" data-level="4.2.8" id="client-ancestororigins"><span class="secno">4.2.8. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-ancestororigins" id="ref-for-dom-windowclient-ancestororigins-2">ancestorOrigins</a></code></span><a class="self-link" href="#client-ancestororigins"></a></h4>
+      <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="WindowClient" data-dfn-type="attribute" data-export="" id="dom-windowclient-ancestororigins"><code>ancestorOrigins</code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-7">service worker client</a>'s <a data-link-type="dfn" href="#windowclient-ancestor-origins-array" id="ref-for-windowclient-ancestor-origins-array-1">ancestor origins array</a>.</p>
      </section>
      <section class="algorithm" data-algorithm="client-focus">
-      <h4 class="heading settled" data-level="4.2.8" id="client-focus"><span class="secno">4.2.8. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-focus" id="ref-for-dom-windowclient-focus-2">focus()</a></code></span><a class="self-link" href="#client-focus"></a></h4>
+      <h4 class="heading settled" data-level="4.2.9" id="client-focus"><span class="secno">4.2.9. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-focus" id="ref-for-dom-windowclient-focus-2">focus()</a></code></span><a class="self-link" href="#client-focus"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="WindowClient" data-dfn-type="method" data-export="" id="dom-windowclient-focus"><code>focus()</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
@@ -2496,7 +2510,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>Run these substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>browsingContext</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-5">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>.</p>
+          <p>Let <var>browsingContext</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-8">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>.</p>
          <li data-md="">
           <p>Let <var>visibilityState</var> be null.</p>
          <li data-md="">
@@ -2504,7 +2518,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Let <var>ancestorOrigins</var> be the empty array.</p>
          <li data-md="">
-          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps on the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-6">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">user interaction task source</a>:</p>
+          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps on the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-9">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">user interaction task source</a>:</p>
           <ol>
            <li data-md="">
             <p>Run the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">focusing steps</a> with <var>browsingContext</var>.</p>
@@ -2518,7 +2532,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Wait for <var>task</var> to have executed.</p>
          <li data-md="">
-          <p>Let <var>windowClient</var> be the result of running <a data-link-type="dfn" href="#create-window-client" id="ref-for-create-window-client-1">Create Window Client</a> algorithm with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-7">service worker client</a>, <var>visibilityState</var>, <var>focusState</var>, and <var>ancestorOrigins</var> as the arguments.</p>
+          <p>Let <var>windowClient</var> be the result of running <a data-link-type="dfn" href="#create-window-client" id="ref-for-create-window-client-1">Create Window Client</a> algorithm with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-10">service worker client</a>, <var>visibilityState</var>, <var>focusState</var>, and <var>ancestorOrigins</var> as the arguments.</p>
          <li data-md="">
           <p>If <var>windowClient</var>’s <a data-link-type="dfn" href="#dfn-service-worker-client-focusstate" id="ref-for-dfn-service-worker-client-focusstate-2">focus state</a> is true, resolve <var>promise</var> with <var>windowClient</var>.</p>
          <li data-md="">
@@ -2529,7 +2543,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       </ol>
      </section>
      <section class="algorithm" data-algorithm="client-navigate">
-      <h4 class="heading settled" data-level="4.2.9" id="client-navigate"><span class="secno">4.2.9. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-navigate" id="ref-for-dom-windowclient-navigate-2">navigate(url)</a></code></span><a class="self-link" href="#client-navigate"></a></h4>
+      <h4 class="heading settled" data-level="4.2.10" id="client-navigate"><span class="secno">4.2.10. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-navigate" id="ref-for-dom-windowclient-navigate-2">navigate(url)</a></code></span><a class="self-link" href="#client-navigate"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="WindowClient" data-dfn-type="method" data-export="" data-lt="navigate(url)" id="dom-windowclient-navigate"><code>navigate()</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
@@ -2539,14 +2553,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>If <var>url</var> is <code>about:blank</code>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with a <code>TypeError</code>.</p>
        <li data-md="">
-        <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-8">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-5">service worker</a>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with a <code>TypeError</code>.</p>
+        <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-11">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-5">service worker</a>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with a <code>TypeError</code>.</p>
        <li data-md="">
         <p>Let <var>promise</var> be a new <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>.</p>
        <li data-md="">
         <p>Run these substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>browsingContext</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-9">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>.</p>
+          <p>Let <var>browsingContext</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-12">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>.</p>
          <li data-md="">
           <p>If <var>browsingContext</var> has <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#discard-a-document">discarded</a> its <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code>, reject <var>promise</var> with a <code>TypeError</code> and abort these steps.</p>
          <li data-md="">
@@ -2558,7 +2572,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Let <var>ancestorOrigins</var> be the empty array.</p>
          <li data-md="">
-          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps on the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-10">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">user interaction task source</a>:</p>
+          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps on the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-13">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">user interaction task source</a>:</p>
           <ol>
            <li data-md="">
             <p><em>HandleNavigate</em>: <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#navigate">Navigate</a> <var>browsingContext</var> to <var>url</var> with <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#exceptions-enabled">exceptions enabled</a>. The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#source-browsing-context">source browsing context</a> must be <var>browsingContext</var>.</p>
@@ -2607,7 +2621,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 <pre class="idl highlight def" id="serviceworker-client-query-options-dictionary"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-clientqueryoptions">ClientQueryOptions</dfn> {
   <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-default="false" data-dfn-for="ClientQueryOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-clientqueryoptions-includeuncontrolled">includeUncontrolled</dfn> = <span class="kt">false</span>;
   <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-default="false" data-dfn-for="ClientQueryOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-clientqueryoptions-includereserved">includeReserved</dfn> = <span class="kt">false</span>;
-  <a class="n" data-link-type="idl-name" href="#enumdef-clienttype" id="ref-for-enumdef-clienttype-1">ClientType</a> <dfn class="nv dfn-paneled idl-code" data-default="&quot;window&quot;" data-dfn-for="ClientQueryOptions" data-dfn-type="dict-member" data-export="" data-type="ClientType " id="dom-clientqueryoptions-type">type</dfn> = "window";
+  <a class="n" data-link-type="idl-name" href="#enumdef-clienttype" id="ref-for-enumdef-clienttype-2">ClientType</a> <dfn class="nv dfn-paneled idl-code" data-default="&quot;window&quot;" data-dfn-for="ClientQueryOptions" data-dfn-type="dict-member" data-export="" data-type="ClientType " id="dom-clientqueryoptions-type">type</dfn> = "window";
 };
 </pre>
 <pre class="idl highlight def" id="client-type-enum"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-clienttype">ClientType</dfn> {
@@ -2645,7 +2659,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
               <p>If <var>client</var> is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>, reject <var>promise</var> with a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception and abort these steps.</p>
             </ol>
            <li data-md="">
-            <p>If <var>client</var> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a> or is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-1">window client</a>, then:</p>
+            <p>If <var>client</var> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a> or is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-2">window client</a>, then:</p>
             <ol>
              <li data-md="">
               <p>Let <var>browsingContext</var> be null.</p>
@@ -2667,7 +2681,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
                <li data-md="">
                 <p>Set <var>focusState</var> to the result of running the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">has focus steps</a> with <var>browsingContext</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a> as the argument.</p>
                <li data-md="">
-                <p>If <var>client</var> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-2">window client</a>, set <var>ancestorOrigins</var> to <var>browsingContext</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#location">Location</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-array">ancestor origins array</a>.</p>
+                <p>If <var>client</var> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-3">window client</a>, set <var>ancestorOrigins</var> to <var>browsingContext</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#location">Location</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-array">ancestor origins array</a>.</p>
               </ol>
              <li data-md="">
               <p>Wait for <var>task</var> to have executed.</p>
@@ -2739,7 +2753,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-30">service worker client</a> <var>client</var> in <var>targetClients</var>:</p>
           <ol>
            <li data-md="">
-            <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-type" id="ref-for-dom-clientqueryoptions-type-1">type</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-clienttype-window" id="ref-for-dom-clienttype-window-1">"window"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-clienttype-all" id="ref-for-dom-clienttype-all-1">"all"</a></code>, and <var>client</var> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a> or is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-3">window client</a>, then:</p>
+            <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-type" id="ref-for-dom-clientqueryoptions-type-1">type</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-clienttype-window" id="ref-for-dom-clienttype-window-2">"window"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-clienttype-all" id="ref-for-dom-clienttype-all-1">"all"</a></code>, and <var>client</var> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a> or is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-4">window client</a>, then:</p>
             <ol>
              <li data-md="">
               <p>Let <var>browsingContext</var> be null.</p>
@@ -2767,7 +2781,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
                <li data-md="">
                 <p>Set <var>focusState</var> to the result of running the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">has focus steps</a> with <var>browsingContext</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a> as the argument.</p>
                <li data-md="">
-                <p>It <var>client</var> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-4">window client</a>, set <var>ancestorOrigins</var> to <var>browsingContext</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#location">Location</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-array">ancestor origins array</a>.</p>
+                <p>It <var>client</var> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-5">window client</a>, set <var>ancestorOrigins</var> to <var>browsingContext</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#location">Location</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-array">ancestor origins array</a>.</p>
               </ol>
              <li data-md="">
               <p>Wait for <var>task</var> to have executed.</p>
@@ -2782,7 +2796,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
               </ol>
             </ol>
            <li data-md="">
-            <p>Else if <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-type" id="ref-for-dom-clientqueryoptions-type-2">type</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-clienttype-worker" id="ref-for-dom-clienttype-worker-1">"worker"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-clienttype-all" id="ref-for-dom-clienttype-all-2">"all"</a></code> and <var>client</var> is a <a data-link-type="dfn" href="#dfn-dedicatedworker-client" id="ref-for-dfn-dedicatedworker-client-2">dedicated worker client</a>, or <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-type" id="ref-for-dom-clientqueryoptions-type-3">type</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-clienttype-sharedworker" id="ref-for-dom-clienttype-sharedworker-1">"sharedworker"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-clienttype-all" id="ref-for-dom-clienttype-all-3">"all"</a></code> and <var>client</var> is a <a data-link-type="dfn" href="#dfn-sharedworker-client" id="ref-for-dfn-sharedworker-client-2">shared worker client</a>, then:</p>
+            <p>Else if <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-type" id="ref-for-dom-clientqueryoptions-type-2">type</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-clienttype-worker" id="ref-for-dom-clienttype-worker-2">"worker"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-clienttype-all" id="ref-for-dom-clienttype-all-2">"all"</a></code> and <var>client</var> is a <a data-link-type="dfn" href="#dfn-dedicatedworker-client" id="ref-for-dfn-dedicatedworker-client-3">dedicated worker client</a>, or <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-type" id="ref-for-dom-clientqueryoptions-type-3">type</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-clienttype-sharedworker" id="ref-for-dom-clienttype-sharedworker-2">"sharedworker"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-clienttype-all" id="ref-for-dom-clienttype-all-3">"all"</a></code> and <var>client</var> is a <a data-link-type="dfn" href="#dfn-sharedworker-client" id="ref-for-dfn-sharedworker-client-3">shared worker client</a>, then:</p>
             <ol>
              <li data-md="">
               <p>Let <var>clientObject</var> be the result of running <a data-link-type="dfn" href="#create-client" id="ref-for-create-client-2">Create Client</a> algorithm with <var>client</var> as the argument.</p>
@@ -2794,11 +2808,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <p>Sort <var>matchedClients</var> such that:</p>
           <ul>
            <li data-md="">
-            <p><code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-8">WindowClient</a></code> objects are always placed before <code class="idl"><a data-link-type="idl" href="#client" id="ref-for-client-7">Client</a></code> objects whose associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-11">service worker clients</a> are <a data-link-type="dfn" href="#dfn-worker-client" id="ref-for-dfn-worker-client-2">worker clients</a>.</p>
+            <p><code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-8">WindowClient</a></code> objects are always placed before <code class="idl"><a data-link-type="idl" href="#client" id="ref-for-client-7">Client</a></code> objects whose associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-14">service worker clients</a> are <a data-link-type="dfn" href="#dfn-worker-client" id="ref-for-dfn-worker-client-2">worker clients</a>.</p>
            <li data-md="">
-            <p><code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-9">WindowClient</a></code> objects that have been <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">focused</a> are placed first sorted in the most recently <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">focused</a> order, and <code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-10">WindowClient</a></code> objects that have never been <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">focused</a> are placed next sorted in their <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-12">service worker clients</a>' creation order.</p>
+            <p><code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-9">WindowClient</a></code> objects that have been <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">focused</a> are placed first sorted in the most recently <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">focused</a> order, and <code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-10">WindowClient</a></code> objects that have never been <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">focused</a> are placed next sorted in their <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-15">service worker clients</a>' creation order.</p>
            <li data-md="">
-            <p><code class="idl"><a data-link-type="idl" href="#client" id="ref-for-client-8">Client</a></code> objects whose associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-13">service worker clients</a> are <a data-link-type="dfn" href="#dfn-worker-client" id="ref-for-dfn-worker-client-3">worker clients</a> are placed next sorted in their <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-14">service worker clients</a>' creation order.</p>
+            <p><code class="idl"><a data-link-type="idl" href="#client" id="ref-for-client-8">Client</a></code> objects whose associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-16">service worker clients</a> are <a data-link-type="dfn" href="#dfn-worker-client" id="ref-for-dfn-worker-client-3">worker clients</a> are placed next sorted in their <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-17">service worker clients</a>' creation order.</p>
           </ul>
          <li data-md="">
           <p>Resolve <var>promise</var> with <var>matchedClients</var>.</p>
@@ -5025,9 +5039,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-41">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-9">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-18">scope url</a>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>client</var> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-5">window client</a>, unassociate <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a> from its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#application-cache">application cache</a>, if it has one.</p>
+         <p>If <var>client</var> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-6">window client</a>, unassociate <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a> from its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#application-cache">application cache</a>, if it has one.</p>
         <li data-md="">
-         <p>Else if <var>client</var> is a <a data-link-type="dfn" href="#dfn-sharedworker-client" id="ref-for-dfn-sharedworker-client-3">shared worker client</a>, unassociate <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> from its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#application-cache">application cache</a>, if it has one.</p>
+         <p>Else if <var>client</var> is a <a data-link-type="dfn" href="#dfn-sharedworker-client" id="ref-for-dfn-sharedworker-client-4">shared worker client</a>, unassociate <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> from its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#application-cache">application cache</a>, if it has one.</p>
        </ol>
        <p class="note" role="note">Note: Resources will now use the service worker registration instead of the existing application cache.</p>
       <li data-md="">
@@ -5336,7 +5350,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request">navigation request</a>, initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-targetclientid" id="ref-for-dom-fetchevent-targetclientid-3">targetClientId</a></code> attribute to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-client-id">target client id</a>, and to the empty string otherwise.</p>
         <li data-md="">
-         <p>Let the <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-isreload" id="ref-for-dom-fetchevent-isreload-3">isReload</a></code> attribute of <var>e</var> be initialized to <code>true</code> if <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">client</a> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-6">window client</a> and the event was dispatched with the user’s intention for the page reload, and <code>false</code> otherwise.</p>
+         <p>Let the <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-isreload" id="ref-for-dom-fetchevent-isreload-3">isReload</a></code> attribute of <var>e</var> be initialized to <code>true</code> if <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">client</a> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-7">window client</a> and the event was dispatched with the user’s intention for the page reload, and <code>false</code> otherwise.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-5">global object</a>.</p>
         <li data-md="">
@@ -6069,7 +6083,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>clientObject</var> be a new <code class="idl"><a data-link-type="idl" href="#client" id="ref-for-client-13">Client</a></code> object.</p>
       <li data-md="">
-       <p>Set <var>clientObject</var>’s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-15">service worker client</a> to <var>client</var>.</p>
+       <p>Set <var>clientObject</var>’s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-18">service worker client</a> to <var>client</var>.</p>
       <li data-md="">
        <p>Set <var>clientObject</var>’s <a data-link-type="dfn" href="#client-reserved-state" id="ref-for-client-reserved-state-2">reserved state</a> to true if <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag">execution ready flag</a> is unset, and false otherwise.</p>
       <li data-md="">
@@ -6098,7 +6112,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>windowClient</var> be a new <code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-12">WindowClient</a></code> object.</p>
       <li data-md="">
-       <p>Set <var>windowClient</var>’s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-16">service worker client</a> to <var>client</var>.</p>
+       <p>Set <var>windowClient</var>’s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-19">service worker client</a> to <var>client</var>.</p>
       <li data-md="">
        <p>Set <var>windowClient</var>’s <a data-link-type="dfn" href="#dfn-service-worker-client-visibilitystate" id="ref-for-dfn-service-worker-client-visibilitystate-2">visibility state</a> to <var>visibilityState</var>.</p>
       <li data-md="">
@@ -6454,7 +6468,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dom-cache-add">add(request)</a><span>, in §6.4.3</span>
    <li><a href="#dom-clienttype-all">all</a><span>, in §4.3</span>
    <li><a href="#dom-clienttype-all">"all"</a><span>, in §4.3</span>
-   <li><a href="#dom-windowclient-ancestororigins">ancestorOrigins</a><span>, in §4.2.7</span>
+   <li><a href="#dom-windowclient-ancestororigins">ancestorOrigins</a><span>, in §4.2.8</span>
    <li><a href="#windowclient-ancestor-origins-array">ancestor origins array</a><span>, in §4.2</span>
    <li><a href="#batch-cache-operations">Batch Cache Operations</a><span>, in §Unnumbered section</span>
    <li><a href="#cache">Cache</a><span>, in §6.4</span>
@@ -6513,8 +6527,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dom-fetchevent-fetchevent">FetchEvent(type, eventInitDict)</a><span>, in §4.6</span>
    <li><a href="#dfn-fetching-record">fetching record</a><span>, in §6.1</span>
    <li><a href="#finish-job">Finish Job</a><span>, in §Unnumbered section</span>
-   <li><a href="#dom-windowclient-focus">focus()</a><span>, in §4.2.8</span>
-   <li><a href="#dom-windowclient-focused">focused</a><span>, in §4.2.6</span>
+   <li><a href="#dom-windowclient-focus">focus()</a><span>, in §4.2.9</span>
+   <li><a href="#dom-windowclient-focused">focused</a><span>, in §4.2.7</span>
    <li><a href="#dfn-service-worker-client-focusstate">focus state</a><span>, in §4.2</span>
    <li><a href="#dfn-job-force-bypass-cache-flag">force bypass cache flag</a><span>, in §Unnumbered section</span>
    <li><a href="#service-worker-global-scope-foreignfetch-event">foreignfetch</a><span>, in §4.9</span>
@@ -6631,7 +6645,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#match-service-worker-registration">Match Service Worker Registration</a><span>, in §Unnumbered section</span>
    <li><a href="#eventdef-serviceworkerglobalscope-message">message</a><span>, in §4.9</span>
    <li><a href="#dfn-name-to-cache-map">name to cache map</a><span>, in §6.1</span>
-   <li><a href="#dom-windowclient-navigate">navigate(url)</a><span>, in §4.2.9</span>
+   <li><a href="#dom-windowclient-navigate">navigate(url)</a><span>, in §4.2.10</span>
    <li><a href="#notify-controller-change">Notify Controller Change</a><span>, in §Unnumbered section</span>
    <li><a href="#dom-serviceworkerglobalscope-onactivate">onactivate</a><span>, in §4.1.4</span>
    <li><a href="#dom-serviceworkercontainer-oncontrollerchange">oncontrollerchange</a><span>, in §3.4.7</span>
@@ -6667,12 +6681,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="#dom-extendablemessageeventinit-ports">dict-member for ExtendableMessageEventInit</a><span>, in §4.8</span>
      <li><a href="#dom-extendablemessageevent-ports">attribute for ExtendableMessageEvent</a><span>, in §4.8.5</span>
     </ul>
-   <li><a href="#dom-client-postmessage">postMessage(message)</a><span>, in §4.2.4</span>
+   <li><a href="#dom-client-postmessage">postMessage(message)</a><span>, in §4.2.5</span>
    <li>
     postMessage(message, transfer)
     <ul>
      <li><a href="#dom-serviceworker-postmessage">method for ServiceWorker</a><span>, in §3.1.3</span>
-     <li><a href="#dom-client-postmessage">method for Client</a><span>, in §4.2.4</span>
+     <li><a href="#dom-client-postmessage">method for Client</a><span>, in §4.2.5</span>
     </ul>
    <li>
     potential response
@@ -6712,7 +6726,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="#dom-cachebatchoperation-request">dict-member for CacheBatchOperation</a><span>, in §6.4</span>
     </ul>
    <li><a href="#dfn-request-to-response-map">request to response map</a><span>, in §6.1</span>
-   <li><a href="#dom-client-reserved">reserved</a><span>, in §4.2.3</span>
+   <li><a href="#dom-client-reserved">reserved</a><span>, in §4.2.4</span>
    <li>
     reservedClientId
     <ul>
@@ -6839,6 +6853,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <ul>
      <li><a href="#dfn-type">dfn for service worker</a><span>, in §2.1</span>
      <li><a href="#dom-registrationoptions-type">dict-member for RegistrationOptions</a><span>, in §3.4</span>
+     <li><a href="#dom-client-type">attribute for Client</a><span>, in §4.2.3</span>
      <li><a href="#dom-clientqueryoptions-type">dict-member for ClientQueryOptions</a><span>, in §4.3</span>
      <li><a href="#dom-cachebatchoperation-type">dict-member for CacheBatchOperation</a><span>, in §6.4</span>
     </ul>
@@ -6855,7 +6870,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dfn-use">uses</a><span>, in §2.4</span>
    <li><a href="#dfn-use">using</a><span>, in §2.4</span>
    <li><a href="#dfn-service-worker-client-visibilitystate">visibility state</a><span>, in §4.2</span>
-   <li><a href="#dom-windowclient-visibilitystate">visibilityState</a><span>, in §4.2.5</span>
+   <li><a href="#dom-windowclient-visibilitystate">visibilityState</a><span>, in §4.2.6</span>
    <li><a href="#dom-serviceworkerregistration-waiting">waiting</a><span>, in §3.2.2</span>
    <li><a href="#dfn-waiting-worker">waiting worker</a><span>, in §2.2</span>
    <li>
@@ -7332,6 +7347,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 <span class="kt">interface</span> <a class="nv" href="#client">Client</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-client-url">url</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-client-id">id</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-clienttype">ClientType</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="ClientType" href="#dom-client-type">type</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-client-reserved">reserved</a>;
   <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-client-postmessage">postMessage</a>(<span class="kt">any</span> <a class="nv" href="#dom-client-postmessage-message-transfer-message">message</a>, <span class="kt">optional</span> <span class="kt">sequence</span>&lt;<span class="kt">object</span>> <a class="nv" href="#dom-client-postmessage-message-transfer-transfer">transfer</a> = []);
 };
@@ -7887,25 +7903,28 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-window-client">
    <b><a href="#dfn-window-client">#dfn-window-client</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-window-client-1">4.3.1. get(id)</a> <a href="#ref-for-dfn-window-client-2">(2)</a>
-    <li><a href="#ref-for-dfn-window-client-3">4.3.2. matchAll(options)</a> <a href="#ref-for-dfn-window-client-4">(2)</a>
-    <li><a href="#ref-for-dfn-window-client-5">Activate</a>
-    <li><a href="#ref-for-dfn-window-client-6">Handle Fetch</a>
+    <li><a href="#ref-for-dfn-window-client-1">4.2.3. type</a>
+    <li><a href="#ref-for-dfn-window-client-2">4.3.1. get(id)</a> <a href="#ref-for-dfn-window-client-3">(2)</a>
+    <li><a href="#ref-for-dfn-window-client-4">4.3.2. matchAll(options)</a> <a href="#ref-for-dfn-window-client-5">(2)</a>
+    <li><a href="#ref-for-dfn-window-client-6">Activate</a>
+    <li><a href="#ref-for-dfn-window-client-7">Handle Fetch</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-dedicatedworker-client">
    <b><a href="#dfn-dedicatedworker-client">#dfn-dedicatedworker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-dedicatedworker-client-1">2.3. Service Worker Client</a>
-    <li><a href="#ref-for-dfn-dedicatedworker-client-2">4.3.2. matchAll(options)</a>
+    <li><a href="#ref-for-dfn-dedicatedworker-client-2">4.2.3. type</a>
+    <li><a href="#ref-for-dfn-dedicatedworker-client-3">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-sharedworker-client">
    <b><a href="#dfn-sharedworker-client">#dfn-sharedworker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-sharedworker-client-1">2.3. Service Worker Client</a>
-    <li><a href="#ref-for-dfn-sharedworker-client-2">4.3.2. matchAll(options)</a>
-    <li><a href="#ref-for-dfn-sharedworker-client-3">Activate</a>
+    <li><a href="#ref-for-dfn-sharedworker-client-2">4.2.3. type</a>
+    <li><a href="#ref-for-dfn-sharedworker-client-3">4.3.2. matchAll(options)</a>
+    <li><a href="#ref-for-dfn-sharedworker-client-4">Activate</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-worker-client">
@@ -7975,7 +7994,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworker-17">3.4.1. controller</a> <a href="#ref-for-serviceworker-18">(2)</a>
     <li><a href="#ref-for-serviceworker-19">3.5. Events</a> <a href="#ref-for-serviceworker-20">(2)</a>
     <li><a href="#ref-for-serviceworker-21">4.1. ServiceWorkerGlobalScope</a>
-    <li><a href="#ref-for-serviceworker-22">4.2.4. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-serviceworker-22">4.2.5. postMessage(message, transfer)</a>
     <li><a href="#ref-for-serviceworker-23">4.8. ExtendableMessageEvent</a> <a href="#ref-for-serviceworker-24">(2)</a>
     <li><a href="#ref-for-serviceworker-25">Update Registration State</a> <a href="#ref-for-serviceworker-26">(2)</a> <a href="#ref-for-serviceworker-27">(3)</a>
     <li><a href="#ref-for-serviceworker-28">Update Worker State</a>
@@ -8143,7 +8162,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworkercontainer-4">3.4. ServiceWorkerContainer</a> <a href="#ref-for-serviceworkercontainer-5">(2)</a> <a href="#ref-for-serviceworkercontainer-6">(3)</a> <a href="#ref-for-serviceworkercontainer-7">(4)</a> <a href="#ref-for-serviceworkercontainer-8">(5)</a> <a href="#ref-for-serviceworkercontainer-9">(6)</a> <a href="#ref-for-serviceworkercontainer-10">(7)</a> <a href="#ref-for-serviceworkercontainer-11">(8)</a> <a href="#ref-for-serviceworkercontainer-12">(9)</a>
     <li><a href="#ref-for-serviceworkercontainer-13">3.4.7. Event handlers</a>
     <li><a href="#ref-for-serviceworkercontainer-14">3.5. Events</a>
-    <li><a href="#ref-for-serviceworkercontainer-15">4.2.4. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-serviceworkercontainer-15">4.2.5. postMessage(message, transfer)</a>
     <li><a href="#ref-for-serviceworkercontainer-16">Notify Controller Change</a>
    </ul>
   </aside>
@@ -8174,7 +8193,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworkercontainer-service-worker-client-4">3.4.4. getRegistration(clientURL)</a>
     <li><a href="#ref-for-serviceworkercontainer-service-worker-client-5">3.4.5. getRegistrations()</a>
     <li><a href="#ref-for-serviceworkercontainer-service-worker-client-6">3.5. Events</a>
-    <li><a href="#ref-for-serviceworkercontainer-service-worker-client-7">4.2.4. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-serviceworkercontainer-service-worker-client-7">4.2.5. postMessage(message, transfer)</a>
     <li><a href="#ref-for-serviceworkercontainer-service-worker-client-8">5.1. Processing</a>
     <li><a href="#ref-for-serviceworkercontainer-service-worker-client-9">Notify Controller Change</a>
    </ul>
@@ -8191,7 +8210,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-client-message-queue-1">3.4. ServiceWorkerContainer</a> <a href="#ref-for-dfn-client-message-queue-2">(2)</a> <a href="#ref-for-dfn-client-message-queue-3">(3)</a>
     <li><a href="#ref-for-dfn-client-message-queue-4">3.4.6. startMessages()</a>
     <li><a href="#ref-for-dfn-client-message-queue-5">3.4.7. Event handlers</a>
-    <li><a href="#ref-for-dfn-client-message-queue-6">4.2.4. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-dfn-client-message-queue-6">4.2.5. postMessage(message, transfer)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkercontainer-controller">
@@ -8291,8 +8310,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-1">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-2">3.2.5. update()</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-3">4.1.2. registration</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-4">4.2.4. postMessage(message, transfer)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-5">4.2.9. navigate(url)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-6">(2)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-4">4.2.5. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-5">4.2.10. navigate(url)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-6">(2)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-7">4.3.1. get(id)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-8">4.3.2. matchAll(options)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-9">(2)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-10">4.3.3. openWindow(url)</a>
@@ -8383,41 +8402,42 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-client-service-worker-client-1">4.2.1. url</a>
     <li><a href="#ref-for-client-service-worker-client-2">4.2.2. id</a>
-    <li><a href="#ref-for-client-service-worker-client-3">4.2.4. postMessage(message, transfer)</a>
-    <li><a href="#ref-for-client-service-worker-client-4">4.2.7. ancestorOrigins</a>
-    <li><a href="#ref-for-client-service-worker-client-5">4.2.8. focus()</a> <a href="#ref-for-client-service-worker-client-6">(2)</a> <a href="#ref-for-client-service-worker-client-7">(3)</a>
-    <li><a href="#ref-for-client-service-worker-client-8">4.2.9. navigate(url)</a> <a href="#ref-for-client-service-worker-client-9">(2)</a> <a href="#ref-for-client-service-worker-client-10">(3)</a>
-    <li><a href="#ref-for-client-service-worker-client-11">4.3.2. matchAll(options)</a> <a href="#ref-for-client-service-worker-client-12">(2)</a> <a href="#ref-for-client-service-worker-client-13">(3)</a> <a href="#ref-for-client-service-worker-client-14">(4)</a>
-    <li><a href="#ref-for-client-service-worker-client-15">Create Client</a>
-    <li><a href="#ref-for-client-service-worker-client-16">Create Window Client</a>
+    <li><a href="#ref-for-client-service-worker-client-3">4.2.3. type</a> <a href="#ref-for-client-service-worker-client-4">(2)</a> <a href="#ref-for-client-service-worker-client-5">(3)</a>
+    <li><a href="#ref-for-client-service-worker-client-6">4.2.5. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-client-service-worker-client-7">4.2.8. ancestorOrigins</a>
+    <li><a href="#ref-for-client-service-worker-client-8">4.2.9. focus()</a> <a href="#ref-for-client-service-worker-client-9">(2)</a> <a href="#ref-for-client-service-worker-client-10">(3)</a>
+    <li><a href="#ref-for-client-service-worker-client-11">4.2.10. navigate(url)</a> <a href="#ref-for-client-service-worker-client-12">(2)</a> <a href="#ref-for-client-service-worker-client-13">(3)</a>
+    <li><a href="#ref-for-client-service-worker-client-14">4.3.2. matchAll(options)</a> <a href="#ref-for-client-service-worker-client-15">(2)</a> <a href="#ref-for-client-service-worker-client-16">(3)</a> <a href="#ref-for-client-service-worker-client-17">(4)</a>
+    <li><a href="#ref-for-client-service-worker-client-18">Create Client</a>
+    <li><a href="#ref-for-client-service-worker-client-19">Create Window Client</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-reserved-state">
    <b><a href="#client-reserved-state">#client-reserved-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-client-reserved-state-1">4.2.3. reserved</a>
+    <li><a href="#ref-for-client-reserved-state-1">4.2.4. reserved</a>
     <li><a href="#ref-for-client-reserved-state-2">Create Client</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-service-worker-client-visibilitystate">
    <b><a href="#dfn-service-worker-client-visibilitystate">#dfn-service-worker-client-visibilitystate</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-service-worker-client-visibilitystate-1">4.2.5. visibilityState</a>
+    <li><a href="#ref-for-dfn-service-worker-client-visibilitystate-1">4.2.6. visibilityState</a>
     <li><a href="#ref-for-dfn-service-worker-client-visibilitystate-2">Create Window Client</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-service-worker-client-focusstate">
    <b><a href="#dfn-service-worker-client-focusstate">#dfn-service-worker-client-focusstate</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-service-worker-client-focusstate-1">4.2.6. focused</a>
-    <li><a href="#ref-for-dfn-service-worker-client-focusstate-2">4.2.8. focus()</a>
+    <li><a href="#ref-for-dfn-service-worker-client-focusstate-1">4.2.7. focused</a>
+    <li><a href="#ref-for-dfn-service-worker-client-focusstate-2">4.2.9. focus()</a>
     <li><a href="#ref-for-dfn-service-worker-client-focusstate-3">Create Window Client</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="windowclient-ancestor-origins-array">
    <b><a href="#windowclient-ancestor-origins-array">#windowclient-ancestor-origins-array</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-windowclient-ancestor-origins-array-1">4.2.7. ancestorOrigins</a>
+    <li><a href="#ref-for-windowclient-ancestor-origins-array-1">4.2.8. ancestorOrigins</a>
     <li><a href="#ref-for-windowclient-ancestor-origins-array-2">Create Window Client</a>
    </ul>
   </aside>
@@ -8435,53 +8455,60 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dom-client-id-2">4.2.2. id</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="dom-client-type">
+   <b><a href="#dom-client-type">#dom-client-type</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-client-type-1">4.2. Client</a>
+    <li><a href="#ref-for-dom-client-type-2">4.2.3. type</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="dom-client-reserved">
    <b><a href="#dom-client-reserved">#dom-client-reserved</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-reserved-1">4.2. Client</a>
-    <li><a href="#ref-for-dom-client-reserved-2">4.2.3. reserved</a>
+    <li><a href="#ref-for-dom-client-reserved-2">4.2.4. reserved</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-client-postmessage">
    <b><a href="#dom-client-postmessage">#dom-client-postmessage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-postmessage-1">4.2. Client</a>
-    <li><a href="#ref-for-dom-client-postmessage-2">4.2.4. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-dom-client-postmessage-2">4.2.5. postMessage(message, transfer)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-windowclient-visibilitystate">
    <b><a href="#dom-windowclient-visibilitystate">#dom-windowclient-visibilitystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-visibilitystate-1">4.2. Client</a>
-    <li><a href="#ref-for-dom-windowclient-visibilitystate-2">4.2.5. visibilityState</a>
+    <li><a href="#ref-for-dom-windowclient-visibilitystate-2">4.2.6. visibilityState</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-windowclient-focused">
    <b><a href="#dom-windowclient-focused">#dom-windowclient-focused</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-focused-1">4.2. Client</a>
-    <li><a href="#ref-for-dom-windowclient-focused-2">4.2.6. focused</a>
+    <li><a href="#ref-for-dom-windowclient-focused-2">4.2.7. focused</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-windowclient-ancestororigins">
    <b><a href="#dom-windowclient-ancestororigins">#dom-windowclient-ancestororigins</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-ancestororigins-1">4.2. Client</a>
-    <li><a href="#ref-for-dom-windowclient-ancestororigins-2">4.2.7. ancestorOrigins</a>
+    <li><a href="#ref-for-dom-windowclient-ancestororigins-2">4.2.8. ancestorOrigins</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-windowclient-focus">
    <b><a href="#dom-windowclient-focus">#dom-windowclient-focus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-focus-1">4.2. Client</a>
-    <li><a href="#ref-for-dom-windowclient-focus-2">4.2.8. focus()</a>
+    <li><a href="#ref-for-dom-windowclient-focus-2">4.2.9. focus()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-windowclient-navigate">
    <b><a href="#dom-windowclient-navigate">#dom-windowclient-navigate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-navigate-1">4.2. Client</a>
-    <li><a href="#ref-for-dom-windowclient-navigate-2">4.2.9. navigate(url)</a>
+    <li><a href="#ref-for-dom-windowclient-navigate-2">4.2.10. navigate(url)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="clients">
@@ -8519,25 +8546,29 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="enumdef-clienttype">
    <b><a href="#enumdef-clienttype">#enumdef-clienttype</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-clienttype-1">4.3. Clients</a>
+    <li><a href="#ref-for-enumdef-clienttype-1">4.2. Client</a>
+    <li><a href="#ref-for-enumdef-clienttype-2">4.3. Clients</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-clienttype-window">
    <b><a href="#dom-clienttype-window">#dom-clienttype-window</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-clienttype-window-1">4.3.2. matchAll(options)</a>
+    <li><a href="#ref-for-dom-clienttype-window-1">4.2.3. type</a>
+    <li><a href="#ref-for-dom-clienttype-window-2">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-clienttype-worker">
    <b><a href="#dom-clienttype-worker">#dom-clienttype-worker</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-clienttype-worker-1">4.3.2. matchAll(options)</a>
+    <li><a href="#ref-for-dom-clienttype-worker-1">4.2.3. type</a>
+    <li><a href="#ref-for-dom-clienttype-worker-2">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-clienttype-sharedworker">
    <b><a href="#dom-clienttype-sharedworker">#dom-clienttype-sharedworker</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-clienttype-sharedworker-1">4.3.2. matchAll(options)</a>
+    <li><a href="#ref-for-dom-clienttype-sharedworker-1">4.2.3. type</a>
+    <li><a href="#ref-for-dom-clienttype-sharedworker-2">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-clienttype-all">
@@ -9633,8 +9664,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="create-window-client">
    <b><a href="#create-window-client">#create-window-client</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-create-window-client-1">4.2.8. focus()</a>
-    <li><a href="#ref-for-create-window-client-2">4.2.9. navigate(url)</a>
+    <li><a href="#ref-for-create-window-client-1">4.2.9. focus()</a>
+    <li><a href="#ref-for-create-window-client-2">4.2.10. navigate(url)</a>
     <li><a href="#ref-for-create-window-client-3">4.3.1. get(id)</a>
     <li><a href="#ref-for-create-window-client-4">4.3.2. matchAll(options)</a>
     <li><a href="#ref-for-create-window-client-5">4.3.3. openWindow(url)</a>

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -861,6 +861,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       interface Client {
         readonly attribute USVString url;
         readonly attribute DOMString id;
+        readonly attribute ClientType type;
         readonly attribute boolean reserved;
         void postMessage(any message, optional sequence&lt;object&gt; transfer = []);
       };
@@ -895,6 +896,16 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       <h4 id="client-id">{{Client/id}}</h4>
 
       The <dfn attribute for="Client"><code>id</code></dfn> attribute *must* return its associated [=Client/service worker client=]'s [=environment/id=].
+    </section>
+
+    <section>
+      <h4 id="client-type">{{Client/type}}</h4>
+
+      The <dfn attribute for="Client"><code>type</code></dfn> attribute *must* run these steps:
+
+        1. If the [=context object=]'s [=Client/service worker client=] is a type of [=environment=] or is a [=window client=], return {{ClientType/"window"}}.
+        1. Else if the [=context object=]'s [=Client/service worker client=] is a [=dedicated worker client=], return {{ClientType/"worker"}}.
+        1. Else if the [=context object=]'s [=Client/service worker client=] is a [=shared worker client=], return {{ClientType/"sharedworker"}}.
     </section>
 
     <section>

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-01">1 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-02">2 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1545,13 +1545,14 @@ pre.idl.highlight { color: #708090; }
        <ol class="toc">
         <li><a href="#client-url"><span class="secno">4.2.1</span> <span class="content"><code class="idl"><span>url</span></code></span></a>
         <li><a href="#client-id"><span class="secno">4.2.2</span> <span class="content"><code class="idl"><span>id</span></code></span></a>
-        <li><a href="#client-reserved"><span class="secno">4.2.3</span> <span class="content"><code class="idl"><span>reserved</span></code></span></a>
-        <li><a href="#client-postmessage"><span class="secno">4.2.4</span> <span class="content"><code class="idl"><span>postMessage(message, transfer)</span></code></span></a>
-        <li><a href="#client-visibilitystate"><span class="secno">4.2.5</span> <span class="content"><code class="idl"><span>visibilityState</span></code></span></a>
-        <li><a href="#client-focused"><span class="secno">4.2.6</span> <span class="content"><code class="idl"><span>focused</span></code></span></a>
-        <li><a href="#client-ancestororigins"><span class="secno">4.2.7</span> <span class="content"><code class="idl"><span>ancestorOrigins</span></code></span></a>
-        <li><a href="#client-focus"><span class="secno">4.2.8</span> <span class="content"><code class="idl"><span>focus()</span></code></span></a>
-        <li><a href="#client-navigate"><span class="secno">4.2.9</span> <span class="content"><code class="idl"><span>navigate(url)</span></code></span></a>
+        <li><a href="#client-type"><span class="secno">4.2.3</span> <span class="content"><code class="idl"><span>type</span></code></span></a>
+        <li><a href="#client-reserved"><span class="secno">4.2.4</span> <span class="content"><code class="idl"><span>reserved</span></code></span></a>
+        <li><a href="#client-postmessage"><span class="secno">4.2.5</span> <span class="content"><code class="idl"><span>postMessage(message, transfer)</span></code></span></a>
+        <li><a href="#client-visibilitystate"><span class="secno">4.2.6</span> <span class="content"><code class="idl"><span>visibilityState</span></code></span></a>
+        <li><a href="#client-focused"><span class="secno">4.2.7</span> <span class="content"><code class="idl"><span>focused</span></code></span></a>
+        <li><a href="#client-ancestororigins"><span class="secno">4.2.8</span> <span class="content"><code class="idl"><span>ancestorOrigins</span></code></span></a>
+        <li><a href="#client-focus"><span class="secno">4.2.9</span> <span class="content"><code class="idl"><span>focus()</span></code></span></a>
+        <li><a href="#client-navigate"><span class="secno">4.2.10</span> <span class="content"><code class="idl"><span>navigate(url)</span></code></span></a>
        </ol>
       <li>
        <a href="#clients-interface"><span class="secno">4.3</span> <span class="content"><code class="idl"><span>Clients</span></code></span></a>
@@ -2395,6 +2396,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="client">Client</dfn> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-client-url" id="ref-for-dom-client-url-1">url</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-client-id" id="ref-for-dom-client-id-1">id</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-clienttype" id="ref-for-enumdef-clienttype-1">ClientType</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="ClientType" href="#dom-client-type" id="ref-for-dom-client-type-1">type</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-client-reserved" id="ref-for-dom-client-reserved-1">reserved</a>;
   <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-client-postmessage" id="ref-for-dom-client-postmessage-1">postMessage</a>(<span class="kt">any</span> <dfn class="nv idl-code" data-dfn-for="Client/postMessage(message, transfer), Client/postMessage(message)" data-dfn-type="argument" data-export="" id="dom-client-postmessage-message-transfer-message">message<a class="self-link" href="#dom-client-postmessage-message-transfer-message"></a></dfn>, <span class="kt">optional</span> <span class="kt">sequence</span>&lt;<span class="kt">object</span>> <dfn class="nv idl-code" data-dfn-for="Client/postMessage(message, transfer), Client/postMessage(message)" data-dfn-type="argument" data-export="" id="dom-client-postmessage-message-transfer-transfer">transfer<a class="self-link" href="#dom-client-postmessage-message-transfer-transfer"></a></dfn> = []);
 };
@@ -2422,17 +2424,29 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Client" data-dfn-type="attribute" data-export="" id="dom-client-id"><code>id</code></dfn> attribute <em>must</em> return its associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-2">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id">id</a>.</p>
      </section>
      <section>
-      <h4 class="heading settled" data-level="4.2.3" id="client-reserved"><span class="secno">4.2.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-client-reserved" id="ref-for-dom-client-reserved-2">reserved</a></code></span><a class="self-link" href="#client-reserved"></a></h4>
+      <h4 class="heading settled" data-level="4.2.3" id="client-type"><span class="secno">4.2.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-client-type" id="ref-for-dom-client-type-2">type</a></code></span><a class="self-link" href="#client-type"></a></h4>
+      <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Client" data-dfn-type="attribute" data-export="" id="dom-client-type"><code>type</code></dfn> attribute <em>must</em> run these steps:</p>
+      <ol>
+       <li data-md="">
+        <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-3">service worker client</a> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a> or is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-1">window client</a>, return <code class="idl"><a data-link-type="idl" href="#dom-clienttype-window" id="ref-for-dom-clienttype-window-1">"window"</a></code>.</p>
+       <li data-md="">
+        <p>Else if the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-4">service worker client</a> is a <a data-link-type="dfn" href="#dfn-dedicatedworker-client" id="ref-for-dfn-dedicatedworker-client-2">dedicated worker client</a>, return <code class="idl"><a data-link-type="idl" href="#dom-clienttype-worker" id="ref-for-dom-clienttype-worker-1">"worker"</a></code>.</p>
+       <li data-md="">
+        <p>Else if the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-5">service worker client</a> is a <a data-link-type="dfn" href="#dfn-sharedworker-client" id="ref-for-dfn-sharedworker-client-2">shared worker client</a>, return <code class="idl"><a data-link-type="idl" href="#dom-clienttype-sharedworker" id="ref-for-dom-clienttype-sharedworker-1">"sharedworker"</a></code>.</p>
+      </ol>
+     </section>
+     <section>
+      <h4 class="heading settled" data-level="4.2.4" id="client-reserved"><span class="secno">4.2.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-client-reserved" id="ref-for-dom-client-reserved-2">reserved</a></code></span><a class="self-link" href="#client-reserved"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Client" data-dfn-type="attribute" data-export="" id="dom-client-reserved"><code>reserved</code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-reserved-state" id="ref-for-client-reserved-state-1">reserved state</a>.</p>
      </section>
      <section class="algorithm" data-algorithm="client-postmessage">
-      <h4 class="heading settled" data-level="4.2.4" id="client-postmessage"><span class="secno">4.2.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-client-postmessage" id="ref-for-dom-client-postmessage-2">postMessage(message, transfer)</a></code></span><a class="self-link" href="#client-postmessage"></a></h4>
+      <h4 class="heading settled" data-level="4.2.5" id="client-postmessage"><span class="secno">4.2.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-client-postmessage" id="ref-for-dom-client-postmessage-2">postMessage(message, transfer)</a></code></span><a class="self-link" href="#client-postmessage"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Client" data-dfn-type="method" data-export="" data-lt="postMessage(message, transfer)|postMessage(message)" id="dom-client-postmessage"><code>postMessage(<var>message</var>, <var>transfer</var>)</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
         <p>Let <var>sourceSettings</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>.</p>
        <li data-md="">
-        <p>Let <var>destination</var> be the <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-15">ServiceWorkerContainer</a></code> object whose <a data-link-type="dfn" href="#serviceworkercontainer-service-worker-client" id="ref-for-serviceworkercontainer-service-worker-client-7">service worker client</a> is the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-3">service worker client</a>.</p>
+        <p>Let <var>destination</var> be the <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-15">ServiceWorkerContainer</a></code> object whose <a data-link-type="dfn" href="#serviceworkercontainer-service-worker-client" id="ref-for-serviceworkercontainer-service-worker-client-7">service worker client</a> is the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-6">service worker client</a>.</p>
        <li data-md="">
         <p>If <var>destination</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" exception.</p>
        <li data-md="">
@@ -2462,19 +2476,19 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       </ol>
      </section>
      <section>
-      <h4 class="heading settled" data-level="4.2.5" id="client-visibilitystate"><span class="secno">4.2.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-visibilitystate" id="ref-for-dom-windowclient-visibilitystate-2">visibilityState</a></code></span><a class="self-link" href="#client-visibilitystate"></a></h4>
+      <h4 class="heading settled" data-level="4.2.6" id="client-visibilitystate"><span class="secno">4.2.6. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-visibilitystate" id="ref-for-dom-windowclient-visibilitystate-2">visibilityState</a></code></span><a class="self-link" href="#client-visibilitystate"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="WindowClient" data-dfn-type="attribute" data-export="" id="dom-windowclient-visibilitystate"><code>visibilityState</code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#dfn-service-worker-client-visibilitystate" id="ref-for-dfn-service-worker-client-visibilitystate-1">visibility state</a>.</p>
      </section>
      <section>
-      <h4 class="heading settled" data-level="4.2.6" id="client-focused"><span class="secno">4.2.6. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-focused" id="ref-for-dom-windowclient-focused-2">focused</a></code></span><a class="self-link" href="#client-focused"></a></h4>
+      <h4 class="heading settled" data-level="4.2.7" id="client-focused"><span class="secno">4.2.7. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-focused" id="ref-for-dom-windowclient-focused-2">focused</a></code></span><a class="self-link" href="#client-focused"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="WindowClient" data-dfn-type="attribute" data-export="" id="dom-windowclient-focused"><code>focused</code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#dfn-service-worker-client-focusstate" id="ref-for-dfn-service-worker-client-focusstate-1">focus state</a>.</p>
      </section>
      <section>
-      <h4 class="heading settled" data-level="4.2.7" id="client-ancestororigins"><span class="secno">4.2.7. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-ancestororigins" id="ref-for-dom-windowclient-ancestororigins-2">ancestorOrigins</a></code></span><a class="self-link" href="#client-ancestororigins"></a></h4>
-      <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="WindowClient" data-dfn-type="attribute" data-export="" id="dom-windowclient-ancestororigins"><code>ancestorOrigins</code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-4">service worker client</a>'s <a data-link-type="dfn" href="#windowclient-ancestor-origins-array" id="ref-for-windowclient-ancestor-origins-array-1">ancestor origins array</a>.</p>
+      <h4 class="heading settled" data-level="4.2.8" id="client-ancestororigins"><span class="secno">4.2.8. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-ancestororigins" id="ref-for-dom-windowclient-ancestororigins-2">ancestorOrigins</a></code></span><a class="self-link" href="#client-ancestororigins"></a></h4>
+      <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="WindowClient" data-dfn-type="attribute" data-export="" id="dom-windowclient-ancestororigins"><code>ancestorOrigins</code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-7">service worker client</a>'s <a data-link-type="dfn" href="#windowclient-ancestor-origins-array" id="ref-for-windowclient-ancestor-origins-array-1">ancestor origins array</a>.</p>
      </section>
      <section class="algorithm" data-algorithm="client-focus">
-      <h4 class="heading settled" data-level="4.2.8" id="client-focus"><span class="secno">4.2.8. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-focus" id="ref-for-dom-windowclient-focus-2">focus()</a></code></span><a class="self-link" href="#client-focus"></a></h4>
+      <h4 class="heading settled" data-level="4.2.9" id="client-focus"><span class="secno">4.2.9. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-focus" id="ref-for-dom-windowclient-focus-2">focus()</a></code></span><a class="self-link" href="#client-focus"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="WindowClient" data-dfn-type="method" data-export="" id="dom-windowclient-focus"><code>focus()</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
@@ -2485,7 +2499,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>Run these substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>browsingContext</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-5">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>.</p>
+          <p>Let <var>browsingContext</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-8">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>.</p>
          <li data-md="">
           <p>Let <var>visibilityState</var> be null.</p>
          <li data-md="">
@@ -2493,7 +2507,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Let <var>ancestorOrigins</var> be the empty array.</p>
          <li data-md="">
-          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps on the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-6">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">user interaction task source</a>:</p>
+          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps on the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-9">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">user interaction task source</a>:</p>
           <ol>
            <li data-md="">
             <p>Run the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">focusing steps</a> with <var>browsingContext</var>.</p>
@@ -2507,7 +2521,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Wait for <var>task</var> to have executed.</p>
          <li data-md="">
-          <p>Let <var>windowClient</var> be the result of running <a data-link-type="dfn" href="#create-window-client" id="ref-for-create-window-client-1">Create Window Client</a> algorithm with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-7">service worker client</a>, <var>visibilityState</var>, <var>focusState</var>, and <var>ancestorOrigins</var> as the arguments.</p>
+          <p>Let <var>windowClient</var> be the result of running <a data-link-type="dfn" href="#create-window-client" id="ref-for-create-window-client-1">Create Window Client</a> algorithm with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-10">service worker client</a>, <var>visibilityState</var>, <var>focusState</var>, and <var>ancestorOrigins</var> as the arguments.</p>
          <li data-md="">
           <p>If <var>windowClient</var>’s <a data-link-type="dfn" href="#dfn-service-worker-client-focusstate" id="ref-for-dfn-service-worker-client-focusstate-2">focus state</a> is true, resolve <var>promise</var> with <var>windowClient</var>.</p>
          <li data-md="">
@@ -2518,7 +2532,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       </ol>
      </section>
      <section class="algorithm" data-algorithm="client-navigate">
-      <h4 class="heading settled" data-level="4.2.9" id="client-navigate"><span class="secno">4.2.9. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-navigate" id="ref-for-dom-windowclient-navigate-2">navigate(url)</a></code></span><a class="self-link" href="#client-navigate"></a></h4>
+      <h4 class="heading settled" data-level="4.2.10" id="client-navigate"><span class="secno">4.2.10. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-windowclient-navigate" id="ref-for-dom-windowclient-navigate-2">navigate(url)</a></code></span><a class="self-link" href="#client-navigate"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="WindowClient" data-dfn-type="method" data-export="" data-lt="navigate(url)" id="dom-windowclient-navigate"><code>navigate()</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
@@ -2528,14 +2542,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>If <var>url</var> is <code>about:blank</code>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with a <code>TypeError</code>.</p>
        <li data-md="">
-        <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-8">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-5">service worker</a>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with a <code>TypeError</code>.</p>
+        <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-11">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-5">service worker</a>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with a <code>TypeError</code>.</p>
        <li data-md="">
         <p>Let <var>promise</var> be a new <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>.</p>
        <li data-md="">
         <p>Run these substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>browsingContext</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-9">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>.</p>
+          <p>Let <var>browsingContext</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-12">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>.</p>
          <li data-md="">
           <p>If <var>browsingContext</var> has <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#discard-a-document">discarded</a> its <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code>, reject <var>promise</var> with a <code>TypeError</code> and abort these steps.</p>
          <li data-md="">
@@ -2547,7 +2561,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Let <var>ancestorOrigins</var> be the empty array.</p>
          <li data-md="">
-          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps on the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-10">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">user interaction task source</a>:</p>
+          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps on the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-13">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">user interaction task source</a>:</p>
           <ol>
            <li data-md="">
             <p><em>HandleNavigate</em>: <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#navigate">Navigate</a> <var>browsingContext</var> to <var>url</var> with <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#exceptions-enabled">exceptions enabled</a>. The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#source-browsing-context">source browsing context</a> must be <var>browsingContext</var>.</p>
@@ -2596,7 +2610,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 <pre class="idl highlight def" id="serviceworker-client-query-options-dictionary"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-clientqueryoptions">ClientQueryOptions</dfn> {
   <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-default="false" data-dfn-for="ClientQueryOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-clientqueryoptions-includeuncontrolled">includeUncontrolled</dfn> = <span class="kt">false</span>;
   <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-default="false" data-dfn-for="ClientQueryOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-clientqueryoptions-includereserved">includeReserved</dfn> = <span class="kt">false</span>;
-  <a class="n" data-link-type="idl-name" href="#enumdef-clienttype" id="ref-for-enumdef-clienttype-1">ClientType</a> <dfn class="nv dfn-paneled idl-code" data-default="&quot;window&quot;" data-dfn-for="ClientQueryOptions" data-dfn-type="dict-member" data-export="" data-type="ClientType " id="dom-clientqueryoptions-type">type</dfn> = "window";
+  <a class="n" data-link-type="idl-name" href="#enumdef-clienttype" id="ref-for-enumdef-clienttype-2">ClientType</a> <dfn class="nv dfn-paneled idl-code" data-default="&quot;window&quot;" data-dfn-for="ClientQueryOptions" data-dfn-type="dict-member" data-export="" data-type="ClientType " id="dom-clientqueryoptions-type">type</dfn> = "window";
 };
 </pre>
 <pre class="idl highlight def" id="client-type-enum"><span class="kt">enum</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="enum" data-export="" id="enumdef-clienttype">ClientType</dfn> {
@@ -2634,7 +2648,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
               <p>If <var>client</var> is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>, reject <var>promise</var> with a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception and abort these steps.</p>
             </ol>
            <li data-md="">
-            <p>If <var>client</var> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a> or is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-1">window client</a>, then:</p>
+            <p>If <var>client</var> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a> or is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-2">window client</a>, then:</p>
             <ol>
              <li data-md="">
               <p>Let <var>browsingContext</var> be null.</p>
@@ -2656,7 +2670,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
                <li data-md="">
                 <p>Set <var>focusState</var> to the result of running the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">has focus steps</a> with <var>browsingContext</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a> as the argument.</p>
                <li data-md="">
-                <p>If <var>client</var> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-2">window client</a>, set <var>ancestorOrigins</var> to <var>browsingContext</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#location">Location</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-array">ancestor origins array</a>.</p>
+                <p>If <var>client</var> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-3">window client</a>, set <var>ancestorOrigins</var> to <var>browsingContext</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#location">Location</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-array">ancestor origins array</a>.</p>
               </ol>
              <li data-md="">
               <p>Wait for <var>task</var> to have executed.</p>
@@ -2728,7 +2742,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-30">service worker client</a> <var>client</var> in <var>targetClients</var>:</p>
           <ol>
            <li data-md="">
-            <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-type" id="ref-for-dom-clientqueryoptions-type-1">type</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-clienttype-window" id="ref-for-dom-clienttype-window-1">"window"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-clienttype-all" id="ref-for-dom-clienttype-all-1">"all"</a></code>, and <var>client</var> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a> or is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-3">window client</a>, then:</p>
+            <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-type" id="ref-for-dom-clientqueryoptions-type-1">type</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-clienttype-window" id="ref-for-dom-clienttype-window-2">"window"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-clienttype-all" id="ref-for-dom-clienttype-all-1">"all"</a></code>, and <var>client</var> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a> or is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-4">window client</a>, then:</p>
             <ol>
              <li data-md="">
               <p>Let <var>browsingContext</var> be null.</p>
@@ -2756,7 +2770,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
                <li data-md="">
                 <p>Set <var>focusState</var> to the result of running the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">has focus steps</a> with <var>browsingContext</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a> as the argument.</p>
                <li data-md="">
-                <p>It <var>client</var> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-4">window client</a>, set <var>ancestorOrigins</var> to <var>browsingContext</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#location">Location</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-array">ancestor origins array</a>.</p>
+                <p>It <var>client</var> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-5">window client</a>, set <var>ancestorOrigins</var> to <var>browsingContext</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">active document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#location">Location</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-array">ancestor origins array</a>.</p>
               </ol>
              <li data-md="">
               <p>Wait for <var>task</var> to have executed.</p>
@@ -2771,7 +2785,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
               </ol>
             </ol>
            <li data-md="">
-            <p>Else if <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-type" id="ref-for-dom-clientqueryoptions-type-2">type</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-clienttype-worker" id="ref-for-dom-clienttype-worker-1">"worker"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-clienttype-all" id="ref-for-dom-clienttype-all-2">"all"</a></code> and <var>client</var> is a <a data-link-type="dfn" href="#dfn-dedicatedworker-client" id="ref-for-dfn-dedicatedworker-client-2">dedicated worker client</a>, or <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-type" id="ref-for-dom-clientqueryoptions-type-3">type</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-clienttype-sharedworker" id="ref-for-dom-clienttype-sharedworker-1">"sharedworker"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-clienttype-all" id="ref-for-dom-clienttype-all-3">"all"</a></code> and <var>client</var> is a <a data-link-type="dfn" href="#dfn-sharedworker-client" id="ref-for-dfn-sharedworker-client-2">shared worker client</a>, then:</p>
+            <p>Else if <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-type" id="ref-for-dom-clientqueryoptions-type-2">type</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-clienttype-worker" id="ref-for-dom-clienttype-worker-2">"worker"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-clienttype-all" id="ref-for-dom-clienttype-all-2">"all"</a></code> and <var>client</var> is a <a data-link-type="dfn" href="#dfn-dedicatedworker-client" id="ref-for-dfn-dedicatedworker-client-3">dedicated worker client</a>, or <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-type" id="ref-for-dom-clientqueryoptions-type-3">type</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-clienttype-sharedworker" id="ref-for-dom-clienttype-sharedworker-2">"sharedworker"</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-clienttype-all" id="ref-for-dom-clienttype-all-3">"all"</a></code> and <var>client</var> is a <a data-link-type="dfn" href="#dfn-sharedworker-client" id="ref-for-dfn-sharedworker-client-3">shared worker client</a>, then:</p>
             <ol>
              <li data-md="">
               <p>Let <var>clientObject</var> be the result of running <a data-link-type="dfn" href="#create-client" id="ref-for-create-client-2">Create Client</a> algorithm with <var>client</var> as the argument.</p>
@@ -2783,11 +2797,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <p>Sort <var>matchedClients</var> such that:</p>
           <ul>
            <li data-md="">
-            <p><code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-8">WindowClient</a></code> objects are always placed before <code class="idl"><a data-link-type="idl" href="#client" id="ref-for-client-7">Client</a></code> objects whose associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-11">service worker clients</a> are <a data-link-type="dfn" href="#dfn-worker-client" id="ref-for-dfn-worker-client-2">worker clients</a>.</p>
+            <p><code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-8">WindowClient</a></code> objects are always placed before <code class="idl"><a data-link-type="idl" href="#client" id="ref-for-client-7">Client</a></code> objects whose associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-14">service worker clients</a> are <a data-link-type="dfn" href="#dfn-worker-client" id="ref-for-dfn-worker-client-2">worker clients</a>.</p>
            <li data-md="">
-            <p><code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-9">WindowClient</a></code> objects that have been <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">focused</a> are placed first sorted in the most recently <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">focused</a> order, and <code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-10">WindowClient</a></code> objects that have never been <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">focused</a> are placed next sorted in their <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-12">service worker clients</a>' creation order.</p>
+            <p><code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-9">WindowClient</a></code> objects that have been <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">focused</a> are placed first sorted in the most recently <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">focused</a> order, and <code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-10">WindowClient</a></code> objects that have never been <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">focused</a> are placed next sorted in their <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-15">service worker clients</a>' creation order.</p>
            <li data-md="">
-            <p><code class="idl"><a data-link-type="idl" href="#client" id="ref-for-client-8">Client</a></code> objects whose associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-13">service worker clients</a> are <a data-link-type="dfn" href="#dfn-worker-client" id="ref-for-dfn-worker-client-3">worker clients</a> are placed next sorted in their <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-14">service worker clients</a>' creation order.</p>
+            <p><code class="idl"><a data-link-type="idl" href="#client" id="ref-for-client-8">Client</a></code> objects whose associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-16">service worker clients</a> are <a data-link-type="dfn" href="#dfn-worker-client" id="ref-for-dfn-worker-client-3">worker clients</a> are placed next sorted in their <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-17">service worker clients</a>' creation order.</p>
           </ul>
          <li data-md="">
           <p>Resolve <var>promise</var> with <var>matchedClients</var>.</p>
@@ -4630,9 +4644,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-40">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-9">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-16">scope url</a>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>client</var> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-5">window client</a>, unassociate <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a> from its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#application-cache">application cache</a>, if it has one.</p>
+         <p>If <var>client</var> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-6">window client</a>, unassociate <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a> from its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#application-cache">application cache</a>, if it has one.</p>
         <li data-md="">
-         <p>Else if <var>client</var> is a <a data-link-type="dfn" href="#dfn-sharedworker-client" id="ref-for-dfn-sharedworker-client-3">shared worker client</a>, unassociate <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> from its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#application-cache">application cache</a>, if it has one.</p>
+         <p>Else if <var>client</var> is a <a data-link-type="dfn" href="#dfn-sharedworker-client" id="ref-for-dfn-sharedworker-client-4">shared worker client</a>, unassociate <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> from its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#application-cache">application cache</a>, if it has one.</p>
        </ol>
        <p class="note" role="note">Note: Resources will now use the service worker registration instead of the existing application cache.</p>
       <li data-md="">
@@ -4941,7 +4955,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request">navigation request</a>, initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-targetclientid" id="ref-for-dom-fetchevent-targetclientid-3">targetClientId</a></code> attribute to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-client-id">target client id</a>, and to the empty string otherwise.</p>
         <li data-md="">
-         <p>Let the <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-isreload" id="ref-for-dom-fetchevent-isreload-3">isReload</a></code> attribute of <var>e</var> be initialized to <code>true</code> if <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">client</a> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-6">window client</a> and the event was dispatched with the user’s intention for the page reload, and <code>false</code> otherwise.</p>
+         <p>Let the <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-isreload" id="ref-for-dom-fetchevent-isreload-3">isReload</a></code> attribute of <var>e</var> be initialized to <code>true</code> if <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">client</a> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-7">window client</a> and the event was dispatched with the user’s intention for the page reload, and <code>false</code> otherwise.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-5">global object</a>.</p>
         <li data-md="">
@@ -5490,7 +5504,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>clientObject</var> be a new <code class="idl"><a data-link-type="idl" href="#client" id="ref-for-client-13">Client</a></code> object.</p>
       <li data-md="">
-       <p>Set <var>clientObject</var>’s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-15">service worker client</a> to <var>client</var>.</p>
+       <p>Set <var>clientObject</var>’s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-18">service worker client</a> to <var>client</var>.</p>
       <li data-md="">
        <p>Set <var>clientObject</var>’s <a data-link-type="dfn" href="#client-reserved-state" id="ref-for-client-reserved-state-2">reserved state</a> to true if <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag">execution ready flag</a> is unset, and false otherwise.</p>
       <li data-md="">
@@ -5519,7 +5533,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>windowClient</var> be a new <code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-12">WindowClient</a></code> object.</p>
       <li data-md="">
-       <p>Set <var>windowClient</var>’s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-16">service worker client</a> to <var>client</var>.</p>
+       <p>Set <var>windowClient</var>’s <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-19">service worker client</a> to <var>client</var>.</p>
       <li data-md="">
        <p>Set <var>windowClient</var>’s <a data-link-type="dfn" href="#dfn-service-worker-client-visibilitystate" id="ref-for-dfn-service-worker-client-visibilitystate-2">visibility state</a> to <var>visibilityState</var>.</p>
       <li data-md="">
@@ -5875,7 +5889,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dom-cache-add">add(request)</a><span>, in §5.4.3</span>
    <li><a href="#dom-clienttype-all">all</a><span>, in §4.3</span>
    <li><a href="#dom-clienttype-all">"all"</a><span>, in §4.3</span>
-   <li><a href="#dom-windowclient-ancestororigins">ancestorOrigins</a><span>, in §4.2.7</span>
+   <li><a href="#dom-windowclient-ancestororigins">ancestorOrigins</a><span>, in §4.2.8</span>
    <li><a href="#windowclient-ancestor-origins-array">ancestor origins array</a><span>, in §4.2</span>
    <li><a href="#batch-cache-operations">Batch Cache Operations</a><span>, in §Unnumbered section</span>
    <li><a href="#cache">Cache</a><span>, in §5.4</span>
@@ -5934,8 +5948,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dom-fetchevent-fetchevent">FetchEvent(type, eventInitDict)</a><span>, in §4.5</span>
    <li><a href="#dfn-fetching-record">fetching record</a><span>, in §5.1</span>
    <li><a href="#finish-job">Finish Job</a><span>, in §Unnumbered section</span>
-   <li><a href="#dom-windowclient-focus">focus()</a><span>, in §4.2.8</span>
-   <li><a href="#dom-windowclient-focused">focused</a><span>, in §4.2.6</span>
+   <li><a href="#dom-windowclient-focus">focus()</a><span>, in §4.2.9</span>
+   <li><a href="#dom-windowclient-focused">focused</a><span>, in §4.2.7</span>
    <li><a href="#dfn-service-worker-client-focusstate">focus state</a><span>, in §4.2</span>
    <li><a href="#dfn-job-force-bypass-cache-flag">force bypass cache flag</a><span>, in §Unnumbered section</span>
    <li><a href="#dfn-functional-events">functional events</a><span>, in §2.1</span>
@@ -6037,7 +6051,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#match-service-worker-registration">Match Service Worker Registration</a><span>, in §Unnumbered section</span>
    <li><a href="#eventdef-serviceworkerglobalscope-message">message</a><span>, in §4.7</span>
    <li><a href="#dfn-name-to-cache-map">name to cache map</a><span>, in §5.1</span>
-   <li><a href="#dom-windowclient-navigate">navigate(url)</a><span>, in §4.2.9</span>
+   <li><a href="#dom-windowclient-navigate">navigate(url)</a><span>, in §4.2.10</span>
    <li><a href="#notify-controller-change">Notify Controller Change</a><span>, in §Unnumbered section</span>
    <li><a href="#dom-serviceworkerglobalscope-onactivate">onactivate</a><span>, in §4.1.4</span>
    <li><a href="#dom-serviceworkercontainer-oncontrollerchange">oncontrollerchange</a><span>, in §3.4.7</span>
@@ -6067,12 +6081,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="#dom-extendablemessageeventinit-ports">dict-member for ExtendableMessageEventInit</a><span>, in §4.6</span>
      <li><a href="#dom-extendablemessageevent-ports">attribute for ExtendableMessageEvent</a><span>, in §4.6.5</span>
     </ul>
-   <li><a href="#dom-client-postmessage">postMessage(message)</a><span>, in §4.2.4</span>
+   <li><a href="#dom-client-postmessage">postMessage(message)</a><span>, in §4.2.5</span>
    <li>
     postMessage(message, transfer)
     <ul>
      <li><a href="#dom-serviceworker-postmessage">method for ServiceWorker</a><span>, in §3.1.3</span>
-     <li><a href="#dom-client-postmessage">method for Client</a><span>, in §4.2.4</span>
+     <li><a href="#dom-client-postmessage">method for Client</a><span>, in §4.2.5</span>
     </ul>
    <li><a href="#fetchevent-potential-response">potential response</a><span>, in §4.5</span>
    <li><a href="#dfn-processing-equivalence">processing equivalence</a><span>, in §Unnumbered section</span>
@@ -6103,7 +6117,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="#dom-cachebatchoperation-request">dict-member for CacheBatchOperation</a><span>, in §5.4</span>
     </ul>
    <li><a href="#dfn-request-to-response-map">request to response map</a><span>, in §5.1</span>
-   <li><a href="#dom-client-reserved">reserved</a><span>, in §4.2.3</span>
+   <li><a href="#dom-client-reserved">reserved</a><span>, in §4.2.4</span>
    <li>
     reservedClientId
     <ul>
@@ -6204,6 +6218,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <ul>
      <li><a href="#dfn-type">dfn for service worker</a><span>, in §2.1</span>
      <li><a href="#dom-registrationoptions-type">dict-member for RegistrationOptions</a><span>, in §3.4</span>
+     <li><a href="#dom-client-type">attribute for Client</a><span>, in §4.2.3</span>
      <li><a href="#dom-clientqueryoptions-type">dict-member for ClientQueryOptions</a><span>, in §4.3</span>
      <li><a href="#dom-cachebatchoperation-type">dict-member for CacheBatchOperation</a><span>, in §5.4</span>
     </ul>
@@ -6220,7 +6235,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dfn-use">uses</a><span>, in §2.4</span>
    <li><a href="#dfn-use">using</a><span>, in §2.4</span>
    <li><a href="#dfn-service-worker-client-visibilitystate">visibility state</a><span>, in §4.2</span>
-   <li><a href="#dom-windowclient-visibilitystate">visibilityState</a><span>, in §4.2.5</span>
+   <li><a href="#dom-windowclient-visibilitystate">visibilityState</a><span>, in §4.2.6</span>
    <li><a href="#dom-serviceworkerregistration-waiting">waiting</a><span>, in §3.2.2</span>
    <li><a href="#dfn-waiting-worker">waiting worker</a><span>, in §2.2</span>
    <li><a href="#fetchevent-wait-to-respond-flag">wait to respond flag</a><span>, in §4.5</span>
@@ -6662,6 +6677,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 <span class="kt">interface</span> <a class="nv" href="#client">Client</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-client-url">url</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-client-id">id</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#enumdef-clienttype">ClientType</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="ClientType" href="#dom-client-type">type</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-client-reserved">reserved</a>;
   <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-client-postmessage">postMessage</a>(<span class="kt">any</span> <a class="nv" href="#dom-client-postmessage-message-transfer-message">message</a>, <span class="kt">optional</span> <span class="kt">sequence</span>&lt;<span class="kt">object</span>> <a class="nv" href="#dom-client-postmessage-message-transfer-transfer">transfer</a> = []);
 };
@@ -7156,25 +7172,28 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-window-client">
    <b><a href="#dfn-window-client">#dfn-window-client</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-window-client-1">4.3.1. get(id)</a> <a href="#ref-for-dfn-window-client-2">(2)</a>
-    <li><a href="#ref-for-dfn-window-client-3">4.3.2. matchAll(options)</a> <a href="#ref-for-dfn-window-client-4">(2)</a>
-    <li><a href="#ref-for-dfn-window-client-5">Activate</a>
-    <li><a href="#ref-for-dfn-window-client-6">Handle Fetch</a>
+    <li><a href="#ref-for-dfn-window-client-1">4.2.3. type</a>
+    <li><a href="#ref-for-dfn-window-client-2">4.3.1. get(id)</a> <a href="#ref-for-dfn-window-client-3">(2)</a>
+    <li><a href="#ref-for-dfn-window-client-4">4.3.2. matchAll(options)</a> <a href="#ref-for-dfn-window-client-5">(2)</a>
+    <li><a href="#ref-for-dfn-window-client-6">Activate</a>
+    <li><a href="#ref-for-dfn-window-client-7">Handle Fetch</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-dedicatedworker-client">
    <b><a href="#dfn-dedicatedworker-client">#dfn-dedicatedworker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-dedicatedworker-client-1">2.3. Service Worker Client</a>
-    <li><a href="#ref-for-dfn-dedicatedworker-client-2">4.3.2. matchAll(options)</a>
+    <li><a href="#ref-for-dfn-dedicatedworker-client-2">4.2.3. type</a>
+    <li><a href="#ref-for-dfn-dedicatedworker-client-3">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-sharedworker-client">
    <b><a href="#dfn-sharedworker-client">#dfn-sharedworker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-sharedworker-client-1">2.3. Service Worker Client</a>
-    <li><a href="#ref-for-dfn-sharedworker-client-2">4.3.2. matchAll(options)</a>
-    <li><a href="#ref-for-dfn-sharedworker-client-3">Activate</a>
+    <li><a href="#ref-for-dfn-sharedworker-client-2">4.2.3. type</a>
+    <li><a href="#ref-for-dfn-sharedworker-client-3">4.3.2. matchAll(options)</a>
+    <li><a href="#ref-for-dfn-sharedworker-client-4">Activate</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-worker-client">
@@ -7243,7 +7262,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworker-17">3.4.1. controller</a> <a href="#ref-for-serviceworker-18">(2)</a>
     <li><a href="#ref-for-serviceworker-19">3.5. Events</a> <a href="#ref-for-serviceworker-20">(2)</a>
     <li><a href="#ref-for-serviceworker-21">4.1. ServiceWorkerGlobalScope</a>
-    <li><a href="#ref-for-serviceworker-22">4.2.4. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-serviceworker-22">4.2.5. postMessage(message, transfer)</a>
     <li><a href="#ref-for-serviceworker-23">4.6. ExtendableMessageEvent</a> <a href="#ref-for-serviceworker-24">(2)</a>
     <li><a href="#ref-for-serviceworker-25">Update Registration State</a> <a href="#ref-for-serviceworker-26">(2)</a> <a href="#ref-for-serviceworker-27">(3)</a>
     <li><a href="#ref-for-serviceworker-28">Update Worker State</a>
@@ -7411,7 +7430,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworkercontainer-4">3.4. ServiceWorkerContainer</a> <a href="#ref-for-serviceworkercontainer-5">(2)</a> <a href="#ref-for-serviceworkercontainer-6">(3)</a> <a href="#ref-for-serviceworkercontainer-7">(4)</a> <a href="#ref-for-serviceworkercontainer-8">(5)</a> <a href="#ref-for-serviceworkercontainer-9">(6)</a> <a href="#ref-for-serviceworkercontainer-10">(7)</a> <a href="#ref-for-serviceworkercontainer-11">(8)</a> <a href="#ref-for-serviceworkercontainer-12">(9)</a>
     <li><a href="#ref-for-serviceworkercontainer-13">3.4.7. Event handlers</a>
     <li><a href="#ref-for-serviceworkercontainer-14">3.5. Events</a>
-    <li><a href="#ref-for-serviceworkercontainer-15">4.2.4. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-serviceworkercontainer-15">4.2.5. postMessage(message, transfer)</a>
     <li><a href="#ref-for-serviceworkercontainer-16">Notify Controller Change</a>
    </ul>
   </aside>
@@ -7436,7 +7455,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworkercontainer-service-worker-client-4">3.4.4. getRegistration(clientURL)</a>
     <li><a href="#ref-for-serviceworkercontainer-service-worker-client-5">3.4.5. getRegistrations()</a>
     <li><a href="#ref-for-serviceworkercontainer-service-worker-client-6">3.5. Events</a>
-    <li><a href="#ref-for-serviceworkercontainer-service-worker-client-7">4.2.4. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-serviceworkercontainer-service-worker-client-7">4.2.5. postMessage(message, transfer)</a>
     <li><a href="#ref-for-serviceworkercontainer-service-worker-client-8">Notify Controller Change</a>
    </ul>
   </aside>
@@ -7452,7 +7471,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-client-message-queue-1">3.4. ServiceWorkerContainer</a> <a href="#ref-for-dfn-client-message-queue-2">(2)</a> <a href="#ref-for-dfn-client-message-queue-3">(3)</a>
     <li><a href="#ref-for-dfn-client-message-queue-4">3.4.6. startMessages()</a>
     <li><a href="#ref-for-dfn-client-message-queue-5">3.4.7. Event handlers</a>
-    <li><a href="#ref-for-dfn-client-message-queue-6">4.2.4. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-dfn-client-message-queue-6">4.2.5. postMessage(message, transfer)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkercontainer-controller">
@@ -7552,8 +7571,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-1">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-2">3.2.5. update()</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-3">4.1.2. registration</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-4">4.2.4. postMessage(message, transfer)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-5">4.2.9. navigate(url)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-6">(2)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-4">4.2.5. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-5">4.2.10. navigate(url)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-6">(2)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-7">4.3.1. get(id)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-8">4.3.2. matchAll(options)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-9">(2)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-10">4.3.3. openWindow(url)</a>
@@ -7637,41 +7656,42 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-client-service-worker-client-1">4.2.1. url</a>
     <li><a href="#ref-for-client-service-worker-client-2">4.2.2. id</a>
-    <li><a href="#ref-for-client-service-worker-client-3">4.2.4. postMessage(message, transfer)</a>
-    <li><a href="#ref-for-client-service-worker-client-4">4.2.7. ancestorOrigins</a>
-    <li><a href="#ref-for-client-service-worker-client-5">4.2.8. focus()</a> <a href="#ref-for-client-service-worker-client-6">(2)</a> <a href="#ref-for-client-service-worker-client-7">(3)</a>
-    <li><a href="#ref-for-client-service-worker-client-8">4.2.9. navigate(url)</a> <a href="#ref-for-client-service-worker-client-9">(2)</a> <a href="#ref-for-client-service-worker-client-10">(3)</a>
-    <li><a href="#ref-for-client-service-worker-client-11">4.3.2. matchAll(options)</a> <a href="#ref-for-client-service-worker-client-12">(2)</a> <a href="#ref-for-client-service-worker-client-13">(3)</a> <a href="#ref-for-client-service-worker-client-14">(4)</a>
-    <li><a href="#ref-for-client-service-worker-client-15">Create Client</a>
-    <li><a href="#ref-for-client-service-worker-client-16">Create Window Client</a>
+    <li><a href="#ref-for-client-service-worker-client-3">4.2.3. type</a> <a href="#ref-for-client-service-worker-client-4">(2)</a> <a href="#ref-for-client-service-worker-client-5">(3)</a>
+    <li><a href="#ref-for-client-service-worker-client-6">4.2.5. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-client-service-worker-client-7">4.2.8. ancestorOrigins</a>
+    <li><a href="#ref-for-client-service-worker-client-8">4.2.9. focus()</a> <a href="#ref-for-client-service-worker-client-9">(2)</a> <a href="#ref-for-client-service-worker-client-10">(3)</a>
+    <li><a href="#ref-for-client-service-worker-client-11">4.2.10. navigate(url)</a> <a href="#ref-for-client-service-worker-client-12">(2)</a> <a href="#ref-for-client-service-worker-client-13">(3)</a>
+    <li><a href="#ref-for-client-service-worker-client-14">4.3.2. matchAll(options)</a> <a href="#ref-for-client-service-worker-client-15">(2)</a> <a href="#ref-for-client-service-worker-client-16">(3)</a> <a href="#ref-for-client-service-worker-client-17">(4)</a>
+    <li><a href="#ref-for-client-service-worker-client-18">Create Client</a>
+    <li><a href="#ref-for-client-service-worker-client-19">Create Window Client</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-reserved-state">
    <b><a href="#client-reserved-state">#client-reserved-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-client-reserved-state-1">4.2.3. reserved</a>
+    <li><a href="#ref-for-client-reserved-state-1">4.2.4. reserved</a>
     <li><a href="#ref-for-client-reserved-state-2">Create Client</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-service-worker-client-visibilitystate">
    <b><a href="#dfn-service-worker-client-visibilitystate">#dfn-service-worker-client-visibilitystate</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-service-worker-client-visibilitystate-1">4.2.5. visibilityState</a>
+    <li><a href="#ref-for-dfn-service-worker-client-visibilitystate-1">4.2.6. visibilityState</a>
     <li><a href="#ref-for-dfn-service-worker-client-visibilitystate-2">Create Window Client</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-service-worker-client-focusstate">
    <b><a href="#dfn-service-worker-client-focusstate">#dfn-service-worker-client-focusstate</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-service-worker-client-focusstate-1">4.2.6. focused</a>
-    <li><a href="#ref-for-dfn-service-worker-client-focusstate-2">4.2.8. focus()</a>
+    <li><a href="#ref-for-dfn-service-worker-client-focusstate-1">4.2.7. focused</a>
+    <li><a href="#ref-for-dfn-service-worker-client-focusstate-2">4.2.9. focus()</a>
     <li><a href="#ref-for-dfn-service-worker-client-focusstate-3">Create Window Client</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="windowclient-ancestor-origins-array">
    <b><a href="#windowclient-ancestor-origins-array">#windowclient-ancestor-origins-array</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-windowclient-ancestor-origins-array-1">4.2.7. ancestorOrigins</a>
+    <li><a href="#ref-for-windowclient-ancestor-origins-array-1">4.2.8. ancestorOrigins</a>
     <li><a href="#ref-for-windowclient-ancestor-origins-array-2">Create Window Client</a>
    </ul>
   </aside>
@@ -7689,53 +7709,60 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dom-client-id-2">4.2.2. id</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="dom-client-type">
+   <b><a href="#dom-client-type">#dom-client-type</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-client-type-1">4.2. Client</a>
+    <li><a href="#ref-for-dom-client-type-2">4.2.3. type</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="dom-client-reserved">
    <b><a href="#dom-client-reserved">#dom-client-reserved</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-reserved-1">4.2. Client</a>
-    <li><a href="#ref-for-dom-client-reserved-2">4.2.3. reserved</a>
+    <li><a href="#ref-for-dom-client-reserved-2">4.2.4. reserved</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-client-postmessage">
    <b><a href="#dom-client-postmessage">#dom-client-postmessage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-postmessage-1">4.2. Client</a>
-    <li><a href="#ref-for-dom-client-postmessage-2">4.2.4. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-dom-client-postmessage-2">4.2.5. postMessage(message, transfer)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-windowclient-visibilitystate">
    <b><a href="#dom-windowclient-visibilitystate">#dom-windowclient-visibilitystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-visibilitystate-1">4.2. Client</a>
-    <li><a href="#ref-for-dom-windowclient-visibilitystate-2">4.2.5. visibilityState</a>
+    <li><a href="#ref-for-dom-windowclient-visibilitystate-2">4.2.6. visibilityState</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-windowclient-focused">
    <b><a href="#dom-windowclient-focused">#dom-windowclient-focused</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-focused-1">4.2. Client</a>
-    <li><a href="#ref-for-dom-windowclient-focused-2">4.2.6. focused</a>
+    <li><a href="#ref-for-dom-windowclient-focused-2">4.2.7. focused</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-windowclient-ancestororigins">
    <b><a href="#dom-windowclient-ancestororigins">#dom-windowclient-ancestororigins</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-ancestororigins-1">4.2. Client</a>
-    <li><a href="#ref-for-dom-windowclient-ancestororigins-2">4.2.7. ancestorOrigins</a>
+    <li><a href="#ref-for-dom-windowclient-ancestororigins-2">4.2.8. ancestorOrigins</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-windowclient-focus">
    <b><a href="#dom-windowclient-focus">#dom-windowclient-focus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-focus-1">4.2. Client</a>
-    <li><a href="#ref-for-dom-windowclient-focus-2">4.2.8. focus()</a>
+    <li><a href="#ref-for-dom-windowclient-focus-2">4.2.9. focus()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-windowclient-navigate">
    <b><a href="#dom-windowclient-navigate">#dom-windowclient-navigate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-navigate-1">4.2. Client</a>
-    <li><a href="#ref-for-dom-windowclient-navigate-2">4.2.9. navigate(url)</a>
+    <li><a href="#ref-for-dom-windowclient-navigate-2">4.2.10. navigate(url)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="clients">
@@ -7773,25 +7800,29 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="enumdef-clienttype">
    <b><a href="#enumdef-clienttype">#enumdef-clienttype</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-enumdef-clienttype-1">4.3. Clients</a>
+    <li><a href="#ref-for-enumdef-clienttype-1">4.2. Client</a>
+    <li><a href="#ref-for-enumdef-clienttype-2">4.3. Clients</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-clienttype-window">
    <b><a href="#dom-clienttype-window">#dom-clienttype-window</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-clienttype-window-1">4.3.2. matchAll(options)</a>
+    <li><a href="#ref-for-dom-clienttype-window-1">4.2.3. type</a>
+    <li><a href="#ref-for-dom-clienttype-window-2">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-clienttype-worker">
    <b><a href="#dom-clienttype-worker">#dom-clienttype-worker</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-clienttype-worker-1">4.3.2. matchAll(options)</a>
+    <li><a href="#ref-for-dom-clienttype-worker-1">4.2.3. type</a>
+    <li><a href="#ref-for-dom-clienttype-worker-2">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-clienttype-sharedworker">
    <b><a href="#dom-clienttype-sharedworker">#dom-clienttype-sharedworker</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-clienttype-sharedworker-1">4.3.2. matchAll(options)</a>
+    <li><a href="#ref-for-dom-clienttype-sharedworker-1">4.2.3. type</a>
+    <li><a href="#ref-for-dom-clienttype-sharedworker-2">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-clienttype-all">
@@ -8675,8 +8706,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="create-window-client">
    <b><a href="#create-window-client">#create-window-client</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-create-window-client-1">4.2.8. focus()</a>
-    <li><a href="#ref-for-create-window-client-2">4.2.9. navigate(url)</a>
+    <li><a href="#ref-for-create-window-client-1">4.2.9. focus()</a>
+    <li><a href="#ref-for-create-window-client-2">4.2.10. navigate(url)</a>
     <li><a href="#ref-for-create-window-client-3">4.3.1. get(id)</a>
     <li><a href="#ref-for-create-window-client-4">4.3.2. matchAll(options)</a>
     <li><a href="#ref-for-create-window-client-5">4.3.3. openWindow(url)</a>


### PR DESCRIPTION
This adds a type attribute to Client interface. Before this, we could
only differentiate the WindowClient objects from Client objects. With
the type attribute, a client can be identified as one of window,
dedicated worker, and shared worker.

Fixes #1005.