### PR TITLE
Change behavior of skipWaiting()

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -814,8 +814,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Let |promise| be a new <a>promise</a>.
         1. Run the following substeps <a>in parallel</a>:
             1. Set [=/service worker=]'s <a>skip waiting flag</a>.
-            1. If [=/service worker=]'s <a>state</a> is *installed*, then:
-                1. Run <a>Activate</a> algorithm passing [=/service worker=]'s [=service worker/registration=] as the argument.  
             1. Resolve |promise| with undefined.
         1. Return |promise|.
     </section>
@@ -2578,13 +2576,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and null as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>waiting worker</a> and *installed* as the arguments.
       1. If |redundantWorker| is not null, run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
-      1. If |registration|'s <a>waiting worker</a>'s <a>skip waiting flag</a> is set, then:
-          1. Run <a>Activate</a> algorithm passing |registration| as the argument.
-          1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Invoke <a>Finish Job</a> with |job|.
       1. Wait for all the <a>tasks</a> <a lt="queue a task">queued</a> by <a>Update Worker State</a> invoked in this algorithm have executed.
       1. Wait until no [=/service worker client=] is <a>using</a> |registration| or |registration|'s <a>waiting worker</a>'s <a>skip waiting flag</a> is set.
-      1. If |registration|'s <a>waiting worker</a> |waitingWorker| is not null and |waitingWorker|'s <a>skip waiting flag</a> is not set, invoke <a>Activate</a> algorithm with |registration| as its argument.
+      1. If |registration|'s <a>waiting worker</a> is not null, invoke <a>Activate</a> algorithm with |registration| as its argument.
   </section>
 
   <section algorithm>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-01">1 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-02">2 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2361,12 +2361,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Set <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-58">service worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-2">skip waiting flag</a>.</p>
          <li data-md="">
-          <p>If <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-59">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-6">state</a> is <em>installed</em>, then:</p>
-          <ol>
-           <li data-md="">
-            <p>Run <a data-link-type="dfn" href="#activate" id="ref-for-activate-4">Activate</a> algorithm passing <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-60">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-7">registration</a> as the argument.</p>
-          </ol>
-         <li data-md="">
           <p>Resolve <var>promise</var> with undefined.</p>
         </ol>
        <li data-md="">
@@ -2898,7 +2892,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <li data-md="">
             <p>Let <var>registration</var> be the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-7">Match Service Worker Registration</a> algorithm passing <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> as the argument.</p>
            <li data-md="">
-            <p>If <var>registration</var> is not the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-13">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-8">containing service worker registration</a>, continue to the next iteration of the loop.</p>
+            <p>If <var>registration</var> is not the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-13">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-7">containing service worker registration</a>, continue to the next iteration of the loop.</p>
            <li data-md="">
             <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-14">service worker</a>, then:</p>
             <ol>
@@ -2931,9 +2925,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 </pre>
      <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-2">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-extend-lifetime-promises">extend lifetime promises</dfn> (an array of <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a>). It is initially an empty array.</p>
      <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-3">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="extensions-allowed-flag">extensions allowed flag</dfn>. It is initially set.</p>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-61">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-62">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-59">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-60">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
      <p><a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> also use or extend the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-5">ExtendableEvent</a></code> interface.</p>
-     <p class="note" role="note">Note: To extend the lifetime of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-63">service worker</a>, algorithms that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> events using the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a></code> interface run <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-1">Extend Service Worker Lifetime</a> algorithm after <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> the event. See <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-2">Handle Fetch</a>, <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-1">Handle Foreign Fetch</a>, and <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-1">Handle Functional Event</a>.</p>
+     <p class="note" role="note">Note: To extend the lifetime of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-61">service worker</a>, algorithms that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> events using the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a></code> interface run <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-1">Extend Service Worker Lifetime</a> algorithm after <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> the event. See <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-2">Handle Fetch</a>, <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-1">Handle Foreign Fetch</a>, and <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-1">Handle Functional Event</a>.</p>
      <section class="algorithm" data-algorithm="wait-until-method">
       <h4 class="heading settled" data-level="4.4.1" id="wait-until-method"><span class="secno">4.4.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-2">event.waitUntil(f)</a></code></span><a class="self-link" href="#wait-until-method"></a></h4>
       <p><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-3">waitUntil()</a></code> method extends the lifetime of the event.</p>
@@ -2951,13 +2945,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>Add <var>f</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-1">extend lifetime promises</a>.</p>
       </ol>
      </section>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-64">Service workers</a> and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> define their own behaviors, allowing the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-2">extend lifetime promises</a> to suggest operation length, and the rejected state of any of the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> in <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-3">extend lifetime promises</a> to suggest operation failure.</p>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">Service workers</a> define the following behaviors for <code><a data-link-type="dfn" href="#install" id="ref-for-install-2">install</a></code> event and <code><a data-link-type="dfn" href="#activate" id="ref-for-activate-5">activate</a></code> event, respectively:</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-62">Service workers</a> and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> define their own behaviors, allowing the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-2">extend lifetime promises</a> to suggest operation length, and the rejected state of any of the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> in <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-3">extend lifetime promises</a> to suggest operation failure.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-63">Service workers</a> define the following behaviors for <code><a data-link-type="dfn" href="#install" id="ref-for-install-2">install</a></code> event and <code><a data-link-type="dfn" href="#activate" id="ref-for-activate-4">activate</a></code> event, respectively:</p>
      <ul>
       <li data-md="">
-       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> <var>f</var> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-4">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-5">installing worker</a> as <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-4">waiting worker</a>) until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-5">extend lifetime promises</a> resolve successfully. (See step 11.3.1 of <a data-link-type="dfn" href="#install" id="ref-for-install-3">Install</a> algorithm.) If <var>f</var> rejects, the installation fails. This is primarily used to ensure that a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-66">service worker</a> is not considered <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-5">waiting worker</a>) until all of the core caches it depends on are populated.</p>
+       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> <var>f</var> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-4">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-5">installing worker</a> as <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-4">waiting worker</a>) until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-5">extend lifetime promises</a> resolve successfully. (See step 11.3.1 of <a data-link-type="dfn" href="#install" id="ref-for-install-3">Install</a> algorithm.) If <var>f</var> rejects, the installation fails. This is primarily used to ensure that a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-64">service worker</a> is not considered <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-5">waiting worker</a>) until all of the core caches it depends on are populated.</p>
       <li data-md="">
-       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-6">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-17">active worker</a> as <em>activated</em> until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-7">extend lifetime promises</a> settle. (See step 12.3 of <a data-link-type="dfn" href="#activate" id="ref-for-activate-6">Activate</a> algorithm.) This is primarily used to ensure that any <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-2">functional events</a> are not dispatched to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-11">ServiceWorkerGlobalScope</a></code> object that represents the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-67">service worker</a> until it upgrades database schemas and deletes the outdated cache entries.</p>
+       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-6">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-17">active worker</a> as <em>activated</em> until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-7">extend lifetime promises</a> settle. (See step 12.3 of <a data-link-type="dfn" href="#activate" id="ref-for-activate-5">Activate</a> algorithm.) This is primarily used to ensure that any <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-2">functional events</a> are not dispatched to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-11">ServiceWorkerGlobalScope</a></code> object that represents the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service worker</a> until it upgrades database schemas and deletes the outdated cache entries.</p>
      </ul>
     </section>
     <section>
@@ -3004,7 +2998,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-foreignfetchoptions-scopes" id="ref-for-dom-foreignfetchoptions-scopes-1">scopes</a></code> is empty <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code> and abort these steps.</p>
        <li data-md="">
-        <p>Let <var>scopeString</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-16">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-11">scope url</a>, <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a>.</p>
+        <p>Let <var>scopeString</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-16">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-8">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-11">scope url</a>, <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a>.</p>
        <li data-md="">
         <p>Let <var>subScopeURLs</var> be an empty list of <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URLs</a>.</p>
        <li data-md="">
@@ -3022,9 +3016,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <p>Add <var>subScopeURL</var> to <var>subScopeURLs</var>.</p>
         </ol>
        <li data-md="">
-        <p>Set this <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-68">service worker</a>'s <a data-link-type="dfn" href="#dfn-foreign-fetch-scopes" id="ref-for-dfn-foreign-fetch-scopes-1">list of foreign fetch scopes</a> to <var>subScopeURLs</var>.</p>
+        <p>Set this <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-66">service worker</a>'s <a data-link-type="dfn" href="#dfn-foreign-fetch-scopes" id="ref-for-dfn-foreign-fetch-scopes-1">list of foreign fetch scopes</a> to <var>subScopeURLs</var>.</p>
        <li data-md="">
-        <p>Set this <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-69">service worker</a>'s <a data-link-type="dfn" href="#dfn-foreign-fetch-origins" id="ref-for-dfn-foreign-fetch-origins-1">list of foreign fetch origins</a> to <var>originURLs</var>.</p>
+        <p>Set this <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-67">service worker</a>'s <a data-link-type="dfn" href="#dfn-foreign-fetch-origins" id="ref-for-dfn-foreign-fetch-origins-1">list of foreign fetch origins</a> to <var>originURLs</var>.</p>
       </ol>
      </section>
     </section>
@@ -3049,7 +3043,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="FetchEventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-fetcheventinit-isreload">isReload<a class="self-link" href="#dom-fetcheventinit-isreload"></a></dfn> = <span class="kt">false</span>;
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-70">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-71">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-9">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-68">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-69">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-9">ExtendableEvent</a></code> interface.</p>
      <p>Each event using <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-3">FetchEvent</a></code> interface has an associated <dfn class="dfn-paneled" data-dfn-for="FetchEvent" data-dfn-type="dfn" data-noexport="" id="fetchevent-potential-response">potential response</dfn> (a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>), initially set to null, and the following associated flags that are initially unset:</p>
      <ul>
       <li data-md="">
@@ -3232,7 +3226,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">sequence</span>&lt;<span class="kt">ByteString</span>> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ForeignFetchResponse" data-dfn-type="dict-member" data-export="" data-type="sequence<ByteString> " id="dom-foreignfetchresponse-headers">headers</dfn>;
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-72">Service workers</a> have a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-4">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-2">foreignfetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-3">foreignfetch</a></code> events, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-73">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#foreignfetchevent" id="ref-for-foreignfetchevent-2">ForeignFetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-70">Service workers</a> have a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-4">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-2">foreignfetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-3">foreignfetch</a></code> events, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-71">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#foreignfetchevent" id="ref-for-foreignfetchevent-2">ForeignFetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a></code> interface.</p>
      <p>Each event using <code class="idl"><a data-link-type="idl" href="#foreignfetchevent" id="ref-for-foreignfetchevent-3">ForeignFetchEvent</a></code> interface has an associated <dfn class="dfn-paneled" data-dfn-for="ForeignFetchEvent" data-dfn-type="dfn" data-noexport="" id="foreignfetchevent-potential-response">potential response</dfn> (a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>), initially set to null, an associated <dfn class="dfn-paneled" data-dfn-for="ForeignFetchEvent" data-dfn-type="dfn" data-noexport="" id="foreignfetchevent-origin">origin</dfn> (a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-USVString">USVString</a></code> or null), initially set to null, an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="list-of-exposed-headers">list of exposed headers</dfn> (whose element type is a byte string), initially set to an empty list, and the following associated flags that are initially unset:</p>
      <ul>
       <li data-md="">
@@ -3404,7 +3398,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/comms.html#messageport">MessagePort</a>> <dfn class="nv idl-code" data-default="None" data-dfn-for="ExtendableMessageEventInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MessagePort> " id="dom-extendablemessageeventinit-ports">ports<a class="self-link" href="#dom-extendablemessageeventinit-ports"></a></dfn> = [];
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-74">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-75">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-13">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-72">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-73">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-13">ExtendableEvent</a></code> interface.</p>
      <section>
       <h4 class="heading settled" data-level="4.8.1" id="extendablemessage-event-data"><span class="secno">4.8.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendablemessageevent-data" id="ref-for-dom-extendablemessageevent-data-3">event.data</a></code></span><a class="self-link" href="#extendablemessage-event-data"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ExtendableMessageEvent" data-dfn-type="attribute" data-export="" id="dom-extendablemessageevent-data">data</dfn> attribute <em>must</em> return the value it was initialized to. When the object is created, this attribute <em>must</em> be initialized to null. It represents the message being sent.</p>
@@ -3439,11 +3433,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-install-event"><code>install</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#installevent" id="ref-for-installevent-2">InstallEvent</a></code>
-        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-2">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-17">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-10">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-6">installing worker</a> changes. (See step 11.2 of the <a data-link-type="dfn" href="#install" id="ref-for-install-4">Install</a> algorithm.)
+        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-2">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-17">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-6">installing worker</a> changes. (See step 11.2 of the <a data-link-type="dfn" href="#install" id="ref-for-install-4">Install</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-activate-event"><code>activate</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-14">ExtendableEvent</a></code>
-        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-3">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-18">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-11">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-18">active worker</a> changes. (See step 12.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-7">Activate</a> algorithm.)
+        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-3">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-18">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-10">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-18">active worker</a> changes. (See step 12.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-6">Activate</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-fetch-event"><code>fetch</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-4">FetchEvent</a></code>
@@ -3559,7 +3553,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="6.2" id="cache-lifetimes"><span class="secno">6.2. </span><span class="content">Understanding Cache Lifetimes</span><a class="self-link" href="#cache-lifetimes"></a></h3>
-     <p>The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-7">Cache</a></code> instances are not part of the browser’s HTTP cache. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-8">Cache</a></code> objects are exactly what authors have to manage themselves. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-9">Cache</a></code> objects do not get updated unless authors explicitly request them to be. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-10">Cache</a></code> objects do not expire unless authors delete the entries. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-11">Cache</a></code> objects do not disappear just because the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-76">service worker</a> script is updated. That is, caches are not updated automatically. Updates must be manually managed. This implies that authors should version their caches by name and make sure to use the caches only from the version of the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-77">service worker</a> that can safely operate on.</p>
+     <p>The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-7">Cache</a></code> instances are not part of the browser’s HTTP cache. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-8">Cache</a></code> objects are exactly what authors have to manage themselves. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-9">Cache</a></code> objects do not get updated unless authors explicitly request them to be. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-10">Cache</a></code> objects do not expire unless authors delete the entries. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-11">Cache</a></code> objects do not disappear just because the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-74">service worker</a> script is updated. That is, caches are not updated automatically. Updates must be manually managed. This implies that authors should version their caches by name and make sure to use the caches only from the version of the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-75">service worker</a> that can safely operate on.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="6.3" id="self-caches"><span class="secno">6.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#global-caches-attribute" id="ref-for-global-caches-attribute-1">self.caches</a></code></span><a class="self-link" href="#self-caches"></a></h3>
@@ -4251,11 +4245,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <h2 class="heading settled" data-level="7" id="security-considerations"><span class="secno">7. </span><span class="content">Security Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
     <section>
      <h3 class="heading settled" data-level="7.1" id="secure-context"><span class="secno">7.1. </span><span class="content">Secure Context</span><a class="self-link" href="#secure-context"></a></h3>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-78">Service workers</a> <em>must</em> execute in <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure contexts</a>. <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-33">Service worker clients</a> <em>must</em> also be <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure contexts</a> to register a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-44">service worker registration</a>, to get access to the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-45">service worker registrations</a> and the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-79">service workers</a>, to do messaging with the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-80">service workers</a>, and to be manipulated by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-81">service workers</a>. This effectively means that <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-82">service workers</a> and their <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-34">service worker clients</a> <em>should</em> be hosted over HTTPS. A user agent <em>may</em> allow <code>localhost</code>, <code>127.0.0.0/8</code>, and <code>::1/128</code> for development purpose. (Note that they may still be <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure contexts</a>.) The primary reason for this restriction is to protect users from the <a href="https://w3c.github.io/webappsec-secure-contexts/#threat-risks">risks associated with insecure contexts</a>.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-76">Service workers</a> <em>must</em> execute in <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure contexts</a>. <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-33">Service worker clients</a> <em>must</em> also be <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure contexts</a> to register a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-44">service worker registration</a>, to get access to the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-45">service worker registrations</a> and the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-77">service workers</a>, to do messaging with the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-78">service workers</a>, and to be manipulated by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-79">service workers</a>. This effectively means that <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-80">service workers</a> and their <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-34">service worker clients</a> <em>should</em> be hosted over HTTPS. A user agent <em>may</em> allow <code>localhost</code>, <code>127.0.0.0/8</code>, and <code>::1/128</code> for development purpose. (Note that they may still be <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure contexts</a>.) The primary reason for this restriction is to protect users from the <a href="https://w3c.github.io/webappsec-secure-contexts/#threat-risks">risks associated with insecure contexts</a>.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="7.2" id="content-security-policy"><span class="secno">7.2. </span><span class="content">Content Security Policy</span><a class="self-link" href="#content-security-policy"></a></h3>
-     <p>Whenever a user agent invokes <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-2">Run Service Worker</a> algorithm with a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-83">service worker</a> <var>serviceWorker</var>:</p>
+     <p>Whenever a user agent invokes <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-2">Run Service Worker</a> algorithm with a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-81">service worker</a> <var>serviceWorker</var>:</p>
      <ul>
       <li data-md="">
        <p>If <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-4">script resource</a> was delivered with a <code>Content-Security-Policy</code> HTTP header containing the value <var>policy</var>, the user agent <em>must</em> <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#enforced">enforce</a> <var>policy</var> for <var>serviceWorker</var>.</p>
@@ -4269,7 +4263,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <section>
       <h4 class="heading settled" data-level="7.3.1" id="origin-restriction"><span class="secno">7.3.1. </span><span class="content">Origin restriction</span><a class="self-link" href="#origin-restriction"></a></h4>
       <p><em>This section is non-normative.</em></p>
-      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-84">service worker</a> executes in the registering <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-35">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>. One of the advanced concerns that major applications would encounter is whether they can be hosted from a CDN. By definition, these are servers in other places, often on other <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origins</a>. Therefore, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-85">service workers</a> cannot be hosted on CDNs. But they can include resources via <a data-link-type="functionish" href="#importscripts-method" id="ref-for-importscripts-method-1">importScripts()</a>. The reason for this restriction is that <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-86">service workers</a> create the opportunity for a bad actor to turn a bad day into a bad eternity.</p>
+      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-82">service worker</a> executes in the registering <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-35">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>. One of the advanced concerns that major applications would encounter is whether they can be hosted from a CDN. By definition, these are servers in other places, often on other <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origins</a>. Therefore, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-83">service workers</a> cannot be hosted on CDNs. But they can include resources via <a data-link-type="functionish" href="#importscripts-method" id="ref-for-importscripts-method-1">importScripts()</a>. The reason for this restriction is that <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-84">service workers</a> create the opportunity for a bad actor to turn a bad day into a bad eternity.</p>
      </section>
      <section>
       <h4 class="heading settled" data-level="7.3.2" id="importscripts"><span class="secno">7.3.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-importscripts">importScripts(urls)</a></code></span><a class="self-link" href="#importscripts"></a></h4>
@@ -4305,7 +4299,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="7.4" id="cross-origin-resources"><span class="secno">7.4. </span><span class="content">Cross-Origin Resources and CORS</span><a class="self-link" href="#cross-origin-resources"></a></h3>
      <p><em>This section is non-normative.</em></p>
-     <p>Applications tend to cache items that come from a CDN or other <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>. It is possible to request many of them directly using <code>&lt;script></code>, <code>&lt;img></code>, <code>&lt;video></code> and <code>&lt;link></code> elements. It would be hugely limiting if this sort of runtime collaboration broke when offline. Similarly, it is possible to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> many sorts of off-<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> resources when appropriate CORS headers are set. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-87">Service workers</a> enable this by allowing <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-21">Caches</a></code> to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> and cache off-origin items. Some restrictions apply, however. First, unlike same-origin resources which are managed in the <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-22">Cache</a></code> as <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> objects whose corresponding <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">responses</a> are <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">basic filtered response</a>, the objects stored are <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> objects whose corresponding <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">responses</a> are either <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-cors">CORS filtered responses</a> or <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">opaque filtered responses</a>. They can be passed to <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-4">event.respondWith(r)</a></code> method in the same manner as the <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> objects whose corresponding <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">responses</a> are <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">basic filtered responses</a>, but cannot be meaningfully created programmatically. These limitations are necessary to preserve the security invariants of the platform. Allowing <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-23">Caches</a></code> to store them allows applications to avoid re-architecting in most cases.</p>
+     <p>Applications tend to cache items that come from a CDN or other <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>. It is possible to request many of them directly using <code>&lt;script></code>, <code>&lt;img></code>, <code>&lt;video></code> and <code>&lt;link></code> elements. It would be hugely limiting if this sort of runtime collaboration broke when offline. Similarly, it is possible to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> many sorts of off-<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> resources when appropriate CORS headers are set. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-85">Service workers</a> enable this by allowing <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-21">Caches</a></code> to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> and cache off-origin items. Some restrictions apply, however. First, unlike same-origin resources which are managed in the <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-22">Cache</a></code> as <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> objects whose corresponding <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">responses</a> are <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">basic filtered response</a>, the objects stored are <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> objects whose corresponding <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">responses</a> are either <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-cors">CORS filtered responses</a> or <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">opaque filtered responses</a>. They can be passed to <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-4">event.respondWith(r)</a></code> method in the same manner as the <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> objects whose corresponding <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">responses</a> are <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">basic filtered responses</a>, but cannot be meaningfully created programmatically. These limitations are necessary to preserve the security invariants of the platform. Allowing <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-23">Caches</a></code> to store them allows applications to avoid re-architecting in most cases.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="7.5" id="implementer-concerns"><span class="secno">7.5. </span><span class="content">Implementer Concerns</span><a class="self-link" href="#implementer-concerns"></a></h3>
@@ -4313,19 +4307,19 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <p>The implementers are encouraged to note:</p>
      <ul>
       <li data-md="">
-       <p>Plug-ins should not load via <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-88">service workers</a>. As plug-ins may get their security origins from their own urls, the embedding <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-89">service worker</a> cannot handle it. For this reason, the <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-7">Handle Fetch</a> algorithm makes the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">potential-navigation-or-subresource request</a> (whose context is either <code>&lt;embed></code> or <code>&lt;object></code>) immediately fallback to the network without dispatching <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-6">fetch</a></code> event.</p>
+       <p>Plug-ins should not load via <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-86">service workers</a>. As plug-ins may get their security origins from their own urls, the embedding <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-87">service worker</a> cannot handle it. For this reason, the <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-7">Handle Fetch</a> algorithm makes the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">potential-navigation-or-subresource request</a> (whose context is either <code>&lt;embed></code> or <code>&lt;object></code>) immediately fallback to the network without dispatching <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-6">fetch</a></code> event.</p>
       <li data-md="">
-       <p>Some of the legacy networking stack code may need to be carefully audited to understand the ramifications of interactions with <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-90">service workers</a>.</p>
+       <p>Some of the legacy networking stack code may need to be carefully audited to understand the ramifications of interactions with <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-88">service workers</a>.</p>
      </ul>
     </section>
     <section>
      <h3 class="heading settled" data-level="7.6" id="privacy"><span class="secno">7.6. </span><span class="content">Privacy</span><a class="self-link" href="#privacy"></a></h3>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-91">Service workers</a> introduce new persistent storage features including <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-6">scope to registration map</a> (for <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-46">service worker registrations</a> and their <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-92">service workers</a>), <a data-link-type="dfn" href="#dfn-request-to-response-map" id="ref-for-dfn-request-to-response-map-16">request to response map</a> and <a data-link-type="dfn" href="#dfn-name-to-cache-map" id="ref-for-dfn-name-to-cache-map-11">name to cache map</a> (for caches), and <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map-4">script resource map</a> (for script resources). In order to protect users from any potential <a data-link-type="biblio" href="#biblio-unsanctioned-tracking">unsanctioned tracking</a> threat, these persistent storages <em>should</em> be cleared when users intend to clear them and <em>should</em> maintain and interoperate with existing user controls e.g. purging all existing persistent storages.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-89">Service workers</a> introduce new persistent storage features including <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-6">scope to registration map</a> (for <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-46">service worker registrations</a> and their <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-90">service workers</a>), <a data-link-type="dfn" href="#dfn-request-to-response-map" id="ref-for-dfn-request-to-response-map-16">request to response map</a> and <a data-link-type="dfn" href="#dfn-name-to-cache-map" id="ref-for-dfn-name-to-cache-map-11">name to cache map</a> (for caches), and <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map-4">script resource map</a> (for script resources). In order to protect users from any potential <a data-link-type="biblio" href="#biblio-unsanctioned-tracking">unsanctioned tracking</a> threat, these persistent storages <em>should</em> be cleared when users intend to clear them and <em>should</em> maintain and interoperate with existing user controls e.g. purging all existing persistent storages.</p>
     </section>
    </section>
    <section>
     <h2 class="heading settled" data-level="8" id="extensibility"><span class="secno">8. </span><span class="content">Extensibility</span><a class="self-link" href="#extensibility"></a></h2>
-    <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-93">Service workers</a> are extensible from other specifications.</p>
+    <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-91">Service workers</a> are extensible from other specifications.</p>
     <section>
      <h3 class="heading settled" data-level="8.1" id="extension-to-service-worker-registration"><span class="secno">8.1. </span><span class="content">Define API bound to Service Worker Registration</span><a class="self-link" href="#extension-to-service-worker-registration"></a></h3>
      <p>Specifications <em>may</em> define an API tied to a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-47">service worker registration</a> by using <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-partial-interface">partial interface</a> definition to the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-16">ServiceWorkerRegistration</a></code> interface where it <em>may</em> define the specification specific attributes and methods:</p>
@@ -4356,7 +4350,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="8.4" id="request-functional-event-dispatch"><span class="secno">8.4. </span><span class="content">Request Functional Event Dispatch</span><a class="self-link" href="#request-functional-event-dispatch"></a></h3>
-     <p>To request a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-9">functional event</a> dispatch to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-94">service worker</a>, specifications <em>may</em> invoke <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-2">Handle Functional Event</a> algorithm with its <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-48">service worker registration</a> <var>registration</var> and the algorithm <var>callbackSteps</var> as the arguments.</p>
+     <p>To request a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-9">functional event</a> dispatch to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-92">service worker</a>, specifications <em>may</em> invoke <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-2">Handle Functional Event</a> algorithm with its <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-48">service worker registration</a> <var>registration</var> and the algorithm <var>callbackSteps</var> as the arguments.</p>
      <p>Specifications <em>may</em> define an algorithm <var>callbackSteps</var> where the corresponding <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional event</a> can be created and fired with specification specific objects. The algorithm is passed <var>globalObject</var> (a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-16">ServiceWorkerGlobalScope</a></code> object) at which it <em>may</em> fire its <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>. This algorithm is called on a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-3">Handle Functional Event</a> algorithm.</p>
      <p class="note" role="note">Note: See an <a href="https://notifications.spec.whatwg.org/#activating-a-notification">example</a> hook defined in <a data-link-type="biblio" href="#biblio-notifications">Notifications API</a>.</p>
     </section>
@@ -4814,7 +4808,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Else:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>worker</var> be a new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-95">service worker</a>.</p>
+         <p>Let <var>worker</var> be a new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-93">service worker</a>.</p>
         <li data-md="">
          <p>Generate a unique opaque string and set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-id" id="ref-for-dfn-service-worker-id-1">id</a> to the value.</p>
         <li data-md="">
@@ -4879,7 +4873,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-25">job</a></p>
       <dd data-md="">
-       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-96">service worker</a></p>
+       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-94">service worker</a></p>
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-53">service worker registration</a></p>
       <dt data-md="">
@@ -4903,7 +4897,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-3">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-19">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-39">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-17">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-97">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-12">containing service worker registration</a> is <var>registration</var>.</p>
+       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-39">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-17">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-95">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-11">containing service worker registration</a> is <var>registration</var>.</p>
       <li data-md="">
        <p>Let <var>installingWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-8">installing worker</a>.</p>
       <li data-md="">
@@ -4968,21 +4962,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>redundantWorker</var> is not null, run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-4">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-9">waiting worker</a>’s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set, then:</p>
-       <ol>
-        <li data-md="">
-         <p>Run <a data-link-type="dfn" href="#activate" id="ref-for-activate-8">Activate</a> algorithm passing <var>registration</var> as the argument.</p>
-        <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-11">Finish Job</a> with <var>job</var> and abort these steps.</p>
-       </ol>
-      <li data-md="">
-       <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-12">Finish Job</a> with <var>job</var>.</p>
+       <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-11">Finish Job</a> with <var>job</var>.</p>
       <li data-md="">
        <p>Wait for all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-5">Update Worker State</a> invoked in this algorithm have executed.</p>
       <li data-md="">
-       <p>Wait until no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-40">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-4">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-10">waiting worker</a>’s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-4">skip waiting flag</a> is set.</p>
+       <p>Wait until no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-40">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-4">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-9">waiting worker</a>’s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-11">waiting worker</a> <var>waitingWorker</var> is not null and <var>waitingWorker</var>’s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-5">skip waiting flag</a> is not set, invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-9">Activate</a> algorithm with <var>registration</var> as its argument.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-10">waiting worker</a> is not null, invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-7">Activate</a> algorithm with <var>registration</var> as its argument.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Activate">
@@ -4999,7 +4985,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a> is null, abort these steps.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-11">waiting worker</a> is null, abort these steps.</p>
       <li data-md="">
        <p>Let <var>redundantWorker</var> be null.</p>
       <li data-md="">
@@ -5013,7 +4999,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-5">Terminate</a> <var>redundantWorker</var>.</p>
        </ol>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-5">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-5">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a> as the arguments.</p>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-6">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and null as the arguments.</p>
       <li data-md="">
@@ -5070,7 +5056,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>serviceWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a></p>
+       <p><var>serviceWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-96">service worker</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5148,7 +5134,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Create a new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">WorkerLocation</a></code> object and associate it with <var>workerGlobalScope</var>.</p>
       <li data-md="">
-       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-13">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
+       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-12">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
       <li data-md="">
        <p>If <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>, then <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">run the classic script</a> <var>script</var>. Otherwise, it is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">module script</a>; <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">run the module script</a> <var>script</var>.</p>
        <p class="note" role="note">Note: In addition to the usual possibilities of returning a value or failing due to an exception, this could be prematurely aborted by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">kill a worker</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">terminate a worker</a> algorithms.</p>
@@ -5173,7 +5159,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>serviceWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-99">service worker</a></p>
+       <p><var>serviceWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-97">service worker</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5187,7 +5173,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>serviceWorkerGlobalScope</var>’s closing flag to true.</p>
       <li data-md="">
-       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
+       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-13">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
        <p class="note" role="note">Note: This effectively means that the fetch events and the other functional events such as push events are backed up by the registration’s task queues while the other tasks including message events are discarded.</p>
       <li data-md="">
        <p>Abort the script currently running in <var>serviceWorker</var>.</p>
@@ -5223,11 +5209,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Unset <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-5">extensions allowed flag</a>.</p>
        </ol>
      </ol>
-     <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> until <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-6">extensions allowed flag</a> is unset. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
+     <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> until <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-6">extensions allowed flag</a> is unset. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
     </section>
     <section class="algorithm" data-algorithm="Handle Fetch">
      <h3 class="heading settled" id="on-fetch-request-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="handle-fetch">Handle Fetch</dfn></span><a class="self-link" href="#on-fetch-request-algorithm"></a></h3>
-     <p>The <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-8">Handle Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a> context.</p>
+     <p>The <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-8">Handle Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-99">service worker</a> context.</p>
      <dl>
       <dt data-md="">
        <p>Input</p>
@@ -5292,12 +5278,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-28">active worker</a>.</p>
        </ol>
-       <p class="note" role="note">Note: From this point, the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-44">service worker client</a> starts to <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-6">use</a> its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-15">containing service worker registration</a>.</p>
+       <p class="note" role="note">Note: From this point, the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-44">service worker client</a> starts to <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-6">use</a> its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a>.</p>
       <li data-md="">
        <p>Else if <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is non-null, set <var>registration</var> to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-16">containing service worker registration</a>.</p>
+         <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is non-null, set <var>registration</var> to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-15">containing service worker registration</a>.</p>
         <li data-md="">
          <p>Else, return null.</p>
        </ol>
@@ -5315,7 +5301,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        </ol>
        <p class="note" role="note">Note: To avoid unnecessary delays, the Handle Fetch enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
       <li data-md="">
-       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-7">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-8">state</a> to become <em>activated</em>.</p>
+       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-6">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-7">state</a> to become <em>activated</em>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-6">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
@@ -5392,7 +5378,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section class="algorithm" data-algorithm="Handle Foreign Fetch">
      <h3 class="heading settled" id="on-foreign-fetch-request-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="handle-foreign-fetch">Handle Foreign Fetch</dfn></span><a class="self-link" href="#on-foreign-fetch-request-algorithm"></a></h3>
-     <p>The <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-6">Handle Foreign Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-102">service worker</a> context to handle foreign fetch requests.</p>
+     <p>The <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-6">Handle Foreign Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> context to handle foreign fetch requests.</p>
      <dl>
       <dt data-md="">
        <p>Input</p>
@@ -5421,10 +5407,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>If <var>activeWorker</var> is null, return null.</p>
        <li data-md="">
-        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-9">state</a> is <em>activating</em>, then:</p>
+        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-8">state</a> is <em>activating</em>, then:</p>
         <ol>
          <li data-md="">
-          <p>Wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-10">state</a> to become <em>activated</em>.</p>
+          <p>Wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-9">state</a> to become <em>activated</em>.</p>
         </ol>
        <li data-md="">
         <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> is the same as <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a>, return null.</p>
@@ -5572,7 +5558,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        </ol>
        <p class="note" role="note">Note: To avoid unnecessary delays, the Handle Functional Event enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
       <li data-md="">
-       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-11">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-12">state</a> to become <em>activated</em>.</p>
+       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-10">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-11">state</a> to become <em>activated</em>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-8">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
@@ -5615,7 +5601,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-4">uninstalling flag</a> is set, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-4">Clear Registration</a> algorithm passing <var>registration</var> as its argument and abort these steps.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-14">waiting worker</a> is not null, run <a data-link-type="dfn" href="#activate" id="ref-for-activate-10">Activate</a> algorithm with <var>registration</var> as the argument.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a> is not null, run <a data-link-type="dfn" href="#activate" id="ref-for-activate-8">Activate</a> algorithm with <var>registration</var> as the argument.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle User Agent Shutdown">
@@ -5643,10 +5629,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <p>Else, set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-13">installing worker</a> to null.</p>
          </ol>
         <li data-md="">
-         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-15">waiting worker</a> is not null, run the following substep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-14">waiting worker</a> is not null, run the following substep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-11">Activate</a> with <var>registration</var>.</p>
+           <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-9">Activate</a> with <var>registration</var>.</p>
          </ol>
        </ol>
      </ol>
@@ -5670,7 +5656,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-11">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-13">Finish Job</a> with <var>job</var> and abort these steps.</p>
+         <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-12">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
        <p>Let <var>registration</var> be the result of running <a data-link-type="dfn" href="#get-registration" id="ref-for-get-registration-3">Get Registration</a> algorithm passing <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-10">scope url</a> as the argument.</p>
@@ -5680,7 +5666,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-4">Resolve Job Promise</a> with <var>job</var> and false.</p>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-14">Finish Job</a> with <var>job</var> and abort these steps.</p>
+         <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-13">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
        <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-5">uninstalling flag</a>.</p>
@@ -5690,7 +5676,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-48">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-9">using</a> <var>registration</var>, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-6">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
        <p class="note" role="note">Note: When the registration is being used for a client, the deletion of the registration is handled by the Handle Service Worker Client Unload algorithm.</p>
       <li data-md="">
-       <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-15">Finish Job</a> with <var>job</var>.</p>
+       <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-14">Finish Job</a> with <var>job</var>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Set Registration">
@@ -5750,10 +5736,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-9">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-16">waiting worker</a> is not null, then:</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-15">waiting worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-17">waiting worker</a>.</p>
+         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-16">waiting worker</a>.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-12">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
@@ -5793,7 +5779,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dd data-md="">
        <p><var>target</var>, a string (one of "<code>installing</code>", "<code>waiting</code>", and "<code>active</code>")</p>
       <dd data-md="">
-       <p><var>source</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a> or null</p>
+       <p><var>source</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a> or null</p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5818,12 +5804,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Else if <var>target</var> is "<code>waiting</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-18">waiting worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-17">waiting worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-waiting" id="ref-for-dom-serviceworkerregistration-waiting-3">waiting</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-26">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-19">waiting worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-waiting" id="ref-for-dom-serviceworkerregistration-waiting-3">waiting</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-26">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-18">waiting worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-19">waiting worker</a> is null.</p>
          </ol>
        </ol>
       <li data-md="">
@@ -5847,9 +5833,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a></p>
+       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-102">service worker</a></p>
       <dd data-md="">
-       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-13">state</a></p>
+       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-12">state</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5857,7 +5843,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-14">state</a> to <var>state</var>.</p>
+       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-13">state</a> to <var>state</var>.</p>
       <li data-md="">
        <p>Let <var>workerObjects</var> be an array containing all the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-28">ServiceWorker</a></code> objects associated with <var>worker</var>.</p>
       <li data-md="">
@@ -5867,33 +5853,33 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to run these substeps:</p>
          <ol>
           <li data-md="">
-           <p>Set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworker-state" id="ref-for-dom-serviceworker-state-5">state</a></code> attribute of <var>workerObject</var> to the value (in <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate-4">ServiceWorkerState</a></code> enumeration) corresponding to the first matching statement, switching on <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-15">state</a>:</p>
+           <p>Set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworker-state" id="ref-for-dom-serviceworker-state-5">state</a></code> attribute of <var>workerObject</var> to the value (in <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate-4">ServiceWorkerState</a></code> enumeration) corresponding to the first matching statement, switching on <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-14">state</a>:</p>
            <dl>
             <dt data-md="">
              <p><em>installing</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installing" id="ref-for-dom-serviceworkerstate-installing-1">"installing"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a> is not active until all of the core caches are populated.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a> is not active until all of the core caches are populated.</p>
             <dt data-md="">
              <p><em>installed</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installed" id="ref-for-dom-serviceworkerstate-installed-1">"installed"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-21">waiting worker</a>.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a>.</p>
             <dt data-md="">
              <p><em>activating</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activating" id="ref-for-dom-serviceworkerstate-activating-1">"activating"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-109">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-12">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-12">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
             <dt data-md="">
              <p><em>activated</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activated" id="ref-for-dom-serviceworkerstate-activated-1">"activated"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-110">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-13">functional events</a>.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-13">functional events</a>.</p>
             <dt data-md="">
              <p><em>redundant</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-redundant" id="ref-for-dom-serviceworkerstate-redundant-2">"redundant"</a></code></p>
-             <p class="note" role="note">Note: A new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-111">service worker</a> is replacing the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-112">service worker</a>, or the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-113">service worker</a> is being discarded due to an install failure.</p>
+             <p class="note" role="note">Note: A new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-109">service worker</a> is replacing the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-110">service worker</a>, or the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-111">service worker</a> is being discarded due to an install failure.</p>
            </dl>
           <li data-md="">
            <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <code>statechange</code> at <var>workerObject</var>.</p>
@@ -5968,7 +5954,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-114">service worker</a></p>
+       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-112">service worker</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -6036,7 +6022,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>newestWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-115">service worker</a></p>
+       <p><var>newestWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-113">service worker</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -6046,7 +6032,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-21">installing worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-22">installing worker</a>.</p>
       <li data-md="">
-       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-22">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-23">waiting worker</a>.</p>
+       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-21">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-22">waiting worker</a>.</p>
       <li data-md="">
        <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-42">active worker</a>.</p>
       <li data-md="">
@@ -6331,18 +6317,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <h2 class="heading settled" id="extended-http-headers"><span class="content">Appendix B: Extended HTTP headers</span><a class="self-link" href="#extended-http-headers"></a></h2>
     <section>
      <h3 class="heading settled" id="service-worker-script-request"><span class="content">Service Worker Script Request</span><a class="self-link" href="#service-worker-script-request"></a></h3>
-     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-116">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-13">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-114">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-13">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker"><code>Service-Worker</code><a class="self-link" href="#service-worker"></a></dfn>`</p>
       <dd data-md="">
-       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-117">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> request.</p>
+       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-115">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> request.</p>
        <p class="note" role="note">Note: This header helps administrators log the requests and detect threats.</p>
      </dl>
     </section>
     <section>
      <h3 class="heading settled" id="service-worker-script-response"><span class="content">Service Worker Script Response</span><a class="self-link" href="#service-worker-script-response"></a></h3>
-     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-118">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-116">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker-allowed"><code>Service-Worker-Allowed</code><a class="self-link" href="#service-worker-allowed"></a></dfn>`</p>
@@ -6389,7 +6375,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" id="syntax"><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
-     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-119">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> requests and responses:</p>
+     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-117">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> requests and responses:</p>
 <pre>Service-Worker = %x73.63.72.69.70.74 ; "script", case-sensitive
 </pre>
      <p class="note" role="note">Note: The validation of the Service-Worker-Allowed header’s values is done by URL parsing algorithm (in Update algorithm) instead of using ABNF.</p>
@@ -7508,35 +7494,35 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-50">3.4.1. controller</a>
     <li><a href="#ref-for-dfn-service-worker-51">3.5. Events</a> <a href="#ref-for-dfn-service-worker-52">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-53">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-dfn-service-worker-54">(2)</a> <a href="#ref-for-dfn-service-worker-55">(3)</a> <a href="#ref-for-dfn-service-worker-56">(4)</a>
-    <li><a href="#ref-for-dfn-service-worker-57">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-service-worker-58">(2)</a> <a href="#ref-for-dfn-service-worker-59">(3)</a> <a href="#ref-for-dfn-service-worker-60">(4)</a>
-    <li><a href="#ref-for-dfn-service-worker-61">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-service-worker-62">(2)</a> <a href="#ref-for-dfn-service-worker-63">(3)</a> <a href="#ref-for-dfn-service-worker-64">(4)</a> <a href="#ref-for-dfn-service-worker-65">(5)</a> <a href="#ref-for-dfn-service-worker-66">(6)</a> <a href="#ref-for-dfn-service-worker-67">(7)</a>
-    <li><a href="#ref-for-dfn-service-worker-68">4.5.1. event.registerForeignFetch(options)</a> <a href="#ref-for-dfn-service-worker-69">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-70">4.6. FetchEvent</a> <a href="#ref-for-dfn-service-worker-71">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-72">4.7. ForeignFetchEvent</a> <a href="#ref-for-dfn-service-worker-73">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-74">4.8. ExtendableMessageEvent</a> <a href="#ref-for-dfn-service-worker-75">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-76">6.2. Understanding Cache Lifetimes</a> <a href="#ref-for-dfn-service-worker-77">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-78">7.1. Secure Context</a> <a href="#ref-for-dfn-service-worker-79">(2)</a> <a href="#ref-for-dfn-service-worker-80">(3)</a> <a href="#ref-for-dfn-service-worker-81">(4)</a> <a href="#ref-for-dfn-service-worker-82">(5)</a>
-    <li><a href="#ref-for-dfn-service-worker-83">7.2. Content Security Policy</a>
-    <li><a href="#ref-for-dfn-service-worker-84">7.3.1. Origin restriction</a> <a href="#ref-for-dfn-service-worker-85">(2)</a> <a href="#ref-for-dfn-service-worker-86">(3)</a>
-    <li><a href="#ref-for-dfn-service-worker-87">7.4. Cross-Origin Resources and CORS</a>
-    <li><a href="#ref-for-dfn-service-worker-88">7.5. Implementer Concerns</a> <a href="#ref-for-dfn-service-worker-89">(2)</a> <a href="#ref-for-dfn-service-worker-90">(3)</a>
-    <li><a href="#ref-for-dfn-service-worker-91">7.6. Privacy</a> <a href="#ref-for-dfn-service-worker-92">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-93">8. Extensibility</a>
-    <li><a href="#ref-for-dfn-service-worker-94">8.4. Request Functional Event Dispatch</a>
-    <li><a href="#ref-for-dfn-service-worker-95">Update</a>
-    <li><a href="#ref-for-dfn-service-worker-96">Install</a> <a href="#ref-for-dfn-service-worker-97">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-98">Run Service Worker</a>
-    <li><a href="#ref-for-dfn-service-worker-99">Terminate Service Worker</a>
-    <li><a href="#ref-for-dfn-service-worker-100">Extend Service Worker Lifetime</a>
-    <li><a href="#ref-for-dfn-service-worker-101">Handle Fetch</a>
-    <li><a href="#ref-for-dfn-service-worker-102">Handle Foreign Fetch</a>
-    <li><a href="#ref-for-dfn-service-worker-103">Update Registration State</a>
-    <li><a href="#ref-for-dfn-service-worker-104">Update Worker State</a> <a href="#ref-for-dfn-service-worker-105">(2)</a> <a href="#ref-for-dfn-service-worker-106">(3)</a> <a href="#ref-for-dfn-service-worker-107">(4)</a> <a href="#ref-for-dfn-service-worker-108">(5)</a> <a href="#ref-for-dfn-service-worker-109">(6)</a> <a href="#ref-for-dfn-service-worker-110">(7)</a> <a href="#ref-for-dfn-service-worker-111">(8)</a> <a href="#ref-for-dfn-service-worker-112">(9)</a> <a href="#ref-for-dfn-service-worker-113">(10)</a>
-    <li><a href="#ref-for-dfn-service-worker-114">Match Service Worker for Foreign Fetch</a>
-    <li><a href="#ref-for-dfn-service-worker-115">Get Newest Worker</a>
-    <li><a href="#ref-for-dfn-service-worker-116">Service Worker Script Request</a> <a href="#ref-for-dfn-service-worker-117">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-118">Service Worker Script Response</a>
-    <li><a href="#ref-for-dfn-service-worker-119">Syntax</a>
+    <li><a href="#ref-for-dfn-service-worker-57">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-service-worker-58">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-59">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-service-worker-60">(2)</a> <a href="#ref-for-dfn-service-worker-61">(3)</a> <a href="#ref-for-dfn-service-worker-62">(4)</a> <a href="#ref-for-dfn-service-worker-63">(5)</a> <a href="#ref-for-dfn-service-worker-64">(6)</a> <a href="#ref-for-dfn-service-worker-65">(7)</a>
+    <li><a href="#ref-for-dfn-service-worker-66">4.5.1. event.registerForeignFetch(options)</a> <a href="#ref-for-dfn-service-worker-67">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-68">4.6. FetchEvent</a> <a href="#ref-for-dfn-service-worker-69">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-70">4.7. ForeignFetchEvent</a> <a href="#ref-for-dfn-service-worker-71">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-72">4.8. ExtendableMessageEvent</a> <a href="#ref-for-dfn-service-worker-73">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-74">6.2. Understanding Cache Lifetimes</a> <a href="#ref-for-dfn-service-worker-75">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-76">7.1. Secure Context</a> <a href="#ref-for-dfn-service-worker-77">(2)</a> <a href="#ref-for-dfn-service-worker-78">(3)</a> <a href="#ref-for-dfn-service-worker-79">(4)</a> <a href="#ref-for-dfn-service-worker-80">(5)</a>
+    <li><a href="#ref-for-dfn-service-worker-81">7.2. Content Security Policy</a>
+    <li><a href="#ref-for-dfn-service-worker-82">7.3.1. Origin restriction</a> <a href="#ref-for-dfn-service-worker-83">(2)</a> <a href="#ref-for-dfn-service-worker-84">(3)</a>
+    <li><a href="#ref-for-dfn-service-worker-85">7.4. Cross-Origin Resources and CORS</a>
+    <li><a href="#ref-for-dfn-service-worker-86">7.5. Implementer Concerns</a> <a href="#ref-for-dfn-service-worker-87">(2)</a> <a href="#ref-for-dfn-service-worker-88">(3)</a>
+    <li><a href="#ref-for-dfn-service-worker-89">7.6. Privacy</a> <a href="#ref-for-dfn-service-worker-90">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-91">8. Extensibility</a>
+    <li><a href="#ref-for-dfn-service-worker-92">8.4. Request Functional Event Dispatch</a>
+    <li><a href="#ref-for-dfn-service-worker-93">Update</a>
+    <li><a href="#ref-for-dfn-service-worker-94">Install</a> <a href="#ref-for-dfn-service-worker-95">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-96">Run Service Worker</a>
+    <li><a href="#ref-for-dfn-service-worker-97">Terminate Service Worker</a>
+    <li><a href="#ref-for-dfn-service-worker-98">Extend Service Worker Lifetime</a>
+    <li><a href="#ref-for-dfn-service-worker-99">Handle Fetch</a>
+    <li><a href="#ref-for-dfn-service-worker-100">Handle Foreign Fetch</a>
+    <li><a href="#ref-for-dfn-service-worker-101">Update Registration State</a>
+    <li><a href="#ref-for-dfn-service-worker-102">Update Worker State</a> <a href="#ref-for-dfn-service-worker-103">(2)</a> <a href="#ref-for-dfn-service-worker-104">(3)</a> <a href="#ref-for-dfn-service-worker-105">(4)</a> <a href="#ref-for-dfn-service-worker-106">(5)</a> <a href="#ref-for-dfn-service-worker-107">(6)</a> <a href="#ref-for-dfn-service-worker-108">(7)</a> <a href="#ref-for-dfn-service-worker-109">(8)</a> <a href="#ref-for-dfn-service-worker-110">(9)</a> <a href="#ref-for-dfn-service-worker-111">(10)</a>
+    <li><a href="#ref-for-dfn-service-worker-112">Match Service Worker for Foreign Fetch</a>
+    <li><a href="#ref-for-dfn-service-worker-113">Get Newest Worker</a>
+    <li><a href="#ref-for-dfn-service-worker-114">Service Worker Script Request</a> <a href="#ref-for-dfn-service-worker-115">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-116">Service Worker Script Response</a>
+    <li><a href="#ref-for-dfn-service-worker-117">Syntax</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-state">
@@ -7545,11 +7531,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-state-1">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-state-2">(2)</a> <a href="#ref-for-dfn-state-3">(3)</a>
     <li><a href="#ref-for-dfn-state-4">3.1. ServiceWorker</a>
     <li><a href="#ref-for-dfn-state-5">3.2.5. update()</a>
-    <li><a href="#ref-for-dfn-state-6">4.1.3. skipWaiting()</a>
-    <li><a href="#ref-for-dfn-state-7">Handle Fetch</a> <a href="#ref-for-dfn-state-8">(2)</a>
-    <li><a href="#ref-for-dfn-state-9">Handle Foreign Fetch</a> <a href="#ref-for-dfn-state-10">(2)</a>
-    <li><a href="#ref-for-dfn-state-11">Handle Functional Event</a> <a href="#ref-for-dfn-state-12">(2)</a>
-    <li><a href="#ref-for-dfn-state-13">Update Worker State</a> <a href="#ref-for-dfn-state-14">(2)</a> <a href="#ref-for-dfn-state-15">(3)</a>
+    <li><a href="#ref-for-dfn-state-6">Handle Fetch</a> <a href="#ref-for-dfn-state-7">(2)</a>
+    <li><a href="#ref-for-dfn-state-8">Handle Foreign Fetch</a> <a href="#ref-for-dfn-state-9">(2)</a>
+    <li><a href="#ref-for-dfn-state-10">Handle Functional Event</a> <a href="#ref-for-dfn-state-11">(2)</a>
+    <li><a href="#ref-for-dfn-state-12">Update Worker State</a> <a href="#ref-for-dfn-state-13">(2)</a> <a href="#ref-for-dfn-state-14">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-script-url">
@@ -7579,14 +7564,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-containing-service-worker-registration-2">2.4. Selection and Use</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-3">3.2.6. unregister()</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-4">4.1.2. registration</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-5">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-containing-service-worker-registration-6">(2)</a> <a href="#ref-for-dfn-containing-service-worker-registration-7">(3)</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-8">4.3.4. claim()</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-9">4.5.1. event.registerForeignFetch(options)</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-10">4.9. Events</a> <a href="#ref-for-dfn-containing-service-worker-registration-11">(2)</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-12">Install</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-13">Run Service Worker</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-14">Terminate Service Worker</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-15">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration-16">(2)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-5">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-containing-service-worker-registration-6">(2)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-7">4.3.4. claim()</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-8">4.5.1. event.registerForeignFetch(options)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-9">4.9. Events</a> <a href="#ref-for-dfn-containing-service-worker-registration-10">(2)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-11">Install</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-12">Run Service Worker</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-13">Terminate Service Worker</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-14">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration-15">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-service-worker-id">
@@ -7672,7 +7657,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-skip-waiting-flag-1">3.5. Events</a>
     <li><a href="#ref-for-dfn-skip-waiting-flag-2">4.1.3. skipWaiting()</a>
-    <li><a href="#ref-for-dfn-skip-waiting-flag-3">Install</a> <a href="#ref-for-dfn-skip-waiting-flag-4">(2)</a> <a href="#ref-for-dfn-skip-waiting-flag-5">(3)</a>
+    <li><a href="#ref-for-dfn-skip-waiting-flag-3">Install</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-imported-scripts-updated-flag">
@@ -7782,14 +7767,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-waiting-worker-2">2.6. User Agent Shutdown</a>
     <li><a href="#ref-for-dfn-waiting-worker-3">4.1.3. skipWaiting()</a>
     <li><a href="#ref-for-dfn-waiting-worker-4">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-waiting-worker-5">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-6">Install</a> <a href="#ref-for-dfn-waiting-worker-7">(2)</a> <a href="#ref-for-dfn-waiting-worker-8">(3)</a> <a href="#ref-for-dfn-waiting-worker-9">(4)</a> <a href="#ref-for-dfn-waiting-worker-10">(5)</a> <a href="#ref-for-dfn-waiting-worker-11">(6)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-12">Activate</a> <a href="#ref-for-dfn-waiting-worker-13">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-14">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-dfn-waiting-worker-15">Handle User Agent Shutdown</a>
-    <li><a href="#ref-for-dfn-waiting-worker-16">Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-17">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-18">Update Registration State</a> <a href="#ref-for-dfn-waiting-worker-19">(2)</a> <a href="#ref-for-dfn-waiting-worker-20">(3)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-21">Update Worker State</a>
-    <li><a href="#ref-for-dfn-waiting-worker-22">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker-23">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-6">Install</a> <a href="#ref-for-dfn-waiting-worker-7">(2)</a> <a href="#ref-for-dfn-waiting-worker-8">(3)</a> <a href="#ref-for-dfn-waiting-worker-9">(4)</a> <a href="#ref-for-dfn-waiting-worker-10">(5)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-11">Activate</a> <a href="#ref-for-dfn-waiting-worker-12">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-13">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-dfn-waiting-worker-14">Handle User Agent Shutdown</a>
+    <li><a href="#ref-for-dfn-waiting-worker-15">Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-16">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-17">Update Registration State</a> <a href="#ref-for-dfn-waiting-worker-18">(2)</a> <a href="#ref-for-dfn-waiting-worker-19">(3)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-20">Update Worker State</a>
+    <li><a href="#ref-for-dfn-waiting-worker-21">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker-22">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-active-worker">
@@ -9388,8 +9373,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-finish-job-1">Register</a> <a href="#ref-for-finish-job-2">(2)</a> <a href="#ref-for-finish-job-3">(3)</a> <a href="#ref-for-finish-job-4">(4)</a>
     <li><a href="#ref-for-finish-job-5">Update</a> <a href="#ref-for-finish-job-6">(2)</a> <a href="#ref-for-finish-job-7">(3)</a> <a href="#ref-for-finish-job-8">(4)</a> <a href="#ref-for-finish-job-9">(5)</a>
-    <li><a href="#ref-for-finish-job-10">Install</a> <a href="#ref-for-finish-job-11">(2)</a> <a href="#ref-for-finish-job-12">(3)</a>
-    <li><a href="#ref-for-finish-job-13">Unregister</a> <a href="#ref-for-finish-job-14">(2)</a> <a href="#ref-for-finish-job-15">(3)</a>
+    <li><a href="#ref-for-finish-job-10">Install</a> <a href="#ref-for-finish-job-11">(2)</a>
+    <li><a href="#ref-for-finish-job-12">Unregister</a> <a href="#ref-for-finish-job-13">(2)</a> <a href="#ref-for-finish-job-14">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="resolve-job-promise">
@@ -9452,12 +9437,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-activate-1">3.4.2. ready</a>
     <li><a href="#ref-for-activate-2">3.5. Events</a> <a href="#ref-for-activate-3">(2)</a>
-    <li><a href="#ref-for-activate-4">4.1.3. skipWaiting()</a>
-    <li><a href="#ref-for-activate-5">4.4. ExtendableEvent</a> <a href="#ref-for-activate-6">(2)</a>
-    <li><a href="#ref-for-activate-7">4.9. Events</a>
-    <li><a href="#ref-for-activate-8">Install</a> <a href="#ref-for-activate-9">(2)</a>
-    <li><a href="#ref-for-activate-10">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-activate-11">Handle User Agent Shutdown</a>
+    <li><a href="#ref-for-activate-4">4.4. ExtendableEvent</a> <a href="#ref-for-activate-5">(2)</a>
+    <li><a href="#ref-for-activate-6">4.9. Events</a>
+    <li><a href="#ref-for-activate-7">Install</a>
+    <li><a href="#ref-for-activate-8">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-activate-9">Handle User Agent Shutdown</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="run-service-worker">

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -813,8 +813,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Let |promise| be a new <a>promise</a>.
         1. Run the following substeps <a>in parallel</a>:
             1. Set [=/service worker=]'s <a>skip waiting flag</a>.
-            1. If [=/service worker=]'s <a>state</a> is *installed*, then:
-                1. Run <a>Activate</a> algorithm passing [=/service worker=]'s [=service worker/registration=] as the argument.  
             1. Resolve |promise| with undefined.
         1. Return |promise|.
     </section>
@@ -2305,13 +2303,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and null as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>waiting worker</a> and *installed* as the arguments.
       1. If |redundantWorker| is not null, run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
-      1. If |registration|'s <a>waiting worker</a>'s <a>skip waiting flag</a> is set, then:
-          1. Run <a>Activate</a> algorithm passing |registration| as the argument.
-          1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Invoke <a>Finish Job</a> with |job|.
       1. Wait for all the <a>tasks</a> <a lt="queue a task">queued</a> by <a>Update Worker State</a> invoked in this algorithm have executed.
       1. Wait until no [=/service worker client=] is <a>using</a> |registration| or |registration|'s <a>waiting worker</a>'s <a>skip waiting flag</a> is set.
-      1. If |registration|'s <a>waiting worker</a> |waitingWorker| is not null and |waitingWorker|'s <a>skip waiting flag</a> is not set, invoke <a>Activate</a> algorithm with |registration| as its argument.
+      1. If |registration|'s <a>waiting worker</a> is not null, invoke <a>Activate</a> algorithm with |registration| as its argument.
   </section>
 
   <section algorithm>

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-01">1 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-02">2 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2353,12 +2353,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Set <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-56">service worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-2">skip waiting flag</a>.</p>
          <li data-md="">
-          <p>If <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-57">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-6">state</a> is <em>installed</em>, then:</p>
-          <ol>
-           <li data-md="">
-            <p>Run <a data-link-type="dfn" href="#activate" id="ref-for-activate-4">Activate</a> algorithm passing <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-58">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-7">registration</a> as the argument.</p>
-          </ol>
-         <li data-md="">
           <p>Resolve <var>promise</var> with undefined.</p>
         </ol>
        <li data-md="">
@@ -2887,7 +2881,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <li data-md="">
             <p>Let <var>registration</var> be the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-7">Match Service Worker Registration</a> algorithm passing <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> as the argument.</p>
            <li data-md="">
-            <p>If <var>registration</var> is not the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-13">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-8">containing service worker registration</a>, continue to the next iteration of the loop.</p>
+            <p>If <var>registration</var> is not the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-13">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-7">containing service worker registration</a>, continue to the next iteration of the loop.</p>
            <li data-md="">
             <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-14">service worker</a>, then:</p>
             <ol>
@@ -2920,9 +2914,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 </pre>
      <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-2">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-extend-lifetime-promises">extend lifetime promises</dfn> (an array of <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a>). It is initially an empty array.</p>
      <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-3">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="extensions-allowed-flag">extensions allowed flag</dfn>. It is initially set.</p>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-59">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-60">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-57">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-58">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
      <p><a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> also use or extend the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-5">ExtendableEvent</a></code> interface.</p>
-     <p class="note" role="note">Note: To extend the lifetime of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-61">service worker</a>, algorithms that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> events using the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a></code> interface run <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-1">Extend Service Worker Lifetime</a> algorithm after <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> the event. See <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-2">Handle Fetch</a> and <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-1">Handle Functional Event</a>.</p>
+     <p class="note" role="note">Note: To extend the lifetime of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-59">service worker</a>, algorithms that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> events using the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a></code> interface run <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-1">Extend Service Worker Lifetime</a> algorithm after <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> the event. See <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-2">Handle Fetch</a> and <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-1">Handle Functional Event</a>.</p>
      <section class="algorithm" data-algorithm="wait-until-method">
       <h4 class="heading settled" data-level="4.4.1" id="wait-until-method"><span class="secno">4.4.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-2">event.waitUntil(f)</a></code></span><a class="self-link" href="#wait-until-method"></a></h4>
       <p><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-3">waitUntil()</a></code> method extends the lifetime of the event.</p>
@@ -2940,13 +2934,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>Add <var>f</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-1">extend lifetime promises</a>.</p>
       </ol>
      </section>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-62">Service workers</a> and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> define their own behaviors, allowing the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-2">extend lifetime promises</a> to suggest operation length, and the rejected state of any of the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> in <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-3">extend lifetime promises</a> to suggest operation failure.</p>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-63">Service workers</a> define the following behaviors for <code><a data-link-type="dfn" href="#install" id="ref-for-install-2">install</a></code> event and <code><a data-link-type="dfn" href="#activate" id="ref-for-activate-5">activate</a></code> event, respectively:</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-60">Service workers</a> and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> define their own behaviors, allowing the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-2">extend lifetime promises</a> to suggest operation length, and the rejected state of any of the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> in <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-3">extend lifetime promises</a> to suggest operation failure.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-61">Service workers</a> define the following behaviors for <code><a data-link-type="dfn" href="#install" id="ref-for-install-2">install</a></code> event and <code><a data-link-type="dfn" href="#activate" id="ref-for-activate-4">activate</a></code> event, respectively:</p>
      <ul>
       <li data-md="">
-       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> <var>f</var> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-4">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-5">installing worker</a> as <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-4">waiting worker</a>) until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-5">extend lifetime promises</a> resolve successfully. (See step 11.3.1 of <a data-link-type="dfn" href="#install" id="ref-for-install-3">Install</a> algorithm.) If <var>f</var> rejects, the installation fails. This is primarily used to ensure that a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-64">service worker</a> is not considered <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-5">waiting worker</a>) until all of the core caches it depends on are populated.</p>
+       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> <var>f</var> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-4">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-5">installing worker</a> as <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-4">waiting worker</a>) until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-5">extend lifetime promises</a> resolve successfully. (See step 11.3.1 of <a data-link-type="dfn" href="#install" id="ref-for-install-3">Install</a> algorithm.) If <var>f</var> rejects, the installation fails. This is primarily used to ensure that a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-62">service worker</a> is not considered <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-5">waiting worker</a>) until all of the core caches it depends on are populated.</p>
       <li data-md="">
-       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-6">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-17">active worker</a> as <em>activated</em> until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-7">extend lifetime promises</a> settle. (See step 12.3 of <a data-link-type="dfn" href="#activate" id="ref-for-activate-6">Activate</a> algorithm.) This is primarily used to ensure that any <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-2">functional events</a> are not dispatched to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-11">ServiceWorkerGlobalScope</a></code> object that represents the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service worker</a> until it upgrades database schemas and deletes the outdated cache entries.</p>
+       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-6">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-17">active worker</a> as <em>activated</em> until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-7">extend lifetime promises</a> settle. (See step 12.3 of <a data-link-type="dfn" href="#activate" id="ref-for-activate-5">Activate</a> algorithm.) This is primarily used to ensure that any <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-2">functional events</a> are not dispatched to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-11">ServiceWorkerGlobalScope</a></code> object that represents the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-63">service worker</a> until it upgrades database schemas and deletes the outdated cache entries.</p>
      </ul>
     </section>
     <section>
@@ -2970,7 +2964,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="FetchEventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-fetcheventinit-isreload">isReload<a class="self-link" href="#dom-fetcheventinit-isreload"></a></dfn> = <span class="kt">false</span>;
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-66">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-67">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-8">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-64">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-8">ExtendableEvent</a></code> interface.</p>
      <p>Each event using <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-3">FetchEvent</a></code> interface has an associated <dfn class="dfn-paneled" data-dfn-for="FetchEvent" data-dfn-type="dfn" data-noexport="" id="fetchevent-potential-response">potential response</dfn> (a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>), initially set to null, and the following associated flags that are initially unset:</p>
      <ul>
       <li data-md="">
@@ -3151,7 +3145,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/comms.html#messageport">MessagePort</a>> <dfn class="nv idl-code" data-default="None" data-dfn-for="ExtendableMessageEventInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MessagePort> " id="dom-extendablemessageeventinit-ports">ports<a class="self-link" href="#dom-extendablemessageeventinit-ports"></a></dfn> = [];
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-68">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-69">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-10">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-66">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-67">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-10">ExtendableEvent</a></code> interface.</p>
      <section>
       <h4 class="heading settled" data-level="4.6.1" id="extendablemessage-event-data"><span class="secno">4.6.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendablemessageevent-data" id="ref-for-dom-extendablemessageevent-data-3">event.data</a></code></span><a class="self-link" href="#extendablemessage-event-data"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ExtendableMessageEvent" data-dfn-type="attribute" data-export="" id="dom-extendablemessageevent-data">data</dfn> attribute <em>must</em> return the value it was initialized to. When the object is created, this attribute <em>must</em> be initialized to null. It represents the message being sent.</p>
@@ -3186,11 +3180,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-install-event"><code>install</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a></code>
-        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-2">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-16">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-6">installing worker</a> changes. (See step 11.2 of the <a data-link-type="dfn" href="#install" id="ref-for-install-4">Install</a> algorithm.)
+        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-2">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-16">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-8">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-6">installing worker</a> changes. (See step 11.2 of the <a data-link-type="dfn" href="#install" id="ref-for-install-4">Install</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-activate-event"><code>activate</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-12">ExtendableEvent</a></code>
-        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-3">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-17">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-10">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-18">active worker</a> changes. (See step 12.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-7">Activate</a> algorithm.)
+        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-3">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-17">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-18">active worker</a> changes. (See step 12.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-6">Activate</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-fetch-event"><code>fetch</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-4">FetchEvent</a></code>
@@ -3215,7 +3209,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="5.2" id="cache-lifetimes"><span class="secno">5.2. </span><span class="content">Understanding Cache Lifetimes</span><a class="self-link" href="#cache-lifetimes"></a></h3>
-     <p>The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-6">Cache</a></code> instances are not part of the browser’s HTTP cache. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-7">Cache</a></code> objects are exactly what authors have to manage themselves. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-8">Cache</a></code> objects do not get updated unless authors explicitly request them to be. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-9">Cache</a></code> objects do not expire unless authors delete the entries. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-10">Cache</a></code> objects do not disappear just because the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-70">service worker</a> script is updated. That is, caches are not updated automatically. Updates must be manually managed. This implies that authors should version their caches by name and make sure to use the caches only from the version of the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-71">service worker</a> that can safely operate on.</p>
+     <p>The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-6">Cache</a></code> instances are not part of the browser’s HTTP cache. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-7">Cache</a></code> objects are exactly what authors have to manage themselves. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-8">Cache</a></code> objects do not get updated unless authors explicitly request them to be. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-9">Cache</a></code> objects do not expire unless authors delete the entries. The <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-10">Cache</a></code> objects do not disappear just because the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-68">service worker</a> script is updated. That is, caches are not updated automatically. Updates must be manually managed. This implies that authors should version their caches by name and make sure to use the caches only from the version of the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-69">service worker</a> that can safely operate on.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="5.3" id="self-caches"><span class="secno">5.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#global-caches-attribute" id="ref-for-global-caches-attribute-1">self.caches</a></code></span><a class="self-link" href="#self-caches"></a></h3>
@@ -3907,11 +3901,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <h2 class="heading settled" data-level="6" id="security-considerations"><span class="secno">6. </span><span class="content">Security Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
     <section>
      <h3 class="heading settled" data-level="6.1" id="secure-context"><span class="secno">6.1. </span><span class="content">Secure Context</span><a class="self-link" href="#secure-context"></a></h3>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-72">Service workers</a> <em>must</em> execute in <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure contexts</a>. <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-33">Service worker clients</a> <em>must</em> also be <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure contexts</a> to register a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-43">service worker registration</a>, to get access to the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-44">service worker registrations</a> and the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-73">service workers</a>, to do messaging with the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-74">service workers</a>, and to be manipulated by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-75">service workers</a>. This effectively means that <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-76">service workers</a> and their <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-34">service worker clients</a> <em>should</em> be hosted over HTTPS. A user agent <em>may</em> allow <code>localhost</code>, <code>127.0.0.0/8</code>, and <code>::1/128</code> for development purpose. (Note that they may still be <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure contexts</a>.) The primary reason for this restriction is to protect users from the <a href="https://w3c.github.io/webappsec-secure-contexts/#threat-risks">risks associated with insecure contexts</a>.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-70">Service workers</a> <em>must</em> execute in <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure contexts</a>. <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-33">Service worker clients</a> <em>must</em> also be <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure contexts</a> to register a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-43">service worker registration</a>, to get access to the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-44">service worker registrations</a> and the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-71">service workers</a>, to do messaging with the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-72">service workers</a>, and to be manipulated by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-73">service workers</a>. This effectively means that <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-74">service workers</a> and their <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-34">service worker clients</a> <em>should</em> be hosted over HTTPS. A user agent <em>may</em> allow <code>localhost</code>, <code>127.0.0.0/8</code>, and <code>::1/128</code> for development purpose. (Note that they may still be <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure contexts</a>.) The primary reason for this restriction is to protect users from the <a href="https://w3c.github.io/webappsec-secure-contexts/#threat-risks">risks associated with insecure contexts</a>.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="6.2" id="content-security-policy"><span class="secno">6.2. </span><span class="content">Content Security Policy</span><a class="self-link" href="#content-security-policy"></a></h3>
-     <p>Whenever a user agent invokes <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-2">Run Service Worker</a> algorithm with a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-77">service worker</a> <var>serviceWorker</var>:</p>
+     <p>Whenever a user agent invokes <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-2">Run Service Worker</a> algorithm with a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-75">service worker</a> <var>serviceWorker</var>:</p>
      <ul>
       <li data-md="">
        <p>If <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-4">script resource</a> was delivered with a <code>Content-Security-Policy</code> HTTP header containing the value <var>policy</var>, the user agent <em>must</em> <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#enforced">enforce</a> <var>policy</var> for <var>serviceWorker</var>.</p>
@@ -3925,7 +3919,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <section>
       <h4 class="heading settled" data-level="6.3.1" id="origin-restriction"><span class="secno">6.3.1. </span><span class="content">Origin restriction</span><a class="self-link" href="#origin-restriction"></a></h4>
       <p><em>This section is non-normative.</em></p>
-      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-78">service worker</a> executes in the registering <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-35">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>. One of the advanced concerns that major applications would encounter is whether they can be hosted from a CDN. By definition, these are servers in other places, often on other <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origins</a>. Therefore, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-79">service workers</a> cannot be hosted on CDNs. But they can include resources via <a data-link-type="functionish" href="#importscripts-method" id="ref-for-importscripts-method-1">importScripts()</a>. The reason for this restriction is that <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-80">service workers</a> create the opportunity for a bad actor to turn a bad day into a bad eternity.</p>
+      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-76">service worker</a> executes in the registering <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-35">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>. One of the advanced concerns that major applications would encounter is whether they can be hosted from a CDN. By definition, these are servers in other places, often on other <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origins</a>. Therefore, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-77">service workers</a> cannot be hosted on CDNs. But they can include resources via <a data-link-type="functionish" href="#importscripts-method" id="ref-for-importscripts-method-1">importScripts()</a>. The reason for this restriction is that <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-78">service workers</a> create the opportunity for a bad actor to turn a bad day into a bad eternity.</p>
      </section>
      <section>
       <h4 class="heading settled" data-level="6.3.2" id="importscripts"><span class="secno">6.3.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-importscripts">importScripts(urls)</a></code></span><a class="self-link" href="#importscripts"></a></h4>
@@ -3961,7 +3955,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="6.4" id="cross-origin-resources"><span class="secno">6.4. </span><span class="content">Cross-Origin Resources and CORS</span><a class="self-link" href="#cross-origin-resources"></a></h3>
      <p><em>This section is non-normative.</em></p>
-     <p>Applications tend to cache items that come from a CDN or other <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>. It is possible to request many of them directly using <code>&lt;script></code>, <code>&lt;img></code>, <code>&lt;video></code> and <code>&lt;link></code> elements. It would be hugely limiting if this sort of runtime collaboration broke when offline. Similarly, it is possible to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> many sorts of off-<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> resources when appropriate CORS headers are set. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-81">Service workers</a> enable this by allowing <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-20">Caches</a></code> to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> and cache off-origin items. Some restrictions apply, however. First, unlike same-origin resources which are managed in the <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-21">Cache</a></code> as <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> objects whose corresponding <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">responses</a> are <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">basic filtered response</a>, the objects stored are <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> objects whose corresponding <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">responses</a> are either <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-cors">CORS filtered responses</a> or <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">opaque filtered responses</a>. They can be passed to <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-4">event.respondWith(r)</a></code> method in the same manner as the <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> objects whose corresponding <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">responses</a> are <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">basic filtered responses</a>, but cannot be meaningfully created programmatically. These limitations are necessary to preserve the security invariants of the platform. Allowing <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-22">Caches</a></code> to store them allows applications to avoid re-architecting in most cases.</p>
+     <p>Applications tend to cache items that come from a CDN or other <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>. It is possible to request many of them directly using <code>&lt;script></code>, <code>&lt;img></code>, <code>&lt;video></code> and <code>&lt;link></code> elements. It would be hugely limiting if this sort of runtime collaboration broke when offline. Similarly, it is possible to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> many sorts of off-<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> resources when appropriate CORS headers are set. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-79">Service workers</a> enable this by allowing <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-20">Caches</a></code> to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> and cache off-origin items. Some restrictions apply, however. First, unlike same-origin resources which are managed in the <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-21">Cache</a></code> as <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> objects whose corresponding <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">responses</a> are <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">basic filtered response</a>, the objects stored are <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> objects whose corresponding <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">responses</a> are either <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-cors">CORS filtered responses</a> or <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">opaque filtered responses</a>. They can be passed to <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-4">event.respondWith(r)</a></code> method in the same manner as the <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> objects whose corresponding <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">responses</a> are <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">basic filtered responses</a>, but cannot be meaningfully created programmatically. These limitations are necessary to preserve the security invariants of the platform. Allowing <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-22">Caches</a></code> to store them allows applications to avoid re-architecting in most cases.</p>
     </section>
     <section>
      <h3 class="heading settled" data-level="6.5" id="implementer-concerns"><span class="secno">6.5. </span><span class="content">Implementer Concerns</span><a class="self-link" href="#implementer-concerns"></a></h3>
@@ -3969,19 +3963,19 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <p>The implementers are encouraged to note:</p>
      <ul>
       <li data-md="">
-       <p>Plug-ins should not load via <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-82">service workers</a>. As plug-ins may get their security origins from their own urls, the embedding <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-83">service worker</a> cannot handle it. For this reason, the <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-7">Handle Fetch</a> algorithm makes the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">potential-navigation-or-subresource request</a> (whose context is either <code>&lt;embed></code> or <code>&lt;object></code>) immediately fallback to the network without dispatching <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-6">fetch</a></code> event.</p>
+       <p>Plug-ins should not load via <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-80">service workers</a>. As plug-ins may get their security origins from their own urls, the embedding <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-81">service worker</a> cannot handle it. For this reason, the <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-7">Handle Fetch</a> algorithm makes the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">potential-navigation-or-subresource request</a> (whose context is either <code>&lt;embed></code> or <code>&lt;object></code>) immediately fallback to the network without dispatching <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-6">fetch</a></code> event.</p>
       <li data-md="">
-       <p>Some of the legacy networking stack code may need to be carefully audited to understand the ramifications of interactions with <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-84">service workers</a>.</p>
+       <p>Some of the legacy networking stack code may need to be carefully audited to understand the ramifications of interactions with <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-82">service workers</a>.</p>
      </ul>
     </section>
     <section>
      <h3 class="heading settled" data-level="6.6" id="privacy"><span class="secno">6.6. </span><span class="content">Privacy</span><a class="self-link" href="#privacy"></a></h3>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-85">Service workers</a> introduce new persistent storage features including <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-6">scope to registration map</a> (for <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-45">service worker registrations</a> and their <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-86">service workers</a>), <a data-link-type="dfn" href="#dfn-request-to-response-map" id="ref-for-dfn-request-to-response-map-16">request to response map</a> and <a data-link-type="dfn" href="#dfn-name-to-cache-map" id="ref-for-dfn-name-to-cache-map-11">name to cache map</a> (for caches), and <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map-4">script resource map</a> (for script resources). In order to protect users from any potential <a data-link-type="biblio" href="#biblio-unsanctioned-tracking">unsanctioned tracking</a> threat, these persistent storages <em>should</em> be cleared when users intend to clear them and <em>should</em> maintain and interoperate with existing user controls e.g. purging all existing persistent storages.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-83">Service workers</a> introduce new persistent storage features including <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-6">scope to registration map</a> (for <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-45">service worker registrations</a> and their <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-84">service workers</a>), <a data-link-type="dfn" href="#dfn-request-to-response-map" id="ref-for-dfn-request-to-response-map-16">request to response map</a> and <a data-link-type="dfn" href="#dfn-name-to-cache-map" id="ref-for-dfn-name-to-cache-map-11">name to cache map</a> (for caches), and <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map-4">script resource map</a> (for script resources). In order to protect users from any potential <a data-link-type="biblio" href="#biblio-unsanctioned-tracking">unsanctioned tracking</a> threat, these persistent storages <em>should</em> be cleared when users intend to clear them and <em>should</em> maintain and interoperate with existing user controls e.g. purging all existing persistent storages.</p>
     </section>
    </section>
    <section>
     <h2 class="heading settled" data-level="7" id="extensibility"><span class="secno">7. </span><span class="content">Extensibility</span><a class="self-link" href="#extensibility"></a></h2>
-    <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-87">Service workers</a> are extensible from other specifications.</p>
+    <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-85">Service workers</a> are extensible from other specifications.</p>
     <section>
      <h3 class="heading settled" data-level="7.1" id="extension-to-service-worker-registration"><span class="secno">7.1. </span><span class="content">Define API bound to Service Worker Registration</span><a class="self-link" href="#extension-to-service-worker-registration"></a></h3>
      <p>Specifications <em>may</em> define an API tied to a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-46">service worker registration</a> by using <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-partial-interface">partial interface</a> definition to the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-16">ServiceWorkerRegistration</a></code> interface where it <em>may</em> define the specification specific attributes and methods:</p>
@@ -4012,7 +4006,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="7.4" id="request-functional-event-dispatch"><span class="secno">7.4. </span><span class="content">Request Functional Event Dispatch</span><a class="self-link" href="#request-functional-event-dispatch"></a></h3>
-     <p>To request a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-7">functional event</a> dispatch to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-88">service worker</a>, specifications <em>may</em> invoke <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-2">Handle Functional Event</a> algorithm with its <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-47">service worker registration</a> <var>registration</var> and the algorithm <var>callbackSteps</var> as the arguments.</p>
+     <p>To request a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-7">functional event</a> dispatch to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-86">service worker</a>, specifications <em>may</em> invoke <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-2">Handle Functional Event</a> algorithm with its <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-47">service worker registration</a> <var>registration</var> and the algorithm <var>callbackSteps</var> as the arguments.</p>
      <p>Specifications <em>may</em> define an algorithm <var>callbackSteps</var> where the corresponding <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-8">functional event</a> can be created and fired with specification specific objects. The algorithm is passed <var>globalObject</var> (a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-16">ServiceWorkerGlobalScope</a></code> object) at which it <em>may</em> fire its <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-9">functional events</a>. This algorithm is called on a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-3">Handle Functional Event</a> algorithm.</p>
      <p class="note" role="note">Note: See an <a href="https://notifications.spec.whatwg.org/#activating-a-notification">example</a> hook defined in <a data-link-type="biblio" href="#biblio-notifications">Notifications API</a>.</p>
     </section>
@@ -4419,7 +4413,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Else:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>worker</var> be a new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-89">service worker</a>.</p>
+         <p>Let <var>worker</var> be a new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-87">service worker</a>.</p>
         <li data-md="">
          <p>Generate a unique opaque string and set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-id" id="ref-for-dfn-service-worker-id-1">id</a> to the value.</p>
         <li data-md="">
@@ -4484,7 +4478,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-24">job</a></p>
       <dd data-md="">
-       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-90">service worker</a></p>
+       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-88">service worker</a></p>
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-52">service worker registration</a></p>
       <dt data-md="">
@@ -4508,7 +4502,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-3">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-19">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-38">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-15">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-91">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-11">containing service worker registration</a> is <var>registration</var>.</p>
+       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-38">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-15">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-89">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-10">containing service worker registration</a> is <var>registration</var>.</p>
       <li data-md="">
        <p>Let <var>installingWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-8">installing worker</a>.</p>
       <li data-md="">
@@ -4573,21 +4567,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>redundantWorker</var> is not null, run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-4">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-9">waiting worker</a>’s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set, then:</p>
-       <ol>
-        <li data-md="">
-         <p>Run <a data-link-type="dfn" href="#activate" id="ref-for-activate-8">Activate</a> algorithm passing <var>registration</var> as the argument.</p>
-        <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-11">Finish Job</a> with <var>job</var> and abort these steps.</p>
-       </ol>
-      <li data-md="">
-       <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-12">Finish Job</a> with <var>job</var>.</p>
+       <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-11">Finish Job</a> with <var>job</var>.</p>
       <li data-md="">
        <p>Wait for all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-5">Update Worker State</a> invoked in this algorithm have executed.</p>
       <li data-md="">
-       <p>Wait until no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-39">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-4">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-10">waiting worker</a>’s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-4">skip waiting flag</a> is set.</p>
+       <p>Wait until no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-39">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-4">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-9">waiting worker</a>’s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-11">waiting worker</a> <var>waitingWorker</var> is not null and <var>waitingWorker</var>’s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-5">skip waiting flag</a> is not set, invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-9">Activate</a> algorithm with <var>registration</var> as its argument.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-10">waiting worker</a> is not null, invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-7">Activate</a> algorithm with <var>registration</var> as its argument.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Activate">
@@ -4604,7 +4590,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a> is null, abort these steps.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-11">waiting worker</a> is null, abort these steps.</p>
       <li data-md="">
        <p>Let <var>redundantWorker</var> be null.</p>
       <li data-md="">
@@ -4618,7 +4604,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-5">Terminate</a> <var>redundantWorker</var>.</p>
        </ol>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-5">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-5">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a> as the arguments.</p>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-6">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and null as the arguments.</p>
       <li data-md="">
@@ -4675,7 +4661,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>serviceWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-92">service worker</a></p>
+       <p><var>serviceWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-90">service worker</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -4753,7 +4739,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Create a new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">WorkerLocation</a></code> object and associate it with <var>workerGlobalScope</var>.</p>
       <li data-md="">
-       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-12">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
+       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-11">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
       <li data-md="">
        <p>If <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>, then <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">run the classic script</a> <var>script</var>. Otherwise, it is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">module script</a>; <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">run the module script</a> <var>script</var>.</p>
        <p class="note" role="note">Note: In addition to the usual possibilities of returning a value or failing due to an exception, this could be prematurely aborted by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">kill a worker</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">terminate a worker</a> algorithms.</p>
@@ -4778,7 +4764,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>serviceWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-93">service worker</a></p>
+       <p><var>serviceWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-91">service worker</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -4792,7 +4778,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>serviceWorkerGlobalScope</var>’s closing flag to true.</p>
       <li data-md="">
-       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-13">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
+       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-12">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
        <p class="note" role="note">Note: This effectively means that the fetch events and the other functional events such as push events are backed up by the registration’s task queues while the other tasks including message events are discarded.</p>
       <li data-md="">
        <p>Abort the script currently running in <var>serviceWorker</var>.</p>
@@ -4828,11 +4814,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Unset <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-5">extensions allowed flag</a>.</p>
        </ol>
      </ol>
-     <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-94">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> until <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-6">extensions allowed flag</a> is unset. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
+     <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-92">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> until <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-6">extensions allowed flag</a> is unset. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
     </section>
     <section class="algorithm" data-algorithm="Handle Fetch">
      <h3 class="heading settled" id="on-fetch-request-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="handle-fetch">Handle Fetch</dfn></span><a class="self-link" href="#on-fetch-request-algorithm"></a></h3>
-     <p>The <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-8">Handle Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-95">service worker</a> context.</p>
+     <p>The <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-8">Handle Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-93">service worker</a> context.</p>
      <dl>
       <dt data-md="">
        <p>Input</p>
@@ -4897,12 +4883,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-28">active worker</a>.</p>
        </ol>
-       <p class="note" role="note">Note: From this point, the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-43">service worker client</a> starts to <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-6">use</a> its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a>.</p>
+       <p class="note" role="note">Note: From this point, the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-43">service worker client</a> starts to <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-6">use</a> its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-13">containing service worker registration</a>.</p>
       <li data-md="">
        <p>Else if <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is non-null, set <var>registration</var> to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-15">containing service worker registration</a>.</p>
+         <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is non-null, set <var>registration</var> to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a>.</p>
         <li data-md="">
          <p>Else, return null.</p>
        </ol>
@@ -4920,7 +4906,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        </ol>
        <p class="note" role="note">Note: To avoid unnecessary delays, the Handle Fetch enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
       <li data-md="">
-       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-7">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-8">state</a> to become <em>activated</em>.</p>
+       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-6">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-7">state</a> to become <em>activated</em>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-6">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
@@ -5030,7 +5016,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        </ol>
        <p class="note" role="note">Note: To avoid unnecessary delays, the Handle Functional Event enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
       <li data-md="">
-       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-9">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-10">state</a> to become <em>activated</em>.</p>
+       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-8">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-9">state</a> to become <em>activated</em>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-7">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
@@ -5073,7 +5059,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-4">uninstalling flag</a> is set, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-4">Clear Registration</a> algorithm passing <var>registration</var> as its argument and abort these steps.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-14">waiting worker</a> is not null, run <a data-link-type="dfn" href="#activate" id="ref-for-activate-10">Activate</a> algorithm with <var>registration</var> as the argument.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a> is not null, run <a data-link-type="dfn" href="#activate" id="ref-for-activate-8">Activate</a> algorithm with <var>registration</var> as the argument.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle User Agent Shutdown">
@@ -5101,10 +5087,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <p>Else, set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-13">installing worker</a> to null.</p>
          </ol>
         <li data-md="">
-         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-15">waiting worker</a> is not null, run the following substep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-14">waiting worker</a> is not null, run the following substep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-11">Activate</a> with <var>registration</var>.</p>
+           <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-9">Activate</a> with <var>registration</var>.</p>
          </ol>
        </ol>
      </ol>
@@ -5128,7 +5114,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-11">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-13">Finish Job</a> with <var>job</var> and abort these steps.</p>
+         <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-12">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
        <p>Let <var>registration</var> be the result of running <a data-link-type="dfn" href="#get-registration" id="ref-for-get-registration-3">Get Registration</a> algorithm passing <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-10">scope url</a> as the argument.</p>
@@ -5138,7 +5124,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-4">Resolve Job Promise</a> with <var>job</var> and false.</p>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-14">Finish Job</a> with <var>job</var> and abort these steps.</p>
+         <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-13">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
        <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-5">uninstalling flag</a>.</p>
@@ -5148,7 +5134,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-47">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-9">using</a> <var>registration</var>, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-6">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
        <p class="note" role="note">Note: When the registration is being used for a client, the deletion of the registration is handled by the Handle Service Worker Client Unload algorithm.</p>
       <li data-md="">
-       <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-15">Finish Job</a> with <var>job</var>.</p>
+       <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-14">Finish Job</a> with <var>job</var>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Set Registration">
@@ -5208,10 +5194,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-9">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-16">waiting worker</a> is not null, then:</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-15">waiting worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-17">waiting worker</a>.</p>
+         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-16">waiting worker</a>.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-11">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
@@ -5251,7 +5237,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dd data-md="">
        <p><var>target</var>, a string (one of "<code>installing</code>", "<code>waiting</code>", and "<code>active</code>")</p>
       <dd data-md="">
-       <p><var>source</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-96">service worker</a> or null</p>
+       <p><var>source</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-94">service worker</a> or null</p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5276,12 +5262,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Else if <var>target</var> is "<code>waiting</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-18">waiting worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-17">waiting worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-waiting" id="ref-for-dom-serviceworkerregistration-waiting-3">waiting</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-26">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-19">waiting worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-waiting" id="ref-for-dom-serviceworkerregistration-waiting-3">waiting</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-26">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-18">waiting worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-19">waiting worker</a> is null.</p>
          </ol>
        </ol>
       <li data-md="">
@@ -5305,9 +5291,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-97">service worker</a></p>
+       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-95">service worker</a></p>
       <dd data-md="">
-       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-11">state</a></p>
+       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-96">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-10">state</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5315,7 +5301,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-12">state</a> to <var>state</var>.</p>
+       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-11">state</a> to <var>state</var>.</p>
       <li data-md="">
        <p>Let <var>workerObjects</var> be an array containing all the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-28">ServiceWorker</a></code> objects associated with <var>worker</var>.</p>
       <li data-md="">
@@ -5325,33 +5311,33 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to run these substeps:</p>
          <ol>
           <li data-md="">
-           <p>Set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworker-state" id="ref-for-dom-serviceworker-state-5">state</a></code> attribute of <var>workerObject</var> to the value (in <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate-4">ServiceWorkerState</a></code> enumeration) corresponding to the first matching statement, switching on <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-13">state</a>:</p>
+           <p>Set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworker-state" id="ref-for-dom-serviceworker-state-5">state</a></code> attribute of <var>workerObject</var> to the value (in <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate-4">ServiceWorkerState</a></code> enumeration) corresponding to the first matching statement, switching on <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-12">state</a>:</p>
            <dl>
             <dt data-md="">
              <p><em>installing</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installing" id="ref-for-dom-serviceworkerstate-installing-1">"installing"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-99">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> is not active until all of the core caches are populated.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-97">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a> is not active until all of the core caches are populated.</p>
             <dt data-md="">
              <p><em>installed</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installed" id="ref-for-dom-serviceworkerstate-installed-1">"installed"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-21">waiting worker</a>.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-99">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a>.</p>
             <dt data-md="">
              <p><em>activating</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activating" id="ref-for-dom-serviceworkerstate-activating-1">"activating"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-102">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
             <dt data-md="">
              <p><em>activated</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activated" id="ref-for-dom-serviceworkerstate-activated-1">"activated"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>.</p>
             <dt data-md="">
              <p><em>redundant</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-redundant" id="ref-for-dom-serviceworkerstate-redundant-2">"redundant"</a></code></p>
-             <p class="note" role="note">Note: A new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> is replacing the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a>, or the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a> is being discarded due to an install failure.</p>
+             <p class="note" role="note">Note: A new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-102">service worker</a> is replacing the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a>, or the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> is being discarded due to an install failure.</p>
            </dl>
           <li data-md="">
            <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <code>statechange</code> at <var>workerObject</var>.</p>
@@ -5457,7 +5443,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>newestWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a></p>
+       <p><var>newestWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -5467,7 +5453,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-21">installing worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-22">installing worker</a>.</p>
       <li data-md="">
-       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-22">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-23">waiting worker</a>.</p>
+       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-21">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-22">waiting worker</a>.</p>
       <li data-md="">
        <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a>.</p>
       <li data-md="">
@@ -5752,18 +5738,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <h2 class="heading settled" id="extended-http-headers"><span class="content">Appendix B: Extended HTTP headers</span><a class="self-link" href="#extended-http-headers"></a></h2>
     <section>
      <h3 class="heading settled" id="service-worker-script-request"><span class="content">Service Worker Script Request</span><a class="self-link" href="#service-worker-script-request"></a></h3>
-     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-13">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-13">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker"><code>Service-Worker</code><a class="self-link" href="#service-worker"></a></dfn>`</p>
       <dd data-md="">
-       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-109">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> request.</p>
+       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> request.</p>
        <p class="note" role="note">Note: This header helps administrators log the requests and detect threats.</p>
      </dl>
     </section>
     <section>
      <h3 class="heading settled" id="service-worker-script-response"><span class="content">Service Worker Script Response</span><a class="self-link" href="#service-worker-script-response"></a></h3>
-     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-110">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker-allowed"><code>Service-Worker-Allowed</code><a class="self-link" href="#service-worker-allowed"></a></dfn>`</p>
@@ -5810,7 +5796,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" id="syntax"><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
-     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-111">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> requests and responses:</p>
+     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-109">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> requests and responses:</p>
 <pre>Service-Worker = %x73.63.72.69.70.74 ; "script", case-sensitive
 </pre>
      <p class="note" role="note">Note: The validation of the Service-Worker-Allowed header’s values is done by URL parsing algorithm (in Update algorithm) instead of using ABNF.</p>
@@ -6804,31 +6790,31 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-48">3.4.1. controller</a>
     <li><a href="#ref-for-dfn-service-worker-49">3.5. Events</a> <a href="#ref-for-dfn-service-worker-50">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-51">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-dfn-service-worker-52">(2)</a> <a href="#ref-for-dfn-service-worker-53">(3)</a> <a href="#ref-for-dfn-service-worker-54">(4)</a>
-    <li><a href="#ref-for-dfn-service-worker-55">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-service-worker-56">(2)</a> <a href="#ref-for-dfn-service-worker-57">(3)</a> <a href="#ref-for-dfn-service-worker-58">(4)</a>
-    <li><a href="#ref-for-dfn-service-worker-59">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-service-worker-60">(2)</a> <a href="#ref-for-dfn-service-worker-61">(3)</a> <a href="#ref-for-dfn-service-worker-62">(4)</a> <a href="#ref-for-dfn-service-worker-63">(5)</a> <a href="#ref-for-dfn-service-worker-64">(6)</a> <a href="#ref-for-dfn-service-worker-65">(7)</a>
-    <li><a href="#ref-for-dfn-service-worker-66">4.5. FetchEvent</a> <a href="#ref-for-dfn-service-worker-67">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-68">4.6. ExtendableMessageEvent</a> <a href="#ref-for-dfn-service-worker-69">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-70">5.2. Understanding Cache Lifetimes</a> <a href="#ref-for-dfn-service-worker-71">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-72">6.1. Secure Context</a> <a href="#ref-for-dfn-service-worker-73">(2)</a> <a href="#ref-for-dfn-service-worker-74">(3)</a> <a href="#ref-for-dfn-service-worker-75">(4)</a> <a href="#ref-for-dfn-service-worker-76">(5)</a>
-    <li><a href="#ref-for-dfn-service-worker-77">6.2. Content Security Policy</a>
-    <li><a href="#ref-for-dfn-service-worker-78">6.3.1. Origin restriction</a> <a href="#ref-for-dfn-service-worker-79">(2)</a> <a href="#ref-for-dfn-service-worker-80">(3)</a>
-    <li><a href="#ref-for-dfn-service-worker-81">6.4. Cross-Origin Resources and CORS</a>
-    <li><a href="#ref-for-dfn-service-worker-82">6.5. Implementer Concerns</a> <a href="#ref-for-dfn-service-worker-83">(2)</a> <a href="#ref-for-dfn-service-worker-84">(3)</a>
-    <li><a href="#ref-for-dfn-service-worker-85">6.6. Privacy</a> <a href="#ref-for-dfn-service-worker-86">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-87">7. Extensibility</a>
-    <li><a href="#ref-for-dfn-service-worker-88">7.4. Request Functional Event Dispatch</a>
-    <li><a href="#ref-for-dfn-service-worker-89">Update</a>
-    <li><a href="#ref-for-dfn-service-worker-90">Install</a> <a href="#ref-for-dfn-service-worker-91">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-92">Run Service Worker</a>
-    <li><a href="#ref-for-dfn-service-worker-93">Terminate Service Worker</a>
-    <li><a href="#ref-for-dfn-service-worker-94">Extend Service Worker Lifetime</a>
-    <li><a href="#ref-for-dfn-service-worker-95">Handle Fetch</a>
-    <li><a href="#ref-for-dfn-service-worker-96">Update Registration State</a>
-    <li><a href="#ref-for-dfn-service-worker-97">Update Worker State</a> <a href="#ref-for-dfn-service-worker-98">(2)</a> <a href="#ref-for-dfn-service-worker-99">(3)</a> <a href="#ref-for-dfn-service-worker-100">(4)</a> <a href="#ref-for-dfn-service-worker-101">(5)</a> <a href="#ref-for-dfn-service-worker-102">(6)</a> <a href="#ref-for-dfn-service-worker-103">(7)</a> <a href="#ref-for-dfn-service-worker-104">(8)</a> <a href="#ref-for-dfn-service-worker-105">(9)</a> <a href="#ref-for-dfn-service-worker-106">(10)</a>
-    <li><a href="#ref-for-dfn-service-worker-107">Get Newest Worker</a>
-    <li><a href="#ref-for-dfn-service-worker-108">Service Worker Script Request</a> <a href="#ref-for-dfn-service-worker-109">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-110">Service Worker Script Response</a>
-    <li><a href="#ref-for-dfn-service-worker-111">Syntax</a>
+    <li><a href="#ref-for-dfn-service-worker-55">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-service-worker-56">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-57">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-service-worker-58">(2)</a> <a href="#ref-for-dfn-service-worker-59">(3)</a> <a href="#ref-for-dfn-service-worker-60">(4)</a> <a href="#ref-for-dfn-service-worker-61">(5)</a> <a href="#ref-for-dfn-service-worker-62">(6)</a> <a href="#ref-for-dfn-service-worker-63">(7)</a>
+    <li><a href="#ref-for-dfn-service-worker-64">4.5. FetchEvent</a> <a href="#ref-for-dfn-service-worker-65">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-66">4.6. ExtendableMessageEvent</a> <a href="#ref-for-dfn-service-worker-67">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-68">5.2. Understanding Cache Lifetimes</a> <a href="#ref-for-dfn-service-worker-69">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-70">6.1. Secure Context</a> <a href="#ref-for-dfn-service-worker-71">(2)</a> <a href="#ref-for-dfn-service-worker-72">(3)</a> <a href="#ref-for-dfn-service-worker-73">(4)</a> <a href="#ref-for-dfn-service-worker-74">(5)</a>
+    <li><a href="#ref-for-dfn-service-worker-75">6.2. Content Security Policy</a>
+    <li><a href="#ref-for-dfn-service-worker-76">6.3.1. Origin restriction</a> <a href="#ref-for-dfn-service-worker-77">(2)</a> <a href="#ref-for-dfn-service-worker-78">(3)</a>
+    <li><a href="#ref-for-dfn-service-worker-79">6.4. Cross-Origin Resources and CORS</a>
+    <li><a href="#ref-for-dfn-service-worker-80">6.5. Implementer Concerns</a> <a href="#ref-for-dfn-service-worker-81">(2)</a> <a href="#ref-for-dfn-service-worker-82">(3)</a>
+    <li><a href="#ref-for-dfn-service-worker-83">6.6. Privacy</a> <a href="#ref-for-dfn-service-worker-84">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-85">7. Extensibility</a>
+    <li><a href="#ref-for-dfn-service-worker-86">7.4. Request Functional Event Dispatch</a>
+    <li><a href="#ref-for-dfn-service-worker-87">Update</a>
+    <li><a href="#ref-for-dfn-service-worker-88">Install</a> <a href="#ref-for-dfn-service-worker-89">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-90">Run Service Worker</a>
+    <li><a href="#ref-for-dfn-service-worker-91">Terminate Service Worker</a>
+    <li><a href="#ref-for-dfn-service-worker-92">Extend Service Worker Lifetime</a>
+    <li><a href="#ref-for-dfn-service-worker-93">Handle Fetch</a>
+    <li><a href="#ref-for-dfn-service-worker-94">Update Registration State</a>
+    <li><a href="#ref-for-dfn-service-worker-95">Update Worker State</a> <a href="#ref-for-dfn-service-worker-96">(2)</a> <a href="#ref-for-dfn-service-worker-97">(3)</a> <a href="#ref-for-dfn-service-worker-98">(4)</a> <a href="#ref-for-dfn-service-worker-99">(5)</a> <a href="#ref-for-dfn-service-worker-100">(6)</a> <a href="#ref-for-dfn-service-worker-101">(7)</a> <a href="#ref-for-dfn-service-worker-102">(8)</a> <a href="#ref-for-dfn-service-worker-103">(9)</a> <a href="#ref-for-dfn-service-worker-104">(10)</a>
+    <li><a href="#ref-for-dfn-service-worker-105">Get Newest Worker</a>
+    <li><a href="#ref-for-dfn-service-worker-106">Service Worker Script Request</a> <a href="#ref-for-dfn-service-worker-107">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-108">Service Worker Script Response</a>
+    <li><a href="#ref-for-dfn-service-worker-109">Syntax</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-state">
@@ -6837,10 +6823,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-state-1">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-state-2">(2)</a> <a href="#ref-for-dfn-state-3">(3)</a>
     <li><a href="#ref-for-dfn-state-4">3.1. ServiceWorker</a>
     <li><a href="#ref-for-dfn-state-5">3.2.5. update()</a>
-    <li><a href="#ref-for-dfn-state-6">4.1.3. skipWaiting()</a>
-    <li><a href="#ref-for-dfn-state-7">Handle Fetch</a> <a href="#ref-for-dfn-state-8">(2)</a>
-    <li><a href="#ref-for-dfn-state-9">Handle Functional Event</a> <a href="#ref-for-dfn-state-10">(2)</a>
-    <li><a href="#ref-for-dfn-state-11">Update Worker State</a> <a href="#ref-for-dfn-state-12">(2)</a> <a href="#ref-for-dfn-state-13">(3)</a>
+    <li><a href="#ref-for-dfn-state-6">Handle Fetch</a> <a href="#ref-for-dfn-state-7">(2)</a>
+    <li><a href="#ref-for-dfn-state-8">Handle Functional Event</a> <a href="#ref-for-dfn-state-9">(2)</a>
+    <li><a href="#ref-for-dfn-state-10">Update Worker State</a> <a href="#ref-for-dfn-state-11">(2)</a> <a href="#ref-for-dfn-state-12">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-script-url">
@@ -6870,13 +6855,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-containing-service-worker-registration-2">2.4. Selection and Use</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-3">3.2.6. unregister()</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-4">4.1.2. registration</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-5">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-containing-service-worker-registration-6">(2)</a> <a href="#ref-for-dfn-containing-service-worker-registration-7">(3)</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-8">4.3.4. claim()</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-9">4.7. Events</a> <a href="#ref-for-dfn-containing-service-worker-registration-10">(2)</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-11">Install</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-12">Run Service Worker</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-13">Terminate Service Worker</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-14">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration-15">(2)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-5">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-containing-service-worker-registration-6">(2)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-7">4.3.4. claim()</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-8">4.7. Events</a> <a href="#ref-for-dfn-containing-service-worker-registration-9">(2)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-10">Install</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-11">Run Service Worker</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-12">Terminate Service Worker</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-13">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration-14">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-service-worker-id">
@@ -6960,7 +6945,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-skip-waiting-flag-1">3.5. Events</a>
     <li><a href="#ref-for-dfn-skip-waiting-flag-2">4.1.3. skipWaiting()</a>
-    <li><a href="#ref-for-dfn-skip-waiting-flag-3">Install</a> <a href="#ref-for-dfn-skip-waiting-flag-4">(2)</a> <a href="#ref-for-dfn-skip-waiting-flag-5">(3)</a>
+    <li><a href="#ref-for-dfn-skip-waiting-flag-3">Install</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-imported-scripts-updated-flag">
@@ -7053,14 +7038,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-waiting-worker-2">2.6. User Agent Shutdown</a>
     <li><a href="#ref-for-dfn-waiting-worker-3">4.1.3. skipWaiting()</a>
     <li><a href="#ref-for-dfn-waiting-worker-4">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-waiting-worker-5">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-6">Install</a> <a href="#ref-for-dfn-waiting-worker-7">(2)</a> <a href="#ref-for-dfn-waiting-worker-8">(3)</a> <a href="#ref-for-dfn-waiting-worker-9">(4)</a> <a href="#ref-for-dfn-waiting-worker-10">(5)</a> <a href="#ref-for-dfn-waiting-worker-11">(6)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-12">Activate</a> <a href="#ref-for-dfn-waiting-worker-13">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-14">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-dfn-waiting-worker-15">Handle User Agent Shutdown</a>
-    <li><a href="#ref-for-dfn-waiting-worker-16">Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-17">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-18">Update Registration State</a> <a href="#ref-for-dfn-waiting-worker-19">(2)</a> <a href="#ref-for-dfn-waiting-worker-20">(3)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-21">Update Worker State</a>
-    <li><a href="#ref-for-dfn-waiting-worker-22">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker-23">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-6">Install</a> <a href="#ref-for-dfn-waiting-worker-7">(2)</a> <a href="#ref-for-dfn-waiting-worker-8">(3)</a> <a href="#ref-for-dfn-waiting-worker-9">(4)</a> <a href="#ref-for-dfn-waiting-worker-10">(5)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-11">Activate</a> <a href="#ref-for-dfn-waiting-worker-12">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-13">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-dfn-waiting-worker-14">Handle User Agent Shutdown</a>
+    <li><a href="#ref-for-dfn-waiting-worker-15">Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-16">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-17">Update Registration State</a> <a href="#ref-for-dfn-waiting-worker-18">(2)</a> <a href="#ref-for-dfn-waiting-worker-19">(3)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-20">Update Worker State</a>
+    <li><a href="#ref-for-dfn-waiting-worker-21">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker-22">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-active-worker">
@@ -8456,8 +8441,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-finish-job-1">Register</a> <a href="#ref-for-finish-job-2">(2)</a> <a href="#ref-for-finish-job-3">(3)</a> <a href="#ref-for-finish-job-4">(4)</a>
     <li><a href="#ref-for-finish-job-5">Update</a> <a href="#ref-for-finish-job-6">(2)</a> <a href="#ref-for-finish-job-7">(3)</a> <a href="#ref-for-finish-job-8">(4)</a> <a href="#ref-for-finish-job-9">(5)</a>
-    <li><a href="#ref-for-finish-job-10">Install</a> <a href="#ref-for-finish-job-11">(2)</a> <a href="#ref-for-finish-job-12">(3)</a>
-    <li><a href="#ref-for-finish-job-13">Unregister</a> <a href="#ref-for-finish-job-14">(2)</a> <a href="#ref-for-finish-job-15">(3)</a>
+    <li><a href="#ref-for-finish-job-10">Install</a> <a href="#ref-for-finish-job-11">(2)</a>
+    <li><a href="#ref-for-finish-job-12">Unregister</a> <a href="#ref-for-finish-job-13">(2)</a> <a href="#ref-for-finish-job-14">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="resolve-job-promise">
@@ -8513,12 +8498,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-activate-1">3.4.2. ready</a>
     <li><a href="#ref-for-activate-2">3.5. Events</a> <a href="#ref-for-activate-3">(2)</a>
-    <li><a href="#ref-for-activate-4">4.1.3. skipWaiting()</a>
-    <li><a href="#ref-for-activate-5">4.4. ExtendableEvent</a> <a href="#ref-for-activate-6">(2)</a>
-    <li><a href="#ref-for-activate-7">4.7. Events</a>
-    <li><a href="#ref-for-activate-8">Install</a> <a href="#ref-for-activate-9">(2)</a>
-    <li><a href="#ref-for-activate-10">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-activate-11">Handle User Agent Shutdown</a>
+    <li><a href="#ref-for-activate-4">4.4. ExtendableEvent</a> <a href="#ref-for-activate-5">(2)</a>
+    <li><a href="#ref-for-activate-6">4.7. Events</a>
+    <li><a href="#ref-for-activate-7">Install</a>
+    <li><a href="#ref-for-activate-8">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-activate-9">Handle User Agent Shutdown</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="run-service-worker">


### PR DESCRIPTION
Before this, skipWaiting() promises when called multiple times on a
waiting worker had different behaviors among each other where the winner
waits unitl the Activate is complete while others don't. This makes the
behavior consistent by making the Activate be called only once. To
achieve that, this removes the steps in skipWaiting() that call the
Activate on a waiting worker (so promise resolves right away after
setting the skip waiting flag) and simplifies the call sites of the
Activate in the Install algorithm.

Related issue: #1015.