### PR TITLE
Fetch service worker scripts with "no-cache" by default

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -187,8 +187,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A [=/service worker registration=] has an associated <dfn export id="dfn-scope-url">scope url</dfn> (a [=/URL=]).
 
-    A [=/service worker registration=] has an associated <dfn export id="dfn-registration-script-url">registering script url</dfn> (a [=/URL=]).
-
     A [=/service worker registration=] has an associated <dfn export id="dfn-installing-worker">installing worker</dfn> (a [=/service worker=] or null) whose [=service worker/state=] is *installing*. It is initially set to null.
 
     A [=/service worker registration=] has an associated <dfn export id="dfn-waiting-worker">waiting worker</dfn> (a [=/service worker=] or null) whose [=service worker/state=] is *installed*. It is initially set to null.
@@ -196,6 +194,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     A [=/service worker registration=] has an associated <dfn export id="dfn-active-worker">active worker</dfn> (a [=/service worker=] or null) whose [=service worker/state=] is either *activating* or *activated*. It is initially set to null.
 
     A [=/service worker registration=] has an associated <dfn export id="dfn-last-update-check-time">last update check time</dfn>. It is initially set to null.
+
+    A [=/service worker registration=] has an associated <dfn export id="dfn-use-cache">use cache</dfn> (a boolean). It is initially set to false.
 
     A [=/service worker registration=] has an associated <dfn export id="dfn-uninstalling-flag">uninstalling flag</dfn>. It is initially unset.
 
@@ -391,6 +391,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         readonly attribute ServiceWorker? active;
 
         readonly attribute USVString scope;
+        readonly attribute boolean useCache;
 
         [NewObject] Promise&lt;void&gt; update();
         [NewObject] Promise&lt;boolean&gt; unregister();
@@ -434,6 +435,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       <div class="example">
         In the example in [[#service-worker-url]], the value of <code>registration.scope</code>, obtained from <code>navigator.serviceWorker.ready.then(registration => console.log(registration.scope))</code> for example, will be "<code>https://example.com/</code>".
       </div>
+    </section>
+
+    <section algorithm="service-worker-registration-usecache">
+      <h4 id="service-worker-registration-usecache">{{ServiceWorkerRegistration/useCache}}</h4>
+
+      The <dfn attribute for="ServiceWorkerRegistration"><code>useCache</code></dfn> attribute *must* return [=ServiceWorkerRegistration/service worker registration=]'s [=service worker registration/use cache=].
     </section>
 
     <section algorithm="service-worker-registration-update">
@@ -529,6 +536,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       dictionary RegistrationOptions {
         USVString scope;
         WorkerType type = "classic";
+        boolean useCache = false;
       };
     </pre>
 
@@ -590,7 +598,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Let |scriptURL| be the result of <a lt="URL parser">parsing</a> |scriptURL| with the <a>context object</a>'s <a>relevant settings object</a>'s <a>API base URL</a>.
         1. Let |scopeURL| be null.
         1. If |options|.{{RegistrationOptions/scope}} is <a>present</a>, set |scopeURL| to the result of <a lt="URL parser">parsing</a> |options|.{{RegistrationOptions/scope}} with the <a>context object</a>'s <a>relevant settings object</a>'s <a>API base URL</a>.
-        1. Invoke [=Start Register=] with |scopeURL|, |scriptURL|, |p|, |client|, |client|'s <a>creation URL</a> and |options|.{{RegistrationOptions/type}}.
+        1. Invoke [=Start Register=] with |scopeURL|, |scriptURL|, |p|, |client|, |client|'s <a>creation URL</a>, |options|.{{RegistrationOptions/type}}, and |options|.{{RegistrationOptions/useCache}}.
         1. Return |p|.
     </section>
 
@@ -1636,7 +1644,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If the "<code>scope</code>" <a>target attribute</a> of the <code>Link</code> header is present, set |scopeURL| to the result of <a lt="URL parser">parsing</a> the "<code>scope</code>" <a>target attribute</a> with |scriptURL|.
       1. Let |workerType| be the "<code>workertype</code>" <a>target attribute</a> of the <code>Link</code> header, or "<code>classic</code>" if no such attribute is present.
       1. If |workerType| is not a valid {{WorkerType}} value, abort these steps.
-      1. Invoke [=Start Register=] with |scopeURL|, |scriptURL|, a new <a>promise</a>, null, |contextURL| and |workerType|.
+      1. Let |useCache| be the "<code>usecache</code>" <a>target attribute</a> of the <code>Link</code> header, or false if no such attribute is present.
+      1. If |useCache| is not a valid boolean value, abort these steps.
+      1. Invoke [=Start Register=] with |scopeURL|, |scriptURL|, a new <a>promise</a>, null, |contextURL|, |workerType|, and |useCache|.
 
     When a <a>serviceworker link</a>'s <{link}> element is <a>inserted into a document</a>, a <a>serviceworker link</a> is created on a <{link}> element that is already <a>in a document tree</a>, or the <{link/href}> or <{link/scope}> attributes of the <{link}> element of a <a>serviceworker link</a> is changed, the user agent *should* run these steps:
 
@@ -1648,8 +1658,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If the <{link/scope}> attribute is present, set |scopeURL| to the result of <a lt="URL parser">parsing</a> the <{link/scope}> attribute with the <{link}> element's <a>node document</a>'s <a>document base URL</a>.
       1. Let |workerType| be the <{link/workertype}> attribute, or "<code>classic</code>" if the <{link/workertype}> attribute is omitted.
       1. If |workerType| is not a valid {{WorkerType}} value, <a>queue a task</a> to <a>fire an event</a> named <code>error</code> at the <{link}> element, and abort these steps.
+      1. Let |useCache| be the <{link/usecache}> attribute, or false if the <{link/usecache}> attribute is omitted.
+      1. If |useCache| is not a valid boolean value, <a>queue a task</a> to <a>fire an event</a> named <code>error</code> at the <{link}> element, and abort these steps.
       1. Let |promise| be a new <a>promise</a>.
-      1. Invoke [=Start Register=] with |scopeURL|, |scriptURL|, |promise|, |client|, |client|'s <a>creation URL</a> and |workerType|.
+      1. Invoke [=Start Register=] with |scopeURL|, |scriptURL|, |promise|, |client|, |client|'s <a>creation URL</a>, |workerType|, and |useCache|.
       1. Run the following substeps <a>in parallel</a>:
           1. Wait until |promise| settles.
           1. If |promise| rejected, <a>queue a task</a> to <a>fire an event</a> named <code>error</code> at the <{link}> element.
@@ -1686,12 +1698,15 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       partial interface HTMLLinkElement {
         [CEReactions] attribute USVString scope;
         [CEReactions] attribute WorkerType workerType;
+        [CEReactions] attribute boolean useCache;
       };
     </pre>
 
     The <dfn attribute for="HTMLLinkElement" id="link-scope-attribute">scope</dfn> IDL attribute must <a>reflect</a> the element's <dfn element-attr for="link">scope</dfn> content attribute.
 
     The <dfn attribute for="HTMLLinkElement" id="link-workertype-attribute">workerType</dfn> IDL attribute must <a>reflect</a> the element's <dfn element-attr for="link">workertype</dfn> content attribute.
+
+    The <dfn attribute for="HTMLLinkElement" id="link-usecache-attribute">useCache</dfn> IDL attribute must <a>reflect</a> the element's <dfn element-attr for="link">usecache</dfn> content attribute.
   </section>
 </section>
 
@@ -2247,6 +2262,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A <a>job</a> has a <dfn id="dfn-job-worker-type">worker type</dfn> ("<code>classic</code>" or "<code>module</code>").
 
+    A <a>job</a> has a <dfn id="dfn-job-use-cache">use cache</dfn> (a boolean).
+
     A <a>job</a> has a <dfn id="dfn-job-client">client</dfn> (a [=/service worker client=]). It is initially null.
 
     A <a>job</a> has a <dfn>referrer</dfn> (a [=/URL=] or null).
@@ -2312,7 +2329,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: none
 
-      1. <a>Assert</a>: the <a>job queue</a> is not empty.
+      1. Assert: the <a>job queue</a> is not empty.
       1. <a>Queue a task</a> to run these steps:
           1. Let |job| be the element in the front of the <a>job queue</a>.
           1. If |job|'s <a>job type</a> is *register*, run <a>Register</a> with |job| <a>in parallel</a>.
@@ -2331,7 +2348,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: none
 
-      1. <a>Assert</a>: the top element in the <a>job queue</a> is |job|.
+      1. Assert: the top element in the <a>job queue</a> is |job|.
       1. Pop the top element from the <a>job queue</a>.
       1. If the <a>job queue</a> is not empty, invoke <a>Run Job</a> with the top element of the <a>job queue</a>.
   </section>
@@ -2374,6 +2391,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: |client|, a [=/service worker client=]
       :: |referrer|, a [=/URL=]
       :: |workerType|, a <a>worker type</a>
+      :: |useCache|, a boolean
       : Output
       :: none
 
@@ -2388,7 +2406,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If |scopeURL|'s [=url/scheme=] is not one of "<code>http</code>" and "<code>https</code>", reject |promise| with a <code>TypeError</code> and abort these steps.
       1. If any of the strings in |scopeURL|'s [=url/path=] contains either <a>ASCII case-insensitive</a> "<code>%2f</code>" or <a>ASCII case-insensitive</a> "<code>%5c</code>", reject |promise| with a <code>TypeError</code> and abort these steps.
       1. Let |job| be the result of running [=Create Job=] with *register*, |scopeURL|, |scriptURL|, |promise|, and |client|.
-      1. Set |job|'s <a>worker type</a> to |workerType|.
+      1. Set |job|'s [=job/worker type=] to |workerType|.
+      1. Set |job|'s [=job/use cache=] to |useCache|.
       1. Set |job|'s [=job/referrer=] to |referrer|.
       1. Invoke [=Schedule Job=] with |job|.
   </section>
@@ -2414,11 +2433,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If |registration| is not null, then:
           1. If |registration|'s <a>uninstalling flag</a> is set, unset it.
           1. Let |newestWorker| be the result of running the <a>Get Newest Worker</a> algorithm passing |registration| as the argument.
-          1. If |newestWorker| is not null and |job|'s [=job/script url=] [=url/equals=] |newestWorker|'s [=service worker/script url=] with the *exclude fragments flag* set, then:
+          1. If |newestWorker| is not null, |job|'s [=job/script url=] [=url/equals=] |newestWorker|'s [=service worker/script url=] with the *exclude fragments flag* set, and |job|'s [=job/use cache=]'s value equals |registration|'s [=service worker registration/use cache=]'s value, then:
               1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Else:
-          1. Invoke <a>Set Registration</a> algorithm passing |job|'s [=job/scope url=] as its argument.
+          1. Invoke <a>Set Registration</a> algorithm with |job|'s [=job/scope url=] and |job|'s [=job/use cache=].
       1. Invoke <a>Update</a> algorithm passing |job| as the argument.
   </section>
 
@@ -2454,10 +2473,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             Note: See the definition of the Service-Worker header in Appendix B: Extended HTTP headers.
 
           1. Set |request|'s <a>skip-service-worker flag</a> and |request|'s [=request/redirect mode=] to "<code>error</code>".
-          1. If |newestWorker| is not null and |registration|'s <a>last update check time</a> is not null, then:
-              1. If the time difference in seconds calculated by the current time minus |registration|'s <a>last update check time</a> is greater than 86400, or *force bypass cache flag* is set, set |request|'s [=request/cache mode=] to "<code>reload</code>".
+          1. Set |request|'s [=request/cache mode=] to "<code>no-cache</code>" if any of the following are true:
+              * |registration|'s [=service worker registration/use cache=] is false.
+              * |job|'s [=force bypass cache flag=] is set.
+              * |newestWorker| is not null, and |registration|'s [=last update check time=] is not null and the time difference in seconds calculated by the current time minus |registration|’s [=last update check time=] is greater than 86400.
 
-              Note: Even if the cache mode is not set to "reload", the user agent obeys Cache-Control header's max-age value in the network layer to determine if it should bypass the browser cache.
+              Note: Even if the cache mode is not set to "<code>no-cache</code>", the user agent obeys Cache-Control header's max-age value in the network layer to determine if it should bypass the browser cache.
 
           1. [=/Fetch=] |request|, and asynchronously wait to run the remaining steps as part of fetch's <a>process response</a> for the [=/response=] |response|.
           1. <a>Extract a MIME type</a> from the |response|'s [=response/header list=]. If this MIME type (ignoring parameters) is not one of <code>text/javascript</code>, <code>application/x-javascript</code>, and <code>application/javascript</code>, then:
@@ -2554,7 +2575,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Let |redundantWorker| be null.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and |worker| as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>installing worker</a> and *installing* as the arguments.
-      1. <a>Assert</a>: |job|'s [=job/job promise=] is not null.
+      1. Assert: |job|'s [=job/job promise=] is not null.
       1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
       1. <a>Queue a task</a> to <a>fire an event</a> named <code>updatefound</code> at all the {{ServiceWorkerRegistration}} objects for all the [=/service worker clients=] whose <a>creation URL</a> <a lt="Match Service Worker Registration">matches</a> |registration|'s [=service worker registration/scope url=] and all the [=/service workers=] whose <a>containing service worker registration</a> is |registration|.
       1. Let |installingWorker| be |registration|'s <a>installing worker</a>.
@@ -2904,8 +2925,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: None
 
-      1. <a>Assert</a>: <a>scope to registration map</a> contains a value equal to |registration|.
-      1. <a>Assert</a>: |registration|'s <a>active worker</a> is not null.
+      1. Assert: <a>scope to registration map</a> contains a value equal to |registration|.
+      1. Assert: |registration|'s <a>active worker</a> is not null.
       1. Let |activeWorker| be |registration|'s <a>active worker</a>.
       1. If |activeWorker|'s <a>set of event types to handle</a> does not contain |event|'s {{Event/type}}, then:
           1. Return and continue running these steps <a>in parallel</a>.
@@ -2989,12 +3010,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       : Input
       :: |scope|, a [=/URL=]
+      :: |useCache|, a boolean
       : Output
       :: |registration|, a [=/service worker registration=]
 
       1. Run the following steps atomically.
       1. Let |scopeString| be <a lt="URL serializer">serialized</a> |scope| with the *exclude fragment flag* set.
-      1. Let |registration| be a new [=/service worker registration=] whose [=service worker registration/scope url=] is set to |scope|.
+      1. Let |registration| be a new [=/service worker registration=] whose [=service worker registration/scope url=] is set to |scope| and [=service worker registration/use cache=] is set to |useCache|.
       1. [=map/Set=] <a>scope to registration map</a>[|scopeString|] to |registration|.
       1. Return |registration|.
   </section>
@@ -3110,7 +3132,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: None
 
-      1. <a>Assert</a>: |client| is not null.
+      1. Assert: |client| is not null.
       1. If |client| is a type of <a>environment settings object</a>, <a>queue a task</a> to <a>fire an event</a> named <code>controllerchange</code> at the {{ServiceWorkerContainer}} object |client| is [=ServiceWorkerContainer/service worker client|associated=] with.
 
     The <a>task</a> *must* use |client|'s <a>responsible event loop</a> and the <a>DOM manipulation task source</a>.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2527,7 +2527,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
           Else, continue the rest of these steps after the algorithm's asynchronous completion, with |script| being the asynchronous completion value.
 
-      1. If |newestWorker| is not null, |newestWorker|'s [=service worker/script url=] [=url/equals=] |job|'s [=job/script url=] with the *exclude fragments flag* set, and |script|'s [=source text=] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=source text=], if |script| is a [=classic script=], and |script|'s [=module record=]'s \[[ECMAScriptCode]] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=module record=]'s \[[ECMAScriptCode]] otherwise, then:
+      1. If |newestWorker| is not null, |newestWorker|'s [=service worker/script url=] [=url/equals=] |job|'s [=job/script url=] with the *exclude fragments flag* set, and |script|'s [=source text=] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=source text=], if |script| is a [=classic script=], and |script|'s [=module script/module record=]'s \[[ECMAScriptCode]] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=module script/module record=]'s \[[ECMAScriptCode]] otherwise, then:
           1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Else:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -796,7 +796,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       };
     </pre>
 
-    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]).
+    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]). A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for importscripts flag</dfn>. It is initially unset.
 
     Note: {{ServiceWorkerGlobalScope}} object provides generic, event-driven, time-limited script execution contexts that run at an origin. Once successfully <a>registered</a>, a [=/service worker=] is started, kept alive and killed by their relationship to events, not [=/service worker clients=]. Any type of synchronous requests must not be initiated inside of a [=/service worker=].
 
@@ -2151,7 +2151,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
         1. Let |serviceWorker| be |request|'s [=request/client=]'s [=environment settings object/global object=]'s [=ServiceWorkerGlobalScope/service worker=].
         1. If |serviceWorker|'s <a>imported scripts updated flag</a> is unset, then:
+            1. Let |registration| be |serviceWorker|'s [=containing service worker registration=].
+            1. Set |request|'s [=request/cache mode=] to "<code>no-cache</code>" if any of the following are true:
+                * |registration|'s [=service worker registration/use cache=] is false.
+                * The [=current global object=]'s [=force bypass cache for importscripts flag=] is set.
+                * |registration|'s [=last update check time=] is not null and the time difference in seconds calculated by the current time minus |registration|’s [=last update check time=] is greater than 86400.
             1. Let |response| be the result of <a lt="fetch">fetching</a> |request|.
+            1. If |response|’s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|’s [=service worker registration/last update check time=] to the current time.
             1. If |response|'s <a>unsafe response</a>'s [=response/type=] is not "<code>error</code>", and |response|'s [=response/status=] is an <a>ok status</a>, then:
                 1. [=map/Set=] <a>script resource map</a>[|request|'s [=request/url=]] to |response|
             1. Return |response|.
@@ -2272,7 +2278,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A <a>job</a> has a <dfn id="dfn-job-list-of-equivalent-jobs">list of equivalent jobs</dfn> (a list of <a>jobs</a>). It is initially the empty list.
 
-    A <a>job</a> has a <dfn id="dfn-job-force-bypass-cache-flag">force bypass cache flag</dfn> It is initially unset.
+    A <a>job</a> has a <dfn id="dfn-job-force-bypass-cache-flag">force bypass cache flag</dfn>. It is initially unset.
   </div>
 
 
@@ -2530,7 +2536,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Set |worker|'s [=service worker/script url=] to |job|'s [=job/script url=], |worker|'s <a>script resource</a> to |script|, and |worker|'s <a>type</a> to |job|'s <a>worker type</a>.
           1. Set |worker|'s <a>script resource</a>'s <a>HTTPS state</a> to |httpsState|.
           1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
-          1. Invoke <a>Run Service Worker</a> algorithm with |worker| as the argument.
+          1. Invoke <a>Run Service Worker</a> algorithm given |worker|, and with the *force bypass cache for importscripts flag* set if |job|'s [=job/force bypass cache flag=] is set.
           1. If an uncaught runtime script error occurs during the above step, then:
               1. Invoke <a>Reject Job Promise</a> with |job| and a <code>TypeError</code>.
               1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
@@ -2579,7 +2585,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
       1. <a>Queue a task</a> to <a>fire an event</a> named <code>updatefound</code> at all the {{ServiceWorkerRegistration}} objects for all the [=/service worker clients=] whose <a>creation URL</a> <a lt="Match Service Worker Registration">matches</a> |registration|'s [=service worker registration/scope url=] and all the [=/service workers=] whose <a>containing service worker registration</a> is |registration|.
       1. Let |installingWorker| be |registration|'s <a>installing worker</a>.
-      1. Invoke <a>Run Service Worker</a> algorithm with |installingWorker| as the argument.
+      1. Invoke <a>Run Service Worker</a> algorithm given |installingWorker|, and with the *force bypass cache for importscripts flag* set if |job|'s [=job/force bypass cache flag=] is set.
       1. <a>Queue a task</a> |task| to run the following substeps:
           1. Let |e| be the result of <a>creating an event</a> with {{InstallEvent}}.
           1. Initialize |e|’s {{Event/type}} attribute to {{install!!event}}.
@@ -2662,6 +2668,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       : Input
       :: |serviceWorker|, a [=/service worker=]
+      :: *force bypass cache for importscripts flag*, an optional flag unset by default
       : Output
       :: None
 
@@ -2699,6 +2706,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Set |workerGlobalScope|'s [=WorkerGlobalScope/HTTPS state=] to |serviceWorker|'s <a>script resource</a>'s <a>HTTPS state</a>.
       1. Set |workerGlobalScope|'s [=WorkerGlobalScope/referrer policy=] to |serviceWorker|'s <a>script resource</a>'s [=script resource/referrer policy=].
       1. Set |workerGlobalScope|'s [=WorkerGlobalScope/type=] to |serviceWorker|'s <a>type</a>.
+      1. Set |workerGlobalScope|'s [=ServiceWorkerGlobalScope/force bypass cache for importscripts flag=] if its *force bypass cache for importscripts flag* is set.
       1. Create a new {{WorkerLocation}} object and associate it with |workerGlobalScope|.
       1. If |serviceWorker| is an <a>active worker</a>, and there are any <a>tasks</a> queued in |serviceWorker|'s <a>containing service worker registration</a>'s [=service worker registration/task queues=], <a lt="queue a task">queue</a> them to |serviceWorker|'s <a>event loop</a>'s [=/task queues=] in the same order using their original <a>task sources</a>.
       1. If |script| is a <a>classic script</a>, then <a lt="run a classic script">run the classic script</a> |script|. Otherwise, it is a <a>module script</a>; <a lt="run a module script">run the module script</a> |script|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2521,7 +2521,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
           Else, continue the rest of these steps after the algorithm's asynchronous completion, with |script| being the asynchronous completion value.
 
-      1. If |newestWorker| is not null, |newestWorker|'s [=service worker/script url=] [=url/equals=] |job|'s [=job/script url=] with the *exclude fragments flag* set, and |script| is a byte-for-byte match with |newestWorker|'s <a>script resource</a>, then:
+      1. If |newestWorker| is not null, |newestWorker|'s [=service worker/script url=] [=url/equals=] |job|'s [=job/script url=] with the *exclude fragments flag* set, and |script|'s [=source text=] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=source text=], if |script| is a [=classic script=], and |script|'s [=module record=]'s \[[ECMAScriptCode]] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=module record=]'s \[[ECMAScriptCode]] otherwise, then:
           1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Else:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 18bde035bc0169bb31c49099bf3e6ec57ff9ec7f" name="generator">
+  <meta content="Bikeshed version 0feafaae1a97b66d9da46b325858f9805ac01fb2" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-06">6 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-08">8 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2346,8 +2346,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dom-serviceworkerglobalscope-onmessage" id="ref-for-dom-serviceworkerglobalscope-onmessage-1">onmessage</a>; // event.source of the message events is Client object
 };
 </pre>
-     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-6">ServiceWorkerGlobalScope</a></code> object represents the global execution context of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-53">service worker</a>. A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-7">ServiceWorkerGlobalScope</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="dfn" data-noexport="" id="serviceworkerglobalscope-service-worker">service worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-54">service worker</a>).</p>
-     <p class="note" role="note">Note: <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-8">ServiceWorkerGlobalScope</a></code> object provides generic, event-driven, time-limited script execution contexts that run at an origin. Once successfully <a data-link-type="dfn" href="#register" id="ref-for-register-2">registered</a>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-55">service worker</a> is started, kept alive and killed by their relationship to events, not <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-25">service worker clients</a>. Any type of synchronous requests must not be initiated inside of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-56">service worker</a>.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-6">ServiceWorkerGlobalScope</a></code> object represents the global execution context of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-53">service worker</a>. A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-7">ServiceWorkerGlobalScope</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="dfn" data-noexport="" id="serviceworkerglobalscope-service-worker">service worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-54">service worker</a>). A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-8">ServiceWorkerGlobalScope</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="dfn" data-noexport="" id="serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">force bypass cache for importscripts flag</dfn>. It is initially unset.</p>
+     <p class="note" role="note">Note: <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-9">ServiceWorkerGlobalScope</a></code> object provides generic, event-driven, time-limited script execution contexts that run at an origin. Once successfully <a data-link-type="dfn" href="#register" id="ref-for-register-2">registered</a>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-55">service worker</a> is started, kept alive and killed by their relationship to events, not <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-25">service worker clients</a>. Any type of synchronous requests must not be initiated inside of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-56">service worker</a>.</p>
      <section>
       <h4 class="heading settled" data-level="4.1.1" id="service-worker-global-scope-clients"><span class="secno">4.1.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-clients" id="ref-for-dom-serviceworkerglobalscope-clients-2">clients</a></code></span><a class="self-link" href="#service-worker-global-scope-clients"></a></h4>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export="" id="dom-serviceworkerglobalscope-clients"><code>clients</code></dfn> attribute <em>must</em> return the <code class="idl"><a data-link-type="idl" href="#clients" id="ref-for-clients-2">Clients</a></code> object that is associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
@@ -2377,7 +2377,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </section>
      <section>
       <h4 class="heading settled" data-level="4.1.4" id="service-worker-global-scope-event-handlers"><span class="secno">4.1.4. </span><span class="content">Event handlers</span><a class="self-link" href="#service-worker-global-scope-event-handlers"></a></h4>
-      <p>The following are the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handlers</a> (and their corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event types</a>) that <em>must</em> be supported, as <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">event handler IDL attributes</a>, by all objects implementing the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-9">ServiceWorkerGlobalScope</a></code> interface:</p>
+      <p>The following are the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handlers</a> (and their corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event types</a>) that <em>must</em> be supported, as <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">event handler IDL attributes</a>, by all objects implementing the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-10">ServiceWorkerGlobalScope</a></code> interface:</p>
       <table class="data">
        <thead>
         <tr>
@@ -2632,7 +2632,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <dfn class="s dfn-paneled idl-code" data-dfn-for="ClientType" data-dfn-type="enum-value" data-export="" data-lt="&quot;all&quot;|all" id="dom-clienttype-all">"all"</dfn>
 };
 </pre>
-     <p>The user agent <em>must</em> create a <code class="idl"><a data-link-type="idl" href="#clients" id="ref-for-clients-4">Clients</a></code> object when a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-10">ServiceWorkerGlobalScope</a></code> object is created and associate it with that object.</p>
+     <p>The user agent <em>must</em> create a <code class="idl"><a data-link-type="idl" href="#clients" id="ref-for-clients-4">Clients</a></code> object when a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-11">ServiceWorkerGlobalScope</a></code> object is created and associate it with that object.</p>
      <section class="algorithm" data-algorithm="clients-get">
       <h4 class="heading settled" data-level="4.3.1" id="clients-get"><span class="secno">4.3.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-clients-get" id="ref-for-dom-clients-get-2">get(id)</a></code></span><a class="self-link" href="#clients-get"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Clients" data-dfn-type="method" data-export="" id="dom-clients-get"><code>get(<var>id</var>)</code></dfn> method <em>must</em> run these steps:</p>
@@ -2972,7 +2972,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> <var>f</var> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-4">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-5">installing worker</a> as <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-4">waiting worker</a>) until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-5">extend lifetime promises</a> resolve successfully. (See step 11.3.1 of <a data-link-type="dfn" href="#install" id="ref-for-install-3">Install</a> algorithm.) If <var>f</var> rejects, the installation fails. This is primarily used to ensure that a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-64">service worker</a> is not considered <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-5">waiting worker</a>) until all of the core caches it depends on are populated.</p>
       <li data-md="">
-       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-6">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-17">active worker</a> as <em>activated</em> until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-7">extend lifetime promises</a> settle. (See step 12.3 of <a data-link-type="dfn" href="#activate" id="ref-for-activate-5">Activate</a> algorithm.) This is primarily used to ensure that any <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-2">functional events</a> are not dispatched to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-11">ServiceWorkerGlobalScope</a></code> object that represents the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service worker</a> until it upgrades database schemas and deletes the outdated cache entries.</p>
+       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-6">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-17">active worker</a> as <em>activated</em> until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-7">extend lifetime promises</a> settle. (See step 12.3 of <a data-link-type="dfn" href="#activate" id="ref-for-activate-5">Activate</a> algorithm.) This is primarily used to ensure that any <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-2">functional events</a> are not dispatched to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-12">ServiceWorkerGlobalScope</a></code> object that represents the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service worker</a> until it upgrades database schemas and deletes the outdated cache entries.</p>
      </ul>
     </section>
     <section>
@@ -3443,7 +3443,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="4.9" id="execution-context-events"><span class="secno">4.9. </span><span class="content">Events</span><a class="self-link" href="#execution-context-events"></a></h3>
-     <p>The following events are dispatched on <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-12">ServiceWorkerGlobalScope</a></code> object:</p>
+     <p>The following events are dispatched on <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-13">ServiceWorkerGlobalScope</a></code> object:</p>
      <table class="data">
       <thead>
        <tr>
@@ -4298,7 +4298,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </section>
      <section>
       <h4 class="heading settled" data-level="7.3.2" id="importscripts"><span class="secno">7.3.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-importscripts">importScripts(urls)</a></code></span><a class="self-link" href="#importscripts"></a></h4>
-      <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="method" data-export="" id="importscripts-method"><code>importScripts(<var>urls</var>)</code></dfn> method is called on a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-13">ServiceWorkerGlobalScope</a></code> object, the user agent <em>must</em> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">import scripts into worker global scope</a>, given this <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-14">ServiceWorkerGlobalScope</a></code> object and <var>urls</var>, and with the following steps to <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a> given the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> <var>request</var>:</p>
+      <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="method" data-export="" id="importscripts-method"><code>importScripts(<var>urls</var>)</code></dfn> method is called on a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-14">ServiceWorkerGlobalScope</a></code> object, the user agent <em>must</em> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">import scripts into worker global scope</a>, given this <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-15">ServiceWorkerGlobalScope</a></code> object and <var>urls</var>, and with the following steps to <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a> given the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> <var>request</var>:</p>
       <ol>
        <li data-md="">
         <p>Let <var>serviceWorker</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-21">service worker</a>.</p>
@@ -4306,7 +4306,21 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>If <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-imported-scripts-updated-flag" id="ref-for-dfn-imported-scripts-updated-flag-1">imported scripts updated flag</a> is unset, then:</p>
         <ol>
          <li data-md="">
+          <p>Let <var>registration</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-11">containing service worker registration</a>.</p>
+         <li data-md="">
+          <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">cache mode</a> to "<code>no-cache</code>" if any of the following are true:</p>
+          <ul>
+           <li data-md="">
+            <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-2">use cache</a> is false.</p>
+           <li data-md="">
+            <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">current global object</a>'s <a data-link-type="dfn" href="#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag" id="ref-for-serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag-1">force bypass cache for importscripts flag</a> is set.</p>
+           <li data-md="">
+            <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-1">last update check time</a> is not null and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-2">last update check time</a> is greater than 86400.</p>
+          </ul>
+         <li data-md="">
           <p>Let <var>response</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetching</a> <var>request</var>.</p>
+         <li data-md="">
+          <p>If <var>response</var>’s <a href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-3">last update check time</a> to the current time.</p>
          <li data-md="">
           <p>If <var>response</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#unsafe-response">unsafe response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type">type</a> is not "<code>error</code>", and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status">status</a> is an <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#ok-status">ok status</a>, then:</p>
           <ol>
@@ -4373,7 +4387,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="8.3" id="extension-to-service-worker-global-scope"><span class="secno">8.3. </span><span class="content">Define Event Handler</span><a class="self-link" href="#extension-to-service-worker-global-scope"></a></h3>
-     <p>Specifications <em>may</em> define an event handler attribute for the corresponding <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-8">functional event</a> using <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-partial-interface">partial interface</a> definition to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-15">ServiceWorkerGlobalScope</a></code> interface:</p>
+     <p>Specifications <em>may</em> define an event handler attribute for the corresponding <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-8">functional event</a> using <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-partial-interface">partial interface</a> definition to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-16">ServiceWorkerGlobalScope</a></code> interface:</p>
 <pre class="example idl highlight def" data-no-idl="" id="example-bdf67845"><a class="self-link" href="#example-bdf67845"></a><span class="kt">partial</span> <span class="kt">interface</span> <span class="nv">ServiceWorkerGlobalScope</span> {
   <span class="kt">attribute</span> <span class="n">EventHandler</span> <span class="nv">onfunctionalevent</span>;
 };
@@ -4382,7 +4396,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="8.4" id="request-functional-event-dispatch"><span class="secno">8.4. </span><span class="content">Request Functional Event Dispatch</span><a class="self-link" href="#request-functional-event-dispatch"></a></h3>
      <p>To request a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-9">functional event</a> dispatch to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-92">service worker</a>, specifications <em>may</em> invoke <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-2">Handle Functional Event</a> algorithm with its <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-48">service worker registration</a> <var>registration</var> and the algorithm <var>callbackSteps</var> as the arguments.</p>
-     <p>Specifications <em>may</em> define an algorithm <var>callbackSteps</var> where the corresponding <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional event</a> can be created and fired with specification specific objects. The algorithm is passed <var>globalObject</var> (a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-16">ServiceWorkerGlobalScope</a></code> object) at which it <em>may</em> fire its <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>. This algorithm is called on a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-3">Handle Functional Event</a> algorithm.</p>
+     <p>Specifications <em>may</em> define an algorithm <var>callbackSteps</var> where the corresponding <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional event</a> can be created and fired with specification specific objects. The algorithm is passed <var>globalObject</var> (a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-17">ServiceWorkerGlobalScope</a></code> object) at which it <em>may</em> fire its <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>. This algorithm is called on a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-3">Handle Functional Event</a> algorithm.</p>
      <p class="note" role="note">Note: See an <a href="https://notifications.spec.whatwg.org/#activating-a-notification">example</a> hook defined in <a data-link-type="biblio" href="#biblio-notifications">Notifications API</a>.</p>
     </section>
    </section>
@@ -4401,7 +4415,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-7">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="job-referrer">referrer</dfn> (a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a> or null).</p>
      <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-8">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-promise">job promise</dfn> (a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>). It is initially null.</p>
      <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-9">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-list-of-equivalent-jobs">list of equivalent jobs</dfn> (a list of <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-10">jobs</a>). It is initially the empty list.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-11">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-force-bypass-cache-flag">force bypass cache flag</dfn> It is initially unset.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-11">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-force-bypass-cache-flag">force bypass cache flag</dfn>. It is initially unset.</p>
     </div>
     <p>Two <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-12">jobs</a> are <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dfn-job-equivalent">equivalent</dfn> when their <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-1">job type</a> is the same and:</p>
     <ul>
@@ -4681,7 +4695,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Let <var>newestWorker</var> be the result of running the <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-2">Get Newest Worker</a> algorithm passing <var>registration</var> as the argument.</p>
         <li data-md="">
-         <p>If <var>newestWorker</var> is not null, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-5">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-3">script url</a> with the <em>exclude fragments flag</em> set, and <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-use-cache" id="ref-for-dfn-job-use-cache-2">use cache</a>'s value equals <var>registration</var>’s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-2">use cache</a>'s value, then:</p>
+         <p>If <var>newestWorker</var> is not null, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-5">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-3">script url</a> with the <em>exclude fragments flag</em> set, and <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-use-cache" id="ref-for-dfn-job-use-cache-2">use cache</a>'s value equals <var>registration</var>’s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-3">use cache</a>'s value, then:</p>
          <ol>
           <li data-md="">
            <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-1">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-17">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
@@ -4759,11 +4773,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">cache mode</a> to "<code>no-cache</code>" if any of the following are true:</p>
          <ul>
           <li data-md="">
-           <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-3">use cache</a> is false.</p>
+           <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-4">use cache</a> is false.</p>
           <li data-md="">
            <p><var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-1">force bypass cache flag</a> is set.</p>
           <li data-md="">
-           <p><var>newestWorker</var> is not null, and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-1">last update check time</a> is not null and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-2">last update check time</a> is greater than 86400.</p>
+           <p><var>newestWorker</var> is not null, and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-4">last update check time</a> is not null and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-5">last update check time</a> is greater than 86400.</p>
          </ul>
          <p class="note" role="note">Note: Even if the cache mode is not set to "<code>no-cache</code>", the user agent obeys Cache-Control header’s max-age value in the network layer to determine if it should bypass the browser cache.</p>
         <li data-md="">
@@ -4820,7 +4834,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <p>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
          </ol>
         <li data-md="">
-         <p>If <var>response</var>’s <a href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-3">last update check time</a> to the current time.</p>
+         <p>If <var>response</var>’s <a href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-6">last update check time</a> to the current time.</p>
          <p class="issue" id="issue-3c7457a0"><a class="self-link" href="#issue-3c7457a0"></a> The response’s cache state concept had been removed from fetch. The fetch issue <a href="https://github.com/whatwg/fetch/issues/376">#376</a> tracks the request to restore the concept or add some similar way to check this state.</p>
         <li data-md="">
          <p>Return true.</p>
@@ -4858,7 +4872,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-10">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy-1">referrer policy</a> to <var>referrerPolicy</var>.</p>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-3">Run Service Worker</a> algorithm with <var>worker</var> as the argument.</p>
+         <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-3">Run Service Worker</a> algorithm given <var>worker</var>, and with the <em>force bypass cache for importscripts flag</em> set if <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-2">force bypass cache flag</a> is set.</p>
         <li data-md="">
          <p>If an uncaught runtime script error occurs during the above step, then:</p>
          <ol>
@@ -4900,7 +4914,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-6">worker type</a> to <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-3">type</a>.</p>
       <li data-md="">
-       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-2">force bypass cache flag</a> if its <em>force bypass cache flag</em> is set.</p>
+       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-3">force bypass cache flag</a> if its <em>force bypass cache flag</em> is set.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#schedule-job" id="ref-for-schedule-job-4">Schedule Job</a> with <var>job</var>.</p>
      </ol>
@@ -4937,11 +4951,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-3">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-19">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-39">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-17">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-95">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-11">containing service worker registration</a> is <var>registration</var>.</p>
+       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-39">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-17">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-95">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-12">containing service worker registration</a> is <var>registration</var>.</p>
       <li data-md="">
        <p>Let <var>installingWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-8">installing worker</a>.</p>
       <li data-md="">
-       <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-4">Run Service Worker</a> algorithm with <var>installingWorker</var> as the argument.</p>
+       <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-4">Run Service Worker</a> algorithm given <var>installingWorker</var>, and with the <em>force bypass cache for importscripts flag</em> set if <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-4">force bypass cache flag</a> is set.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps:</p>
        <ol>
@@ -5097,6 +5111,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Input</p>
       <dd data-md="">
        <p><var>serviceWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-96">service worker</a></p>
+      <dd data-md="">
+       <p><em>force bypass cache for importscripts flag</em>, an optional flag unset by default</p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5115,7 +5131,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Call the JavaScript <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-initializehostdefinedrealm">InitializeHostDefinedRealm()</a> abstract operation with the following customizations:</p>
        <ul>
         <li data-md="">
-         <p>For the global object, create a new <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-17">ServiceWorkerGlobalScope</a></code> object. Let <var>workerGlobalScope</var> be the created object.</p>
+         <p>For the global object, create a new <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-18">ServiceWorkerGlobalScope</a></code> object. Let <var>workerGlobalScope</var> be the created object.</p>
         <li data-md="">
          <p>Let <var>realmExecutionContext</var> be the created <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-execution-contexts">JavaScript execution context</a>.</p>
        </ul>
@@ -5172,9 +5188,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type">type</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-4">type</a>.</p>
       <li data-md="">
+       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag" id="ref-for-serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag-2">force bypass cache for importscripts flag</a> if its <em>force bypass cache for importscripts flag</em> is set.</p>
+      <li data-md="">
        <p>Create a new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">WorkerLocation</a></code> object and associate it with <var>workerGlobalScope</var>.</p>
       <li data-md="">
-       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-12">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
+       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-13">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
       <li data-md="">
        <p>If <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>, then <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">run the classic script</a> <var>script</var>. Otherwise, it is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">module script</a>; <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">run the module script</a> <var>script</var>.</p>
        <p class="note" role="note">Note: In addition to the usual possibilities of returning a value or failing due to an exception, this could be prematurely aborted by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">kill a worker</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">terminate a worker</a> algorithms.</p>
@@ -5213,7 +5231,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>serviceWorkerGlobalScope</var>’s closing flag to true.</p>
       <li data-md="">
-       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-13">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
+       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
        <p class="note" role="note">Note: This effectively means that the fetch events and the other functional events such as push events are backed up by the registration’s task queues while the other tasks including message events are discarded.</p>
       <li data-md="">
        <p>Abort the script currently running in <var>serviceWorker</var>.</p>
@@ -5318,12 +5336,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-28">active worker</a>.</p>
        </ol>
-       <p class="note" role="note">Note: From this point, the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-44">service worker client</a> starts to <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-6">use</a> its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a>.</p>
+       <p class="note" role="note">Note: From this point, the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-44">service worker client</a> starts to <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-6">use</a> its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-15">containing service worker registration</a>.</p>
       <li data-md="">
        <p>Else if <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is non-null, set <var>registration</var> to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-15">containing service worker registration</a>.</p>
+         <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is non-null, set <var>registration</var> to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-16">containing service worker registration</a>.</p>
         <li data-md="">
          <p>Else, return null.</p>
        </ol>
@@ -5335,7 +5353,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Return null and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-4">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-1">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-7">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-1">Soft Update</a> algorithm with <var>registration</var>.</p>
         <li data-md="">
          <p>Abort these steps.</p>
        </ol>
@@ -5394,7 +5412,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Else, return null and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-5">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-2">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-8">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-2">Soft Update</a> algorithm with <var>registration</var>.</p>
         <li data-md="">
          <p>Abort these steps.</p>
        </ol>
@@ -5404,7 +5422,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-6">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-3">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-9">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-3">Soft Update</a> algorithm with <var>registration</var>.</p>
        </ol>
       <li data-md="">
        <p>Else:</p>
@@ -5412,7 +5430,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Return <var>response</var> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-7">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-4">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-10">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-4">Soft Update</a> algorithm with <var>registration</var>.</p>
        </ol>
      </ol>
     </section>
@@ -5592,7 +5610,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Return and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
         <li data-md="">
-         <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-8">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-5">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-11">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-5">Soft Update</a> algorithm with <var>registration</var>.</p>
         <li data-md="">
          <p>Abort these steps.</p>
        </ol>
@@ -5613,7 +5631,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded.</p>
       <li data-md="">
-       <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-9">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-6">Soft Update</a> algorithm with <var>registration</var>.</p>
+       <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-12">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-6">Soft Update</a> algorithm with <var>registration</var>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle Service Worker Client Unload">
@@ -5739,7 +5757,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>scopeString</var> be <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <var>scope</var> with the <em>exclude fragment flag</em> set.</p>
       <li data-md="">
-       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-58">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-19">scope url</a> is set to <var>scope</var> and <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-4">use cache</a> is set to <var>useCache</var>.</p>
+       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-58">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-19">scope url</a> is set to <var>scope</var> and <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-5">use cache</a> is set to <var>useCache</var>.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set">Set</a> <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-9">scope to registration map</a>[<var>scopeString</var>] to <var>registration</var>.</p>
       <li data-md="">
@@ -6545,6 +6563,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dom-windowclient-focused">focused</a><span>, in §4.2.7</span>
    <li><a href="#dfn-service-worker-client-focusstate">focus state</a><span>, in §4.2</span>
    <li><a href="#dfn-job-force-bypass-cache-flag">force bypass cache flag</a><span>, in §Unnumbered section</span>
+   <li><a href="#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">force bypass cache for importscripts flag</a><span>, in §4.1</span>
    <li><a href="#service-worker-global-scope-foreignfetch-event">foreignfetch</a><span>, in §4.9</span>
    <li><a href="#foreignfetchevent">ForeignFetchEvent</a><span>, in §4.7</span>
    <li><a href="#dictdef-foreignfetcheventinit">ForeignFetchEventInit</a><span>, in §4.7</span>
@@ -7067,6 +7086,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation url</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">current global object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-data">data</a>
      <li><a href="https://html.spec.whatwg.org/multipage/syntax.html#delay-the-load-event">delay the load event</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#discard-a-document">discard a document</a>
@@ -7628,10 +7648,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-containing-service-worker-registration-7">4.3.4. claim()</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-8">4.5.1. event.registerForeignFetch(options)</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-9">4.9. Events</a> <a href="#ref-for-dfn-containing-service-worker-registration-10">(2)</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-11">Install</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-12">Run Service Worker</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-13">Terminate Service Worker</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-14">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration-15">(2)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-11">7.3.2. importScripts(urls)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-12">Install</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-13">Run Service Worker</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-14">Terminate Service Worker</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-15">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration-16">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-service-worker-id">
@@ -7863,18 +7884,20 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-last-update-check-time">
    <b><a href="#dfn-last-update-check-time">#dfn-last-update-check-time</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-last-update-check-time-1">Update</a> <a href="#ref-for-dfn-last-update-check-time-2">(2)</a> <a href="#ref-for-dfn-last-update-check-time-3">(3)</a>
-    <li><a href="#ref-for-dfn-last-update-check-time-4">Handle Fetch</a> <a href="#ref-for-dfn-last-update-check-time-5">(2)</a> <a href="#ref-for-dfn-last-update-check-time-6">(3)</a> <a href="#ref-for-dfn-last-update-check-time-7">(4)</a>
-    <li><a href="#ref-for-dfn-last-update-check-time-8">Handle Functional Event</a> <a href="#ref-for-dfn-last-update-check-time-9">(2)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time-1">7.3.2. importScripts(urls)</a> <a href="#ref-for-dfn-last-update-check-time-2">(2)</a> <a href="#ref-for-dfn-last-update-check-time-3">(3)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time-4">Update</a> <a href="#ref-for-dfn-last-update-check-time-5">(2)</a> <a href="#ref-for-dfn-last-update-check-time-6">(3)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time-7">Handle Fetch</a> <a href="#ref-for-dfn-last-update-check-time-8">(2)</a> <a href="#ref-for-dfn-last-update-check-time-9">(3)</a> <a href="#ref-for-dfn-last-update-check-time-10">(4)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time-11">Handle Functional Event</a> <a href="#ref-for-dfn-last-update-check-time-12">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-use-cache">
    <b><a href="#dfn-use-cache">#dfn-use-cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-use-cache-1">3.2.5. useCache</a>
-    <li><a href="#ref-for-dfn-use-cache-2">Register</a>
-    <li><a href="#ref-for-dfn-use-cache-3">Update</a>
-    <li><a href="#ref-for-dfn-use-cache-4">Set Registration</a>
+    <li><a href="#ref-for-dfn-use-cache-2">7.3.2. importScripts(urls)</a>
+    <li><a href="#ref-for-dfn-use-cache-3">Register</a>
+    <li><a href="#ref-for-dfn-use-cache-4">Update</a>
+    <li><a href="#ref-for-dfn-use-cache-5">Set Registration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-uninstalling-flag">
@@ -8345,15 +8368,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworkerglobalscope-1">2.1. Service Worker</a>
     <li><a href="#ref-for-serviceworkerglobalscope-2">3.1.3. postMessage(message, transfer)</a> <a href="#ref-for-serviceworkerglobalscope-3">(2)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-4">3.2.6. update()</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-5">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-serviceworkerglobalscope-6">(2)</a> <a href="#ref-for-serviceworkerglobalscope-7">(3)</a> <a href="#ref-for-serviceworkerglobalscope-8">(4)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-9">4.1.4. Event handlers</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-10">4.3. Clients</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-11">4.4. ExtendableEvent</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-12">4.9. Events</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-13">7.3.2. importScripts(urls)</a> <a href="#ref-for-serviceworkerglobalscope-14">(2)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-15">8.3. Define Event Handler</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-16">8.4. Request Functional Event Dispatch</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-17">Run Service Worker</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-5">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-serviceworkerglobalscope-6">(2)</a> <a href="#ref-for-serviceworkerglobalscope-7">(3)</a> <a href="#ref-for-serviceworkerglobalscope-8">(4)</a> <a href="#ref-for-serviceworkerglobalscope-9">(5)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-10">4.1.4. Event handlers</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-11">4.3. Clients</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-12">4.4. ExtendableEvent</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-13">4.9. Events</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-14">7.3.2. importScripts(urls)</a> <a href="#ref-for-serviceworkerglobalscope-15">(2)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-16">8.3. Define Event Handler</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-17">8.4. Request Functional Event Dispatch</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-18">Run Service Worker</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serviceworkerglobalscope-service-worker">
@@ -8372,6 +8395,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-17">4.9. Events</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-18">(2)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-19">(3)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-20">(4)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-21">7.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-22">Run Service Worker</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">
+   <b><a href="#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag-1">7.3.2. importScripts(urls)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag-2">Run Service Worker</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-clients">
@@ -9442,8 +9472,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-job-force-bypass-cache-flag">
    <b><a href="#dfn-job-force-bypass-cache-flag">#dfn-job-force-bypass-cache-flag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-1">Update</a>
-    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-2">Soft Update</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-1">Update</a> <a href="#ref-for-dfn-job-force-bypass-cache-flag-2">(2)</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-3">Soft Update</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-4">Install</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-equivalent">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-08">8 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-09">9 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-02">2 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-06">6 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1512,9 +1512,10 @@ pre.idl.highlight { color: #708090; }
         <li><a href="#navigator-service-worker-waiting"><span class="secno">3.2.2</span> <span class="content"><code class="idl"><span>waiting</span></code></span></a>
         <li><a href="#navigator-service-worker-active"><span class="secno">3.2.3</span> <span class="content"><code class="idl"><span>active</span></code></span></a>
         <li><a href="#service-worker-registration-scope"><span class="secno">3.2.4</span> <span class="content"><code class="idl"><span>scope</span></code></span></a>
-        <li><a href="#service-worker-registration-update"><span class="secno">3.2.5</span> <span class="content"><code class="idl"><span>update()</span></code></span></a>
-        <li><a href="#navigator-service-worker-unregister"><span class="secno">3.2.6</span> <span class="content"><code class="idl"><span>unregister()</span></code></span></a>
-        <li><a href="#service-worker-registration-event-handler"><span class="secno">3.2.7</span> <span class="content">Event handler</span></a>
+        <li><a href="#service-worker-registration-usecache"><span class="secno">3.2.5</span> <span class="content"><code class="idl"><span>useCache</span></code></span></a>
+        <li><a href="#service-worker-registration-update"><span class="secno">3.2.6</span> <span class="content"><code class="idl"><span>update()</span></code></span></a>
+        <li><a href="#navigator-service-worker-unregister"><span class="secno">3.2.7</span> <span class="content"><code class="idl"><span>unregister()</span></code></span></a>
+        <li><a href="#service-worker-registration-event-handler"><span class="secno">3.2.8</span> <span class="content">Event handler</span></a>
        </ol>
       <li><a href="#navigator-serviceworker"><span class="secno">3.3</span> <span class="content"><code class="idl"><span>navigator.serviceWorker</span></code></span></a>
       <li>
@@ -1778,11 +1779,11 @@ pre.idl.highlight { color: #708090; }
      <h3 class="heading settled" data-level="2.2" id="service-worker-registration-concept"><span class="secno">2.2. </span><span class="content">Service Worker Registration</span><a class="self-link" href="#service-worker-registration-concept"></a></h3>
      <p>A <dfn class="dfn-paneled" data-dfn-for="" data-dfn-type="dfn" data-export="" id="dfn-service-worker-registration">service worker registration</dfn> is a tuple of a <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-1">scope url</a> and a set of <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-32">service workers</a>, an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-1">installing worker</a>, a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-1">waiting worker</a>, and an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-1">active worker</a>. A user agent <em>may</em> enable many <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-2">service worker registrations</a> at a single origin so long as the <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-2">scope url</a> of the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-3">service worker registration</a> differs. A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-4">service worker registration</a> of an identical <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-3">scope url</a> when one already exists in the user agent causes the existing <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-5">service worker registration</a> to be replaced.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-6">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-scope-url">scope url</dfn> (a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>).</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-7">service worker registration</a> has an associated <dfn data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-registration-script-url">registering script url<a class="self-link" href="#dfn-registration-script-url"></a></dfn> (a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>).</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-8">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-installing-worker">installing worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-33">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-1">state</a> is <em>installing</em>. It is initially set to null.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-9">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-waiting-worker">waiting worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-34">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-2">state</a> is <em>installed</em>. It is initially set to null.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-10">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-active-worker">active worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-35">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-3">state</a> is either <em>activating</em> or <em>activated</em>. It is initially set to null.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-11">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-last-update-check-time">last update check time</dfn>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-7">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-installing-worker">installing worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-33">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-1">state</a> is <em>installing</em>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-8">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-waiting-worker">waiting worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-34">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-2">state</a> is <em>installed</em>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-9">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-active-worker">active worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-35">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-3">state</a> is either <em>activating</em> or <em>activated</em>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-10">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-last-update-check-time">last update check time</dfn>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-11">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-use-cache">use cache</dfn> (a boolean). It is initially set to false.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-12">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-uninstalling-flag">uninstalling flag</dfn>. It is initially unset.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-13">service worker registration</a> has one or more <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-service-worker-registration-task-queue">task queues</dfn> that back up the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> from its <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-2">active worker</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>. (The target task sources for this back up operation are the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-1">handle fetch task source</a> and the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-1">handle functional event task source</a>.) The user agent dumps the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-3">active worker</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> to the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-14">service worker registration</a>'s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-1">task queues</a> when the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-4">active worker</a> is <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-2">terminated</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">re-queues those tasks</a> to the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-5">active worker</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> when the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-6">active worker</a> spins off. Unlike the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> owned by <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loops</a>, the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-15">service worker registration</a>'s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-2">task queues</a> are not processed by any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loops</a> in and of itself.</p>
      <section>
@@ -1956,6 +1957,7 @@ pre.idl.highlight { color: #708090; }
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#serviceworker" id="ref-for-serviceworker-12">ServiceWorker</a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="ServiceWorker?" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-1">active</a>;
 
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-serviceworkerregistration-scope" id="ref-for-dom-serviceworkerregistration-scope-1">scope</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-serviceworkerregistration-usecache" id="ref-for-dom-serviceworkerregistration-usecache-1">useCache</a>;
 
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject">NewObject</a>] <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-serviceworkerregistration-update" id="ref-for-dom-serviceworkerregistration-update-1">update</a>();
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject">NewObject</a>] <span class="kt">Promise</span>&lt;<span class="kt">boolean</span>> <a class="nv idl-code" data-link-type="method" href="#dom-serviceworkerregistration-unregister" id="ref-for-dom-serviceworkerregistration-unregister-1">unregister</a>();
@@ -1985,14 +1987,18 @@ pre.idl.highlight { color: #708090; }
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export="" id="dom-serviceworkerregistration-scope"><code>scope</code></dfn> attribute <em>must</em> return <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-1">service worker registration</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-6">scope url</a>.</p>
       <div class="example" id="example-2dbb4b8b"><a class="self-link" href="#example-2dbb4b8b"></a> In the example in <a href="#service-worker-url">§3.1.1 scriptURL</a>, the value of <code>registration.scope</code>, obtained from <code>navigator.serviceWorker.ready.then(registration => console.log(registration.scope))</code> for example, will be "<code>https://example.com/</code>". </div>
      </section>
+     <section class="algorithm" data-algorithm="service-worker-registration-usecache">
+      <h4 class="heading settled" data-level="3.2.5" id="service-worker-registration-usecache"><span class="secno">3.2.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-usecache" id="ref-for-dom-serviceworkerregistration-usecache-2">useCache</a></code></span><a class="self-link" href="#service-worker-registration-usecache"></a></h4>
+      <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export="" id="dom-serviceworkerregistration-usecache"><code>useCache</code></dfn> attribute <em>must</em> return <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-2">service worker registration</a>'s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-1">use cache</a>.</p>
+     </section>
      <section class="algorithm" data-algorithm="service-worker-registration-update">
-      <h4 class="heading settled" data-level="3.2.5" id="service-worker-registration-update"><span class="secno">3.2.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-update" id="ref-for-dom-serviceworkerregistration-update-2">update()</a></code></span><a class="self-link" href="#service-worker-registration-update"></a></h4>
+      <h4 class="heading settled" data-level="3.2.6" id="service-worker-registration-update"><span class="secno">3.2.6. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-update" id="ref-for-dom-serviceworkerregistration-update-2">update()</a></code></span><a class="self-link" href="#service-worker-registration-update"></a></h4>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="method" data-export="" id="dom-serviceworkerregistration-update"><code>update()</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
         <p>Let <var>p</var> be a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>.</p>
        <li data-md="">
-        <p>Let <var>registration</var> be the <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-2">service worker registration</a>.</p>
+        <p>Let <var>registration</var> be the <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-3">service worker registration</a>.</p>
        <li data-md="">
         <p>Let <var>newestWorker</var> be the result of running <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-1">Get Newest Worker</a> algorithm passing <var>registration</var> as its argument.</p>
        <li data-md="">
@@ -2010,14 +2016,14 @@ pre.idl.highlight { color: #708090; }
       </ol>
      </section>
      <section class="algorithm" data-algorithm="navigator-service-worker-unregister">
-      <h4 class="heading settled" data-level="3.2.6" id="navigator-service-worker-unregister"><span class="secno">3.2.6. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-unregister" id="ref-for-dom-serviceworkerregistration-unregister-2">unregister()</a></code></span><a class="self-link" href="#navigator-service-worker-unregister"></a></h4>
+      <h4 class="heading settled" data-level="3.2.7" id="navigator-service-worker-unregister"><span class="secno">3.2.7. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-unregister" id="ref-for-dom-serviceworkerregistration-unregister-2">unregister()</a></code></span><a class="self-link" href="#navigator-service-worker-unregister"></a></h4>
       <p class="note" role="note">Note: The <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-unregister" id="ref-for-dom-serviceworkerregistration-unregister-3">unregister()</a></code> method unregisters the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-34">service worker registration</a>. It is important to note that the currently <a data-link-type="dfn" href="#dfn-control" id="ref-for-dfn-control-2">controlled</a> <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-20">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-3">containing service worker registration</a> is effective until all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-21">service worker clients</a> (including itself) using this <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-35">service worker registration</a> unload. That is, the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-unregister" id="ref-for-dom-serviceworkerregistration-unregister-4">unregister()</a></code> method only affects subsequent <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#navigate">navigations</a>.</p>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="method" data-export="" id="dom-serviceworkerregistration-unregister"><code>unregister()</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
         <p>Let <var>p</var> be a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>.</p>
        <li data-md="">
-        <p>Let <var>job</var> be the result of running <a data-link-type="dfn" href="#create-job" id="ref-for-create-job-2">Create Job</a> with <em>unregister</em>, the <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-8">scope url</a> of the <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-3">service worker registration</a>, null, <var>p</var>, and the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>.</p>
+        <p>Let <var>job</var> be the result of running <a data-link-type="dfn" href="#create-job" id="ref-for-create-job-2">Create Job</a> with <em>unregister</em>, the <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-8">scope url</a> of the <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-4">service worker registration</a>, null, <var>p</var>, and the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>.</p>
        <li data-md="">
         <p>Invoke <a data-link-type="dfn" href="#schedule-job" id="ref-for-schedule-job-2">Schedule Job</a> with <var>job</var>.</p>
        <li data-md="">
@@ -2025,7 +2031,7 @@ pre.idl.highlight { color: #708090; }
       </ol>
      </section>
      <section>
-      <h4 class="heading settled" data-level="3.2.7" id="service-worker-registration-event-handler"><span class="secno">3.2.7. </span><span class="content">Event handler</span><a class="self-link" href="#service-worker-registration-event-handler"></a></h4>
+      <h4 class="heading settled" data-level="3.2.8" id="service-worker-registration-event-handler"><span class="secno">3.2.8. </span><span class="content">Event handler</span><a class="self-link" href="#service-worker-registration-event-handler"></a></h4>
       <p>The following is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> (and its corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event type</a>) that <em>must</em> be supported, as <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">event handler IDL attributes</a>, by all objects implementing <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-6">ServiceWorkerRegistration</a></code> interface:</p>
       <table class="data">
        <thead>
@@ -2074,6 +2080,7 @@ pre.idl.highlight { color: #708090; }
 <pre class="idl highlight def" id="registration-option-list-dictionary"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-registrationoptions">RegistrationOptions</dfn> {
   <span class="kt">USVString</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="RegistrationOptions" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-registrationoptions-scope">scope</dfn>;
   <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/workers.html#workertype">WorkerType</a> <dfn class="nv dfn-paneled idl-code" data-default="&quot;classic&quot;" data-dfn-for="RegistrationOptions" data-dfn-type="dict-member" data-export="" data-type="WorkerType " id="dom-registrationoptions-type">type</dfn> = "classic";
+  <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-default="false" data-dfn-for="RegistrationOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-registrationoptions-usecache">useCache</dfn> = <span class="kt">false</span>;
 };
 </pre>
      <p>The user agent <em>must</em> create a <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-5">ServiceWorkerContainer</a></code> object when a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#navigator">Navigator</a></code> object or a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">WorkerNavigator</a></code> object is created and associate it with that object.</p>
@@ -2148,7 +2155,7 @@ pre.idl.highlight { color: #708090; }
        <li data-md="">
         <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-registrationoptions-scope" id="ref-for-dom-registrationoptions-scope-1">scope</a></code> is <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-present">present</a>, set <var>scopeURL</var> to the result of <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser">parsing</a> <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-registrationoptions-scope" id="ref-for-dom-registrationoptions-scope-2">scope</a></code> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">API base URL</a>.</p>
        <li data-md="">
-        <p>Invoke <a data-link-type="dfn" href="#start-register" id="ref-for-start-register-1">Start Register</a> with <var>scopeURL</var>, <var>scriptURL</var>, <var>p</var>, <var>client</var>, <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> and <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-registrationoptions-type" id="ref-for-dom-registrationoptions-type-1">type</a></code>.</p>
+        <p>Invoke <a data-link-type="dfn" href="#start-register" id="ref-for-start-register-1">Start Register</a> with <var>scopeURL</var>, <var>scriptURL</var>, <var>p</var>, <var>client</var>, <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a>, <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-registrationoptions-type" id="ref-for-dom-registrationoptions-type-1">type</a></code>, and <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-registrationoptions-usecache" id="ref-for-dom-registrationoptions-usecache-1">useCache</a></code>.</p>
        <li data-md="">
         <p>Return <var>p</var>.</p>
       </ol>
@@ -2264,7 +2271,7 @@ pre.idl.highlight { color: #708090; }
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="event" data-export="" id="service-worker-registration-updatefound-event"><code>updatefound</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code>
-        <td>The <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-4">service worker registration</a>'s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-4">installing worker</a> changes. (See step 8 of the <a data-link-type="dfn" href="#install" id="ref-for-install-1">Install</a> algorithm.)
+        <td>The <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-5">service worker registration</a>'s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-4">installing worker</a> changes. (See step 8 of the <a data-link-type="dfn" href="#install" id="ref-for-install-1">Install</a> algorithm.)
      </table>
      <p>The following events are dispatched on <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-14">ServiceWorkerContainer</a></code> object:</p>
      <table class="data">
@@ -3495,7 +3502,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>workerType</var> is not a valid <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workertype">WorkerType</a></code> value, abort these steps.</p>
       <li data-md="">
-       <p>Invoke <a data-link-type="dfn" href="#start-register" id="ref-for-start-register-2">Start Register</a> with <var>scopeURL</var>, <var>scriptURL</var>, a new <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>, null, <var>contextURL</var> and <var>workerType</var>.</p>
+       <p>Let <var>useCache</var> be the "<code>usecache</code>" <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc5988#section-5.4">target attribute</a> of the <code>Link</code> header, or false if no such attribute is present.</p>
+      <li data-md="">
+       <p>If <var>useCache</var> is not a valid boolean value, abort these steps.</p>
+      <li data-md="">
+       <p>Invoke <a data-link-type="dfn" href="#start-register" id="ref-for-start-register-2">Start Register</a> with <var>scopeURL</var>, <var>scriptURL</var>, a new <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>, null, <var>contextURL</var>, <var>workerType</var>, and <var>useCache</var>.</p>
      </ol>
      <p>When a <a data-link-type="dfn" href="#dfn-serviceworker-link" id="ref-for-dfn-serviceworker-link-2">serviceworker link</a>’s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#insert-an-element-into-a-document">inserted into a document</a>, a <a data-link-type="dfn" href="#dfn-serviceworker-link" id="ref-for-dfn-serviceworker-link-3">serviceworker link</a> is created on a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element that is already <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#in-a-document-tree">in a document tree</a>, or the <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-href">href</a></code> or <code><a data-link-type="element-sub" href="#element-attrdef-link-scope" id="ref-for-element-attrdef-link-scope-1">scope</a></code> attributes of the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element of a <a data-link-type="dfn" href="#dfn-serviceworker-link" id="ref-for-dfn-serviceworker-link-4">serviceworker link</a> is changed, the user agent <em>should</em> run these steps:</p>
      <ol>
@@ -3516,9 +3527,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>workerType</var> is not a valid <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workertype">WorkerType</a></code> value, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>error</code> at the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element, and abort these steps.</p>
       <li data-md="">
+       <p>Let <var>useCache</var> be the <code><a data-link-type="element-sub" href="#element-attrdef-link-usecache" id="ref-for-element-attrdef-link-usecache-1">usecache</a></code> attribute, or false if the <code><a data-link-type="element-sub" href="#element-attrdef-link-usecache" id="ref-for-element-attrdef-link-usecache-2">usecache</a></code> attribute is omitted.</p>
+      <li data-md="">
+       <p>If <var>useCache</var> is not a valid boolean value, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>error</code> at the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element, and abort these steps.</p>
+      <li data-md="">
        <p>Let <var>promise</var> be a new <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>.</p>
       <li data-md="">
-       <p>Invoke <a data-link-type="dfn" href="#start-register" id="ref-for-start-register-3">Start Register</a> with <var>scopeURL</var>, <var>scriptURL</var>, <var>promise</var>, <var>client</var>, <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> and <var>workerType</var>.</p>
+       <p>Invoke <a data-link-type="dfn" href="#start-register" id="ref-for-start-register-3">Start Register</a> with <var>scopeURL</var>, <var>scriptURL</var>, <var>promise</var>, <var>client</var>, <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a>, <var>workerType</var>, and <var>useCache</var>.</p>
       <li data-md="">
        <p>Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
        <ol>
@@ -3548,10 +3563,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 <pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement">HTMLLinkElement</a> {
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>] <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-type="USVString" href="#link-scope-attribute" id="ref-for-link-scope-attribute-1">scope</a>;
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>] <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/workers.html#workertype">WorkerType</a> <a class="nv idl-code" data-link-type="attribute" data-type="WorkerType" href="#link-workertype-attribute" id="ref-for-link-workertype-attribute-1">workerType</a>;
+  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>] <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-type="boolean" href="#link-usecache-attribute" id="ref-for-link-usecache-attribute-1">useCache</a>;
 };
 </pre>
      <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="HTMLLinkElement" data-dfn-type="attribute" data-export="" id="link-scope-attribute">scope</dfn> IDL attribute must <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-reflect">reflect</a> the element’s <dfn class="dfn-paneled" data-dfn-for="link" data-dfn-type="element-attr" data-export="" id="element-attrdef-link-scope">scope</dfn> content attribute.</p>
      <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="HTMLLinkElement" data-dfn-type="attribute" data-export="" id="link-workertype-attribute">workerType</dfn> IDL attribute must <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-reflect">reflect</a> the element’s <dfn class="dfn-paneled" data-dfn-for="link" data-dfn-type="element-attr" data-export="" id="element-attrdef-link-workertype">workertype</dfn> content attribute.</p>
+     <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="HTMLLinkElement" data-dfn-type="attribute" data-export="" id="link-usecache-attribute">useCache</dfn> IDL attribute must <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-reflect">reflect</a> the element’s <dfn class="dfn-paneled" data-dfn-for="link" data-dfn-type="element-attr" data-export="" id="element-attrdef-link-usecache">usecache</dfn> content attribute.</p>
     </section>
    </section>
    <section>
@@ -4379,20 +4396,21 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-2">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-scope-url">scope url</dfn> (a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>).</p>
      <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-3">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-script-url">script url</dfn> (a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>).</p>
      <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-4">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-worker-type">worker type</dfn> ("<code>classic</code>" or "<code>module</code>").</p>
-     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-5">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-client">client</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-36">service worker client</a>). It is initially null.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-6">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="job-referrer">referrer</dfn> (a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a> or null).</p>
-     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-7">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-promise">job promise</dfn> (a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>). It is initially null.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-8">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-list-of-equivalent-jobs">list of equivalent jobs</dfn> (a list of <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-9">jobs</a>). It is initially the empty list.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-10">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-force-bypass-cache-flag">force bypass cache flag</dfn> It is initially unset.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-5">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-use-cache">use cache</dfn> (a boolean).</p>
+     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-6">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-client">client</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-36">service worker client</a>). It is initially null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-7">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="job-referrer">referrer</dfn> (a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a> or null).</p>
+     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-8">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-promise">job promise</dfn> (a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>). It is initially null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-9">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-list-of-equivalent-jobs">list of equivalent jobs</dfn> (a list of <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-10">jobs</a>). It is initially the empty list.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-11">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-force-bypass-cache-flag">force bypass cache flag</dfn> It is initially unset.</p>
     </div>
-    <p>Two <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-11">jobs</a> are <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dfn-job-equivalent">equivalent</dfn> when their <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-1">job type</a> is the same and:</p>
+    <p>Two <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-12">jobs</a> are <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dfn-job-equivalent">equivalent</dfn> when their <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-1">job type</a> is the same and:</p>
     <ul>
      <li data-md="">
-      <p>For <em>register</em> and <em>update</em> <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-12">jobs</a>, both their <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-1">scope url</a> and the <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-1">script url</a> are the same.</p>
+      <p>For <em>register</em> and <em>update</em> <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-13">jobs</a>, both their <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-1">scope url</a> and the <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-1">script url</a> are the same.</p>
      <li data-md="">
-      <p>For <em>unregister</em> <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-13">jobs</a>, their <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-2">scope url</a> is the same.</p>
+      <p>For <em>unregister</em> <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-14">jobs</a>, their <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-2">scope url</a> is the same.</p>
     </ul>
-    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dfn-job-queue">job queue</dfn> is a thread safe queue used to synchronize the set of concurrent <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-14">jobs</a>. The <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-1">job queue</a> contains <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-15">jobs</a> as its elements. The <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-2">job queue</a> <em>should</em> satisfy the general properties of FIFO queue. A user agent <em>must</em> maintain a separate <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-3">job queue</a> for each <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-51">service worker registration</a> keyed by its <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-14">scope url</a>. A <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-4">job queue</a> is initially empty. Unless stated otherwise, the <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-5">job queue</a> referenced from the algorithm steps is a <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-6">job queue</a> for the <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-16">job</a>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-3">scope url</a>.</p>
+    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dfn-job-queue">job queue</dfn> is a thread safe queue used to synchronize the set of concurrent <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-15">jobs</a>. The <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-1">job queue</a> contains <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-16">jobs</a> as its elements. The <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-2">job queue</a> <em>should</em> satisfy the general properties of FIFO queue. A user agent <em>must</em> maintain a separate <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-3">job queue</a> for each <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-51">service worker registration</a> keyed by its <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-14">scope url</a>. A <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-4">job queue</a> is initially empty. Unless stated otherwise, the <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-5">job queue</a> referenced from the algorithm steps is a <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-6">job queue</a> for the <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-17">job</a>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-3">scope url</a>.</p>
     <section class="algorithm" data-algorithm="Create Job">
      <h3 class="heading settled" id="create-job-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="create-job">Create Job</dfn></span><a class="self-link" href="#create-job-algorithm"></a></h3>
      <dl>
@@ -4411,11 +4429,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-17">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-18">job</a></p>
      </dl>
      <ol>
       <li data-md="">
-       <p>Let <var>job</var> be a new <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-18">job</a>.</p>
+       <p>Let <var>job</var> be a new <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-19">job</a>.</p>
       <li data-md="">
        <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-3">job type</a> to <var>jobType</var>.</p>
       <li data-md="">
@@ -4438,7 +4456,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-19">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-20">job</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -4477,7 +4495,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p><a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">Assert</a>: the <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-11">job queue</a> is not empty.</p>
+       <p class="assertion">Assert: the <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-11">job queue</a> is not empty.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to run these steps:</p>
        <ol>
@@ -4499,7 +4517,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-20">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-21">job</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -4507,7 +4525,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p><a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">Assert</a>: the top element in the <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-13">job queue</a> is <var>job</var>.</p>
+       <p class="assertion">Assert: the top element in the <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-13">job queue</a> is <var>job</var>.</p>
       <li data-md="">
        <p>Pop the top element from the <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-14">job queue</a>.</p>
       <li data-md="">
@@ -4520,7 +4538,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-21">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-22">job</a></p>
       <dd data-md="">
        <p><var>value</var>, any</p>
       <dt data-md="">
@@ -4545,7 +4563,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-22">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-23">job</a></p>
       <dd data-md="">
        <p><var>reason</var>, an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a></p>
       <dt data-md="">
@@ -4581,6 +4599,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><var>referrer</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a></p>
       <dd data-md="">
        <p><var>workerType</var>, a <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-2">worker type</a></p>
+      <dd data-md="">
+       <p><var>useCache</var>, a boolean</p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -4607,6 +4627,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-3">worker type</a> to <var>workerType</var>.</p>
       <li data-md="">
+       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-use-cache" id="ref-for-dfn-job-use-cache-1">use cache</a> to <var>useCache</var>.</p>
+      <li data-md="">
        <p>Set <var>job</var>’s <a data-link-type="dfn" href="#job-referrer" id="ref-for-job-referrer-2">referrer</a> to <var>referrer</var>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#schedule-job" id="ref-for-schedule-job-3">Schedule Job</a> with <var>job</var>.</p>
@@ -4618,7 +4640,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-23">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-24">job</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -4659,7 +4681,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Let <var>newestWorker</var> be the result of running the <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-2">Get Newest Worker</a> algorithm passing <var>registration</var> as the argument.</p>
         <li data-md="">
-         <p>If <var>newestWorker</var> is not null and <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-5">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-3">script url</a> with the <em>exclude fragments flag</em> set, then:</p>
+         <p>If <var>newestWorker</var> is not null, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-5">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-3">script url</a> with the <em>exclude fragments flag</em> set, and <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-use-cache" id="ref-for-dfn-job-use-cache-2">use cache</a>'s value equals <var>registration</var>’s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-2">use cache</a>'s value, then:</p>
          <ol>
           <li data-md="">
            <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-1">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-17">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
@@ -4671,7 +4693,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Else:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#set-registration" id="ref-for-set-registration-1">Set Registration</a> algorithm passing <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-7">scope url</a> as its argument.</p>
+         <p>Invoke <a data-link-type="dfn" href="#set-registration" id="ref-for-set-registration-1">Set Registration</a> algorithm with <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-7">scope url</a> and <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-use-cache" id="ref-for-dfn-job-use-cache-3">use cache</a>.</p>
        </ol>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#update" id="ref-for-update-2">Update</a> algorithm passing <var>job</var> as the argument.</p>
@@ -4683,7 +4705,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-24">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-25">job</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -4734,12 +4756,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#skip-service-worker-flag">skip-service-worker flag</a> and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">redirect mode</a> to "<code>error</code>".</p>
         <li data-md="">
-         <p>If <var>newestWorker</var> is not null and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-1">last update check time</a> is not null, then:</p>
-         <ol>
+         <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">cache mode</a> to "<code>no-cache</code>" if any of the following are true:</p>
+         <ul>
           <li data-md="">
-           <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-2">last update check time</a> is greater than 86400, or <em>force bypass cache flag</em> is set, set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">cache mode</a> to "<code>reload</code>".</p>
-         </ol>
-         <p class="note" role="note">Note: Even if the cache mode is not set to "reload", the user agent obeys Cache-Control header’s max-age value in the network layer to determine if it should bypass the browser cache.</p>
+           <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-3">use cache</a> is false.</p>
+          <li data-md="">
+           <p><var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-1">force bypass cache flag</a> is set.</p>
+          <li data-md="">
+           <p><var>newestWorker</var> is not null, and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-1">last update check time</a> is not null and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-2">last update check time</a> is greater than 86400.</p>
+         </ul>
+         <p class="note" role="note">Note: Even if the cache mode is not set to "<code>no-cache</code>", the user agent obeys Cache-Control header’s max-age value in the network layer to determine if it should bypass the browser cache.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> <var>request</var>, and asynchronously wait to run the remaining steps as part of fetch’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#process-response">process response</a> for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> <var>response</var>.</p>
         <li data-md="">
@@ -4874,7 +4900,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-6">worker type</a> to <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-3">type</a>.</p>
       <li data-md="">
-       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-1">force bypass cache flag</a> if its <em>force bypass cache flag</em> is set.</p>
+       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-2">force bypass cache flag</a> if its <em>force bypass cache flag</em> is set.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#schedule-job" id="ref-for-schedule-job-4">Schedule Job</a> with <var>job</var>.</p>
      </ol>
@@ -4885,7 +4911,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-25">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-26">job</a></p>
       <dd data-md="">
        <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-94">service worker</a></p>
       <dd data-md="">
@@ -4907,7 +4933,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-1">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-7">installing worker</a> and <em>installing</em> as the arguments.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">Assert</a>: <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-7">job promise</a> is not null.</p>
+       <p class="assertion">Assert: <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-7">job promise</a> is not null.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-3">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-19">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
       <li data-md="">
@@ -5555,9 +5581,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p><a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">Assert</a>: <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-7">scope to registration map</a> contains a value equal to <var>registration</var>.</p>
+       <p class="assertion">Assert: <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-7">scope to registration map</a> contains a value equal to <var>registration</var>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">Assert</a>: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a> is not null.</p>
+       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a> is not null.</p>
       <li data-md="">
        <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-31">active worker</a>.</p>
       <li data-md="">
@@ -5657,7 +5683,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-26">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-27">job</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5700,6 +5726,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Input</p>
       <dd data-md="">
        <p><var>scope</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a></p>
+      <dd data-md="">
+       <p><var>useCache</var>, a boolean</p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5711,7 +5739,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>scopeString</var> be <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <var>scope</var> with the <em>exclude fragment flag</em> set.</p>
       <li data-md="">
-       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-58">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-19">scope url</a> is set to <var>scope</var>.</p>
+       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-58">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-19">scope url</a> is set to <var>scope</var> and <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-4">use cache</a> is set to <var>useCache</var>.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set">Set</a> <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-9">scope to registration map</a>[<var>scopeString</var>] to <var>registration</var>.</p>
       <li data-md="">
@@ -5916,7 +5944,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p><a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">Assert</a>: <var>client</var> is not null.</p>
+       <p class="assertion">Assert: <var>client</var> is not null.</p>
       <li data-md="">
        <p>If <var>client</var> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>controllerchange</code> at the <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-16">ServiceWorkerContainer</a></code> object <var>client</var> is <a data-link-type="dfn" href="#serviceworkercontainer-service-worker-client" id="ref-for-serviceworkercontainer-service-worker-client-9">associated</a> with.</p>
      </ol>
@@ -6645,7 +6673,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="#dom-serviceworkerglobalscope-onmessage">attribute for ServiceWorkerGlobalScope</a><span>, in §4.1.4</span>
     </ul>
    <li><a href="#dom-serviceworker-onstatechange">onstatechange</a><span>, in §3.1.4</span>
-   <li><a href="#dom-serviceworkerregistration-onupdatefound">onupdatefound</a><span>, in §3.2.7</span>
+   <li><a href="#dom-serviceworkerregistration-onupdatefound">onupdatefound</a><span>, in §3.2.8</span>
    <li><a href="#dom-cachestorage-open">open(cacheName)</a><span>, in §6.5.3</span>
    <li><a href="#dom-clients-openwindow">openWindow(url)</a><span>, in §4.3.3</span>
    <li><a href="#dom-cachebatchoperation-options">options</a><span>, in §6.4</span>
@@ -6691,7 +6719,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dfn-referrer-policy">referrer policy</a><span>, in §2.1</span>
    <li><a href="#register">Register</a><span>, in §Unnumbered section</span>
    <li><a href="#dom-installevent-registerforeignfetch">registerForeignFetch(options)</a><span>, in §4.5.1</span>
-   <li><a href="#dfn-registration-script-url">registering script url</a><span>, in §2.2</span>
    <li><a href="#dom-serviceworkercontainer-register">register(scriptURL)</a><span>, in §3.4.3</span>
    <li><a href="#dom-serviceworkercontainer-register">register(scriptURL, options)</a><span>, in §3.4.3</span>
    <li>
@@ -6844,14 +6871,28 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="#dom-cachebatchoperation-type">dict-member for CacheBatchOperation</a><span>, in §6.4</span>
     </ul>
    <li><a href="#dfn-uninstalling-flag">uninstalling flag</a><span>, in §2.2</span>
-   <li><a href="#dom-serviceworkerregistration-unregister">unregister()</a><span>, in §3.2.6</span>
+   <li><a href="#dom-serviceworkerregistration-unregister">unregister()</a><span>, in §3.2.7</span>
    <li><a href="#unregister">Unregister</a><span>, in §Unnumbered section</span>
-   <li><a href="#dom-serviceworkerregistration-update">update()</a><span>, in §3.2.5</span>
+   <li><a href="#dom-serviceworkerregistration-update">update()</a><span>, in §3.2.6</span>
    <li><a href="#update">Update</a><span>, in §Unnumbered section</span>
    <li><a href="#service-worker-registration-updatefound-event">updatefound</a><span>, in §3.5</span>
    <li><a href="#update-registration-state">Update Registration State</a><span>, in §Unnumbered section</span>
    <li><a href="#update-worker-state">Update Worker State</a><span>, in §Unnumbered section</span>
    <li><a href="#dom-client-url">url</a><span>, in §4.2.1</span>
+   <li>
+    use cache
+    <ul>
+     <li><a href="#dfn-use-cache">dfn for service worker registration</a><span>, in §2.2</span>
+     <li><a href="#dfn-job-use-cache">dfn for job</a><span>, in §Unnumbered section</span>
+    </ul>
+   <li><a href="#element-attrdef-link-usecache">usecache</a><span>, in §5.2</span>
+   <li>
+    useCache
+    <ul>
+     <li><a href="#dom-serviceworkerregistration-usecache">attribute for ServiceWorkerRegistration</a><span>, in §3.2.5</span>
+     <li><a href="#dom-registrationoptions-usecache">dict-member for RegistrationOptions</a><span>, in §3.4</span>
+     <li><a href="#link-usecache-attribute">attribute for HTMLLinkElement</a><span>, in §5.2</span>
+    </ul>
    <li><a href="#dfn-use">used</a><span>, in §2.4</span>
    <li><a href="#dfn-use">uses</a><span>, in §2.4</span>
    <li><a href="#dfn-use">using</a><span>, in §2.4</span>
@@ -6912,7 +6953,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <a data-link-type="biblio">[ECMASCRIPT]</a> defines the following terms:
     <ul>
      <li><a href="http://tc39.github.io/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist">[[call]]</a>
-     <li><a href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">assert</a>
      <li><a href="http://tc39.github.io/ecma262/#sec-detacharraybuffer">detacharraybuffer</a>
      <li><a href="http://tc39.github.io/ecma262/#sec-execution-contexts">execution context</a>
      <li><a href="http://tc39.github.io/ecma262/#sec-initializehostdefinedrealm">initializehostdefinedrealm</a>
@@ -7272,6 +7312,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#serviceworker">ServiceWorker</a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="ServiceWorker?" href="#dom-serviceworkerregistration-active">active</a>;
 
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-serviceworkerregistration-scope">scope</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-serviceworkerregistration-usecache">useCache</a>;
 
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject">NewObject</a>] <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-serviceworkerregistration-update">update</a>();
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject">NewObject</a>] <span class="kt">Promise</span>&lt;<span class="kt">boolean</span>> <a class="nv idl-code" data-link-type="method" href="#dom-serviceworkerregistration-unregister">unregister</a>();
@@ -7309,6 +7350,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-registrationoptions">RegistrationOptions</a> {
   <span class="kt">USVString</span> <a class="nv" data-type="USVString " href="#dom-registrationoptions-scope">scope</a>;
   <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/workers.html#workertype">WorkerType</a> <a class="nv" data-default="&quot;classic&quot;" data-type="WorkerType " href="#dom-registrationoptions-type">type</a> = "classic";
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-registrationoptions-usecache">useCache</a> = <span class="kt">false</span>;
 };
 
 [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Global">Global</a>=(<a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/workers.html#worker">Worker</a>,<a class="n" data-link-type="idl-name" href="#serviceworker">ServiceWorker</a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
@@ -7446,6 +7488,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 <span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement">HTMLLinkElement</a> {
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>] <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-type="USVString" href="#link-scope-attribute">scope</a>;
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>] <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/workers.html#workertype">WorkerType</a> <a class="nv idl-code" data-link-type="attribute" data-type="WorkerType" href="#link-workertype-attribute">workerType</a>;
+  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>] <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-type="boolean" href="#link-usecache-attribute">useCache</a>;
 };
 
 <span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">WindowOrWorkerGlobalScope</a> {
@@ -7546,7 +7589,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-state-1">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-state-2">(2)</a> <a href="#ref-for-dfn-state-3">(3)</a>
     <li><a href="#ref-for-dfn-state-4">3.1. ServiceWorker</a>
-    <li><a href="#ref-for-dfn-state-5">3.2.5. update()</a>
+    <li><a href="#ref-for-dfn-state-5">3.2.6. update()</a>
     <li><a href="#ref-for-dfn-state-6">Handle Fetch</a> <a href="#ref-for-dfn-state-7">(2)</a>
     <li><a href="#ref-for-dfn-state-8">Handle Foreign Fetch</a> <a href="#ref-for-dfn-state-9">(2)</a>
     <li><a href="#ref-for-dfn-state-10">Handle Functional Event</a> <a href="#ref-for-dfn-state-11">(2)</a>
@@ -7557,7 +7600,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dfn-script-url">#dfn-script-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-script-url-1">3.1.1. scriptURL</a>
-    <li><a href="#ref-for-dfn-script-url-2">3.2.5. update()</a>
+    <li><a href="#ref-for-dfn-script-url-2">3.2.6. update()</a>
     <li><a href="#ref-for-dfn-script-url-3">Register</a>
     <li><a href="#ref-for-dfn-script-url-4">Update</a> <a href="#ref-for-dfn-script-url-5">(2)</a> <a href="#ref-for-dfn-script-url-6">(3)</a>
     <li><a href="#ref-for-dfn-script-url-7">Soft Update</a>
@@ -7567,7 +7610,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-type">
    <b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-type-1">3.2.5. update()</a>
+    <li><a href="#ref-for-dfn-type-1">3.2.6. update()</a>
     <li><a href="#ref-for-dfn-type-2">Update</a>
     <li><a href="#ref-for-dfn-type-3">Soft Update</a>
     <li><a href="#ref-for-dfn-type-4">Run Service Worker</a>
@@ -7578,7 +7621,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-1">2.1. Service Worker</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-2">2.4. Selection and Use</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-3">3.2.6. unregister()</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-3">3.2.7. unregister()</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-4">4.1.2. registration</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-5">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-containing-service-worker-registration-6">(2)</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-7">4.3.4. claim()</a>
@@ -7714,7 +7757,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-registration-20">2.4. Selection and Use</a> <a href="#ref-for-dfn-service-worker-registration-21">(2)</a> <a href="#ref-for-dfn-service-worker-registration-22">(3)</a> <a href="#ref-for-dfn-service-worker-registration-23">(4)</a> <a href="#ref-for-dfn-service-worker-registration-24">(5)</a> <a href="#ref-for-dfn-service-worker-registration-25">(6)</a> <a href="#ref-for-dfn-service-worker-registration-26">(7)</a> <a href="#ref-for-dfn-service-worker-registration-27">(8)</a>
     <li><a href="#ref-for-dfn-service-worker-registration-28">2.6. User Agent Shutdown</a> <a href="#ref-for-dfn-service-worker-registration-29">(2)</a> <a href="#ref-for-dfn-service-worker-registration-30">(3)</a>
     <li><a href="#ref-for-dfn-service-worker-registration-31">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-dfn-service-worker-registration-32">(2)</a> <a href="#ref-for-dfn-service-worker-registration-33">(3)</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-34">3.2.6. unregister()</a> <a href="#ref-for-dfn-service-worker-registration-35">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-34">3.2.7. unregister()</a> <a href="#ref-for-dfn-service-worker-registration-35">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-registration-36">3.4. ServiceWorkerContainer</a> <a href="#ref-for-dfn-service-worker-registration-37">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-registration-38">3.4.2. ready</a>
     <li><a href="#ref-for-dfn-service-worker-registration-39">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-dfn-service-worker-registration-40">(2)</a>
@@ -7745,8 +7788,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-scope-url-4">2.2.1. Lifetime</a>
     <li><a href="#ref-for-dfn-scope-url-5">2.4. Selection and Use</a>
     <li><a href="#ref-for-dfn-scope-url-6">3.2.4. scope</a>
-    <li><a href="#ref-for-dfn-scope-url-7">3.2.5. update()</a>
-    <li><a href="#ref-for-dfn-scope-url-8">3.2.6. unregister()</a>
+    <li><a href="#ref-for-dfn-scope-url-7">3.2.6. update()</a>
+    <li><a href="#ref-for-dfn-scope-url-8">3.2.7. unregister()</a>
     <li><a href="#ref-for-dfn-scope-url-9">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-dfn-scope-url-10">(2)</a>
     <li><a href="#ref-for-dfn-scope-url-11">4.5.1. event.registerForeignFetch(options)</a>
     <li><a href="#ref-for-dfn-scope-url-12">5. Link type "serviceworker"</a>
@@ -7824,6 +7867,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-last-update-check-time-8">Handle Functional Event</a> <a href="#ref-for-dfn-last-update-check-time-9">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="dfn-use-cache">
+   <b><a href="#dfn-use-cache">#dfn-use-cache</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-use-cache-1">3.2.5. useCache</a>
+    <li><a href="#ref-for-dfn-use-cache-2">Register</a>
+    <li><a href="#ref-for-dfn-use-cache-3">Update</a>
+    <li><a href="#ref-for-dfn-use-cache-4">Set Registration</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="dfn-uninstalling-flag">
    <b><a href="#dfn-uninstalling-flag">#dfn-uninstalling-flag</a></b><b>Referenced in:</b>
    <ul>
@@ -7851,7 +7903,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-client-3">2.2.1. Lifetime</a>
     <li><a href="#ref-for-dfn-service-worker-client-4">2.3. Service Worker Client</a> <a href="#ref-for-dfn-service-worker-client-5">(2)</a> <a href="#ref-for-dfn-service-worker-client-6">(3)</a> <a href="#ref-for-dfn-service-worker-client-7">(4)</a> <a href="#ref-for-dfn-service-worker-client-8">(5)</a> <a href="#ref-for-dfn-service-worker-client-9">(6)</a> <a href="#ref-for-dfn-service-worker-client-10">(7)</a>
     <li><a href="#ref-for-dfn-service-worker-client-11">2.4. Selection and Use</a> <a href="#ref-for-dfn-service-worker-client-12">(2)</a> <a href="#ref-for-dfn-service-worker-client-13">(3)</a> <a href="#ref-for-dfn-service-worker-client-14">(4)</a> <a href="#ref-for-dfn-service-worker-client-15">(5)</a> <a href="#ref-for-dfn-service-worker-client-16">(6)</a> <a href="#ref-for-dfn-service-worker-client-17">(7)</a> <a href="#ref-for-dfn-service-worker-client-18">(8)</a> <a href="#ref-for-dfn-service-worker-client-19">(9)</a>
-    <li><a href="#ref-for-dfn-service-worker-client-20">3.2.6. unregister()</a> <a href="#ref-for-dfn-service-worker-client-21">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-client-20">3.2.7. unregister()</a> <a href="#ref-for-dfn-service-worker-client-21">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-client-22">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dfn-service-worker-client-23">3.5. Events</a> <a href="#ref-for-dfn-service-worker-client-24">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-client-25">4.1. ServiceWorkerGlobalScope</a>
@@ -7929,7 +7981,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dfn-control">#dfn-control</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-control-1">2.4. Selection and Use</a>
-    <li><a href="#ref-for-dfn-control-2">3.2.6. unregister()</a>
+    <li><a href="#ref-for-dfn-control-2">3.2.7. unregister()</a>
     <li><a href="#ref-for-dfn-control-3">3.5. Events</a>
     <li><a href="#ref-for-dfn-control-4">Service Worker Script Response</a>
    </ul>
@@ -8059,7 +8111,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-serviceworkerregistration-1">2.2.1. Lifetime</a>
     <li><a href="#ref-for-serviceworkerregistration-2">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-serviceworkerregistration-3">(2)</a> <a href="#ref-for-serviceworkerregistration-4">(3)</a> <a href="#ref-for-serviceworkerregistration-5">(4)</a>
-    <li><a href="#ref-for-serviceworkerregistration-6">3.2.7. Event handler</a>
+    <li><a href="#ref-for-serviceworkerregistration-6">3.2.8. Event handler</a>
     <li><a href="#ref-for-serviceworkerregistration-7">3.4. ServiceWorkerContainer</a> <a href="#ref-for-serviceworkerregistration-8">(2)</a> <a href="#ref-for-serviceworkerregistration-9">(3)</a>
     <li><a href="#ref-for-serviceworkerregistration-10">3.4.2. ready</a>
     <li><a href="#ref-for-serviceworkerregistration-11">3.4.4. getRegistration(clientURL)</a>
@@ -8078,9 +8130,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#serviceworkerregistration-service-worker-registration">#serviceworkerregistration-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-1">3.2.4. scope</a>
-    <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-2">3.2.5. update()</a>
-    <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-3">3.2.6. unregister()</a>
-    <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-4">3.5. Events</a>
+    <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-2">3.2.5. useCache</a>
+    <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-3">3.2.6. update()</a>
+    <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-4">3.2.7. unregister()</a>
+    <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-5">3.5. Events</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerregistration-installing">
@@ -8114,18 +8167,25 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dom-serviceworkerregistration-scope-2">3.2.4. scope</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-usecache">
+   <b><a href="#dom-serviceworkerregistration-usecache">#dom-serviceworkerregistration-usecache</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-serviceworkerregistration-usecache-1">3.2. ServiceWorkerRegistration</a>
+    <li><a href="#ref-for-dom-serviceworkerregistration-usecache-2">3.2.5. useCache</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerregistration-update">
    <b><a href="#dom-serviceworkerregistration-update">#dom-serviceworkerregistration-update</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-update-1">3.2. ServiceWorkerRegistration</a>
-    <li><a href="#ref-for-dom-serviceworkerregistration-update-2">3.2.5. update()</a>
+    <li><a href="#ref-for-dom-serviceworkerregistration-update-2">3.2.6. update()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerregistration-unregister">
    <b><a href="#dom-serviceworkerregistration-unregister">#dom-serviceworkerregistration-unregister</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-unregister-1">3.2. ServiceWorkerRegistration</a>
-    <li><a href="#ref-for-dom-serviceworkerregistration-unregister-2">3.2.6. unregister()</a> <a href="#ref-for-dom-serviceworkerregistration-unregister-3">(2)</a> <a href="#ref-for-dom-serviceworkerregistration-unregister-4">(3)</a>
+    <li><a href="#ref-for-dom-serviceworkerregistration-unregister-2">3.2.7. unregister()</a> <a href="#ref-for-dom-serviceworkerregistration-unregister-3">(2)</a> <a href="#ref-for-dom-serviceworkerregistration-unregister-4">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerregistration-onupdatefound">
@@ -8167,6 +8227,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dom-registrationoptions-type">#dom-registrationoptions-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-registrationoptions-type-1">3.4.3. register(scriptURL, options)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-registrationoptions-usecache">
+   <b><a href="#dom-registrationoptions-usecache">#dom-registrationoptions-usecache</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-registrationoptions-usecache-1">3.4.3. register(scriptURL, options)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serviceworkercontainer-service-worker-client">
@@ -8263,7 +8329,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="service-worker-registration-updatefound-event">
    <b><a href="#service-worker-registration-updatefound-event">#service-worker-registration-updatefound-event</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-service-worker-registration-updatefound-event-1">3.2.7. Event handler</a>
+    <li><a href="#ref-for-service-worker-registration-updatefound-event-1">3.2.8. Event handler</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="service-worker-container-controllerchange-event">
@@ -8277,7 +8343,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope-1">2.1. Service Worker</a>
     <li><a href="#ref-for-serviceworkerglobalscope-2">3.1.3. postMessage(message, transfer)</a> <a href="#ref-for-serviceworkerglobalscope-3">(2)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-4">3.2.5. update()</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-4">3.2.6. update()</a>
     <li><a href="#ref-for-serviceworkerglobalscope-5">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-serviceworkerglobalscope-6">(2)</a> <a href="#ref-for-serviceworkerglobalscope-7">(3)</a> <a href="#ref-for-serviceworkerglobalscope-8">(4)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-9">4.1.4. Event handlers</a>
     <li><a href="#ref-for-serviceworkerglobalscope-10">4.3. Clients</a>
@@ -8293,7 +8359,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#serviceworkerglobalscope-service-worker">#serviceworkerglobalscope-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-1">3.1.3. postMessage(message, transfer)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-2">3.2.5. update()</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-2">3.2.6. update()</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-3">4.1.2. registration</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-4">4.2.5. postMessage(message, transfer)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-5">4.2.10. navigate(url)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-6">(2)</a>
@@ -8999,6 +9065,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-element-attrdef-link-workertype-1">5.1. Processing</a> <a href="#ref-for-element-attrdef-link-workertype-2">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="link-usecache-attribute">
+   <b><a href="#link-usecache-attribute">#link-usecache-attribute</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-link-usecache-attribute-1">5.2. Link element interface extensions</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="element-attrdef-link-usecache">
+   <b><a href="#element-attrdef-link-usecache">#element-attrdef-link-usecache</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-element-attrdef-link-usecache-1">5.1. Processing</a> <a href="#ref-for-element-attrdef-link-usecache-2">(2)</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="dfn-fetching-record">
    <b><a href="#dfn-fetching-record">#dfn-fetching-record</a></b><b>Referenced in:</b>
    <ul>
@@ -9268,16 +9346,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-job">
    <b><a href="#dfn-job">#dfn-job</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-job-1">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job-2">(2)</a> <a href="#ref-for-dfn-job-3">(3)</a> <a href="#ref-for-dfn-job-4">(4)</a> <a href="#ref-for-dfn-job-5">(5)</a> <a href="#ref-for-dfn-job-6">(6)</a> <a href="#ref-for-dfn-job-7">(7)</a> <a href="#ref-for-dfn-job-8">(8)</a> <a href="#ref-for-dfn-job-9">(9)</a> <a href="#ref-for-dfn-job-10">(10)</a> <a href="#ref-for-dfn-job-11">(11)</a> <a href="#ref-for-dfn-job-12">(12)</a> <a href="#ref-for-dfn-job-13">(13)</a> <a href="#ref-for-dfn-job-14">(14)</a> <a href="#ref-for-dfn-job-15">(15)</a> <a href="#ref-for-dfn-job-16">(16)</a>
-    <li><a href="#ref-for-dfn-job-17">Create Job</a> <a href="#ref-for-dfn-job-18">(2)</a>
-    <li><a href="#ref-for-dfn-job-19">Schedule Job</a>
-    <li><a href="#ref-for-dfn-job-20">Finish Job</a>
-    <li><a href="#ref-for-dfn-job-21">Resolve Job Promise</a>
-    <li><a href="#ref-for-dfn-job-22">Reject Job Promise</a>
-    <li><a href="#ref-for-dfn-job-23">Register</a>
-    <li><a href="#ref-for-dfn-job-24">Update</a>
-    <li><a href="#ref-for-dfn-job-25">Install</a>
-    <li><a href="#ref-for-dfn-job-26">Unregister</a>
+    <li><a href="#ref-for-dfn-job-1">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job-2">(2)</a> <a href="#ref-for-dfn-job-3">(3)</a> <a href="#ref-for-dfn-job-4">(4)</a> <a href="#ref-for-dfn-job-5">(5)</a> <a href="#ref-for-dfn-job-6">(6)</a> <a href="#ref-for-dfn-job-7">(7)</a> <a href="#ref-for-dfn-job-8">(8)</a> <a href="#ref-for-dfn-job-9">(9)</a> <a href="#ref-for-dfn-job-10">(10)</a> <a href="#ref-for-dfn-job-11">(11)</a> <a href="#ref-for-dfn-job-12">(12)</a> <a href="#ref-for-dfn-job-13">(13)</a> <a href="#ref-for-dfn-job-14">(14)</a> <a href="#ref-for-dfn-job-15">(15)</a> <a href="#ref-for-dfn-job-16">(16)</a> <a href="#ref-for-dfn-job-17">(17)</a>
+    <li><a href="#ref-for-dfn-job-18">Create Job</a> <a href="#ref-for-dfn-job-19">(2)</a>
+    <li><a href="#ref-for-dfn-job-20">Schedule Job</a>
+    <li><a href="#ref-for-dfn-job-21">Finish Job</a>
+    <li><a href="#ref-for-dfn-job-22">Resolve Job Promise</a>
+    <li><a href="#ref-for-dfn-job-23">Reject Job Promise</a>
+    <li><a href="#ref-for-dfn-job-24">Register</a>
+    <li><a href="#ref-for-dfn-job-25">Update</a>
+    <li><a href="#ref-for-dfn-job-26">Install</a>
+    <li><a href="#ref-for-dfn-job-27">Unregister</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-type">
@@ -9311,10 +9389,17 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-job-worker-type">
    <b><a href="#dfn-job-worker-type">#dfn-job-worker-type</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-job-worker-type-1">3.2.5. update()</a>
+    <li><a href="#ref-for-dfn-job-worker-type-1">3.2.6. update()</a>
     <li><a href="#ref-for-dfn-job-worker-type-2">Start Register</a> <a href="#ref-for-dfn-job-worker-type-3">(2)</a>
     <li><a href="#ref-for-dfn-job-worker-type-4">Update</a> <a href="#ref-for-dfn-job-worker-type-5">(2)</a>
     <li><a href="#ref-for-dfn-job-worker-type-6">Soft Update</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-job-use-cache">
+   <b><a href="#dfn-job-use-cache">#dfn-job-use-cache</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-job-use-cache-1">Start Register</a>
+    <li><a href="#ref-for-dfn-job-use-cache-2">Register</a> <a href="#ref-for-dfn-job-use-cache-3">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-client">
@@ -9356,7 +9441,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-job-force-bypass-cache-flag">
    <b><a href="#dfn-job-force-bypass-cache-flag">#dfn-job-force-bypass-cache-flag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-1">Soft Update</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-1">Update</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-2">Soft Update</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-equivalent">
@@ -9377,8 +9463,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="create-job">
    <b><a href="#create-job">#create-job</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-create-job-1">3.2.5. update()</a>
-    <li><a href="#ref-for-create-job-2">3.2.6. unregister()</a>
+    <li><a href="#ref-for-create-job-1">3.2.6. update()</a>
+    <li><a href="#ref-for-create-job-2">3.2.7. unregister()</a>
     <li><a href="#ref-for-create-job-3">Start Register</a>
     <li><a href="#ref-for-create-job-4">Soft Update</a>
    </ul>
@@ -9386,8 +9472,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="schedule-job">
    <b><a href="#schedule-job">#schedule-job</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-schedule-job-1">3.2.5. update()</a>
-    <li><a href="#ref-for-schedule-job-2">3.2.6. unregister()</a>
+    <li><a href="#ref-for-schedule-job-1">3.2.6. update()</a>
+    <li><a href="#ref-for-schedule-job-2">3.2.7. unregister()</a>
     <li><a href="#ref-for-schedule-job-3">Start Register</a>
     <li><a href="#ref-for-schedule-job-4">Soft Update</a>
    </ul>
@@ -9630,7 +9716,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="get-newest-worker">
    <b><a href="#get-newest-worker">#get-newest-worker</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-get-newest-worker-1">3.2.5. update()</a>
+    <li><a href="#ref-for-get-newest-worker-1">3.2.6. update()</a>
     <li><a href="#ref-for-get-newest-worker-2">Register</a>
     <li><a href="#ref-for-get-newest-worker-3">Update</a>
     <li><a href="#ref-for-get-newest-worker-4">Soft Update</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4837,7 +4837,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        </ol>
        <p>Else, continue the rest of these steps after the algorithm’s asynchronous completion, with <var>script</var> being the asynchronous completion value.</p>
       <li data-md="">
-       <p>If <var>newestWorker</var> is not null, <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-5">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-11">script url</a> with the <em>exclude fragments flag</em> set, and <var>script</var> is a byte-for-byte match with <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-6">script resource</a>, then:</p>
+       <p>If <var>newestWorker</var> is not null, <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-5">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-11">script url</a> with the <em>exclude fragments flag</em> set, and <var>script</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-classic-script-source-text">source text</a> is a byte-for-byte match with <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-6">script resource</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-classic-script-source-text">source text</a>, if <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>, and <var>script</var>’s <a data-link-type="dfn">module record</a>'s [[ECMAScriptCode]] is a byte-for-byte match with <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-7">script resource</a>'s <a data-link-type="dfn">module record</a>'s [[ECMAScriptCode]] otherwise, then:</p>
        <ol>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-2">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-18">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
@@ -4852,11 +4852,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Generate a unique opaque string and set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-id" id="ref-for-dfn-service-worker-id-1">id</a> to the value.</p>
         <li data-md="">
-         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-6">script url</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-12">script url</a>, <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-7">script resource</a> to <var>script</var>, and <var>worker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-2">type</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-5">worker type</a>.</p>
+         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-6">script url</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-12">script url</a>, <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-8">script resource</a> to <var>script</var>, and <var>worker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-2">type</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-5">worker type</a>.</p>
         <li data-md="">
-         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-8">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state-1">HTTPS state</a> to <var>httpsState</var>.</p>
+         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-9">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state-1">HTTPS state</a> to <var>httpsState</var>.</p>
         <li data-md="">
-         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-9">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy-1">referrer policy</a> to <var>referrerPolicy</var>.</p>
+         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-10">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy-1">referrer policy</a> to <var>referrerPolicy</var>.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-3">Run Service Worker</a> algorithm with <var>worker</var> as the argument.</p>
         <li data-md="">
@@ -5104,7 +5104,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>Let <var>script</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-10">script resource</a>.</p>
+       <p>Let <var>script</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-11">script resource</a>.</p>
       <li data-md="">
        <p class="assertion">Assert: <var>script</var> is not null.</p>
       <li data-md="">
@@ -5166,9 +5166,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">url</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-9">script url</a>.</p>
       <li data-md="">
-       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state">HTTPS state</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-11">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state-2">HTTPS state</a>.</p>
+       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state">HTTPS state</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-12">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state-2">HTTPS state</a>.</p>
       <li data-md="">
-       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-referrer-policy">referrer policy</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-12">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy-2">referrer policy</a>.</p>
+       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-referrer-policy">referrer policy</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-13">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy-2">referrer policy</a>.</p>
       <li data-md="">
        <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type">type</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-4">type</a>.</p>
       <li data-md="">
@@ -6359,18 +6359,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <h2 class="heading settled" id="extended-http-headers"><span class="content">Appendix B: Extended HTTP headers</span><a class="self-link" href="#extended-http-headers"></a></h2>
     <section>
      <h3 class="heading settled" id="service-worker-script-request"><span class="content">Service Worker Script Request</span><a class="self-link" href="#service-worker-script-request"></a></h3>
-     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-114">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-13">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-114">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker"><code>Service-Worker</code><a class="self-link" href="#service-worker"></a></dfn>`</p>
       <dd data-md="">
-       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-115">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> request.</p>
+       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-115">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request.</p>
        <p class="note" role="note">Note: This header helps administrators log the requests and detect threats.</p>
      </dl>
     </section>
     <section>
      <h3 class="heading settled" id="service-worker-script-response"><span class="content">Service Worker Script Response</span><a class="self-link" href="#service-worker-script-response"></a></h3>
-     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-116">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-116">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker-allowed"><code>Service-Worker-Allowed</code><a class="self-link" href="#service-worker-allowed"></a></dfn>`</p>
@@ -6417,7 +6417,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" id="syntax"><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
-     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-117">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> requests and responses:</p>
+     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-117">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-17">script resource</a> requests and responses:</p>
 <pre>Service-Worker = %x73.63.72.69.70.74 ; "script", case-sensitive
 </pre>
      <p class="note" role="note">Note: The validation of the Service-Worker-Allowed header’s values is done by URL parsing algorithm (in Update algorithm) instead of using ABNF.</p>
@@ -7128,6 +7128,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#shared-workers">shared worker</a>
      <li><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source">source</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#source-browsing-context">source browsing context</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-classic-script-source-text">source text</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">target browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>
@@ -7677,11 +7678,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-script-resource-1">2.1. Service Worker</a> <a href="#ref-for-dfn-script-resource-2">(2)</a> <a href="#ref-for-dfn-script-resource-3">(3)</a>
     <li><a href="#ref-for-dfn-script-resource-4">7.2. Content Security Policy</a> <a href="#ref-for-dfn-script-resource-5">(2)</a>
-    <li><a href="#ref-for-dfn-script-resource-6">Update</a> <a href="#ref-for-dfn-script-resource-7">(2)</a> <a href="#ref-for-dfn-script-resource-8">(3)</a> <a href="#ref-for-dfn-script-resource-9">(4)</a>
-    <li><a href="#ref-for-dfn-script-resource-10">Run Service Worker</a> <a href="#ref-for-dfn-script-resource-11">(2)</a> <a href="#ref-for-dfn-script-resource-12">(3)</a>
-    <li><a href="#ref-for-dfn-script-resource-13">Service Worker Script Request</a> <a href="#ref-for-dfn-script-resource-14">(2)</a>
-    <li><a href="#ref-for-dfn-script-resource-15">Service Worker Script Response</a>
-    <li><a href="#ref-for-dfn-script-resource-16">Syntax</a>
+    <li><a href="#ref-for-dfn-script-resource-6">Update</a> <a href="#ref-for-dfn-script-resource-7">(2)</a> <a href="#ref-for-dfn-script-resource-8">(3)</a> <a href="#ref-for-dfn-script-resource-9">(4)</a> <a href="#ref-for-dfn-script-resource-10">(5)</a>
+    <li><a href="#ref-for-dfn-script-resource-11">Run Service Worker</a> <a href="#ref-for-dfn-script-resource-12">(2)</a> <a href="#ref-for-dfn-script-resource-13">(3)</a>
+    <li><a href="#ref-for-dfn-script-resource-14">Service Worker Script Request</a> <a href="#ref-for-dfn-script-resource-15">(2)</a>
+    <li><a href="#ref-for-dfn-script-resource-16">Service Worker Script Response</a>
+    <li><a href="#ref-for-dfn-script-resource-17">Syntax</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-has-ever-been-evaluated-flag">

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -2241,7 +2241,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
           Else, continue the rest of these steps after the algorithm's asynchronous completion, with |script| being the asynchronous completion value.
 
-      1. If |newestWorker| is not null, |newestWorker|'s [=service worker/script url=] [=url/equals=] |job|'s [=job/script url=] with the *exclude fragments flag* set, and |script| is a byte-for-byte match with |newestWorker|'s <a>script resource</a>, then:
+      1. If |newestWorker| is not null, |newestWorker|'s [=service worker/script url=] [=url/equals=] |job|'s [=job/script url=] with the *exclude fragments flag* set, and |script|'s [=source text=] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=source text=], if |script| is a [=classic script=], and |script|'s [=module record=]'s \[[ECMAScriptCode]] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=module record=]'s \[[ECMAScriptCode]] otherwise, then:
           1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Else:

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -2247,7 +2247,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
           Else, continue the rest of these steps after the algorithm's asynchronous completion, with |script| being the asynchronous completion value.
 
-      1. If |newestWorker| is not null, |newestWorker|'s [=service worker/script url=] [=url/equals=] |job|'s [=job/script url=] with the *exclude fragments flag* set, and |script|'s [=source text=] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=source text=], if |script| is a [=classic script=], and |script|'s [=module record=]'s \[[ECMAScriptCode]] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=module record=]'s \[[ECMAScriptCode]] otherwise, then:
+      1. If |newestWorker| is not null, |newestWorker|'s [=service worker/script url=] [=url/equals=] |job|'s [=job/script url=] with the *exclude fragments flag* set, and |script|'s [=source text=] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=source text=], if |script| is a [=classic script=], and |script|'s [=module script/module record=]'s \[[ECMAScriptCode]] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=module script/module record=]'s \[[ECMAScriptCode]] otherwise, then:
           1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Else:

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -176,8 +176,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A [=/service worker registration=] has an associated <dfn export id="dfn-scope-url">scope url</dfn> (a [=/URL=]).
 
-    A [=/service worker registration=] has an associated <dfn export id="dfn-registration-script-url">registering script url</dfn> (a [=/URL=]).
-
     A [=/service worker registration=] has an associated <dfn export id="dfn-installing-worker">installing worker</dfn> (a [=/service worker=] or null) whose [=service worker/state=] is *installing*. It is initially set to null.
 
     A [=/service worker registration=] has an associated <dfn export id="dfn-waiting-worker">waiting worker</dfn> (a [=/service worker=] or null) whose [=service worker/state=] is *installed*. It is initially set to null.
@@ -185,6 +183,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     A [=/service worker registration=] has an associated <dfn export id="dfn-active-worker">active worker</dfn> (a [=/service worker=] or null) whose [=service worker/state=] is either *activating* or *activated*. It is initially set to null.
 
     A [=/service worker registration=] has an associated <dfn export id="dfn-last-update-check-time">last update check time</dfn>. It is initially set to null.
+
+    A [=/service worker registration=] has an associated <dfn export id="dfn-use-cache">use cache</dfn> (a boolean). It is initially set to false.
 
     A [=/service worker registration=] has an associated <dfn export id="dfn-uninstalling-flag">uninstalling flag</dfn>. It is initially unset.
 
@@ -380,6 +380,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         readonly attribute ServiceWorker? active;
 
         readonly attribute USVString scope;
+        readonly attribute boolean useCache;
 
         [NewObject] Promise&lt;void&gt; update();
         [NewObject] Promise&lt;boolean&gt; unregister();
@@ -423,6 +424,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       <div class="example">
         In the example in [[#service-worker-url]], the value of <code>registration.scope</code>, obtained from <code>navigator.serviceWorker.ready.then(registration => console.log(registration.scope))</code> for example, will be "<code>https://example.com/</code>".
       </div>
+    </section>
+
+    <section algorithm="service-worker-registration-usecache">
+      <h4 id="service-worker-registration-usecache">{{ServiceWorkerRegistration/useCache}}</h4>
+
+      The <dfn attribute for="ServiceWorkerRegistration"><code>useCache</code></dfn> attribute *must* return [=ServiceWorkerRegistration/service worker registration=]'s [=service worker registration/use cache=].
     </section>
 
     <section algorithm="service-worker-registration-update">
@@ -518,6 +525,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       dictionary RegistrationOptions {
         USVString scope;
         WorkerType type = "classic";
+        boolean useCache = false;
       };
     </pre>
 
@@ -590,6 +598,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. If |scopeURL|'s [=url/scheme=] is not one of "<code>http</code>" and "<code>https</code>", reject |p| with a <code>TypeError</code> and abort these steps.
         1. If any of the strings in |scopeURL|'s [=url/path=] contains either <a>ASCII case-insensitive</a> "<code>%2f</code>" or <a>ASCII case-insensitive</a> "<code>%5c</code>", reject |p| with a <code>TypeError</code> and abort these steps.
         1. Let |job| be the result of running <a>Create Job</a> with *register*, |scopeURL|, |scriptURL|, |p|, and |client|.
+        1. Set |job|'s [=job/worker type=] to |options|.{{RegistrationOptions/type}}.
+        1. Set |job|'s [=job/use cache=] to |options|.{{RegistrationOptions/useCache}}.
         1. Invoke <a>Schedule Job</a> with |job|.
         1. Return |p|.
     </section>
@@ -2006,6 +2016,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A <a>job</a> has a <dfn id="dfn-job-worker-type">worker type</dfn> ("<code>classic</code>" or "<code>module</code>").
 
+    A <a>job</a> has a <dfn id="dfn-job-use-cache">use cache</dfn> (a boolean).
+
     A <a>job</a> has a <dfn id="dfn-job-client">client</dfn> (a [=/service worker client=]). It is initially null.
 
     A <a>job</a> has a <dfn id="dfn-job-promise">job promise</dfn> (a <a>promise</a>). It is initially null.
@@ -2068,7 +2080,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: none
 
-      1. <a>Assert</a>: the <a>job queue</a> is not empty.
+      1. Assert: the <a>job queue</a> is not empty.
       1. <a>Queue a task</a> to run these steps:
           1. Let |job| be the element in the front of the <a>job queue</a>.
           1. If |job|'s <a>job type</a> is *register*, run <a>Register</a> with |job| <a>in parallel</a>.
@@ -2087,7 +2099,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: none
 
-      1. <a>Assert</a>: the top element in the <a>job queue</a> is |job|.
+      1. Assert: the top element in the <a>job queue</a> is |job|.
       1. Pop the top element from the <a>job queue</a>.
       1. If the <a>job queue</a> is not empty, invoke <a>Run Job</a> with the top element of the <a>job queue</a>.
   </section>
@@ -2141,11 +2153,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If |registration| is not null, then:
           1. If |registration|'s <a>uninstalling flag</a> is set, unset it.
           1. Let |newestWorker| be the result of running the <a>Get Newest Worker</a> algorithm passing |registration| as the argument.
-          1. If |newestWorker| is not null and |job|'s [=job/script url=] [=url/equals=] |newestWorker|'s [=service worker/script url=] with the *exclude fragments flag* set, then:
+          1. If |newestWorker| is not null, |job|'s [=job/script url=] [=url/equals=] |newestWorker|'s [=service worker/script url=] with the *exclude fragments flag* set, and |job|'s [=job/use cache=]'s value equals |registration|'s [=service worker registration/use cache=]'s value, then:
               1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Else:
-          1. Invoke <a>Set Registration</a> algorithm passing |job|'s [=job/scope url=] as its argument.
+          1. Invoke <a>Set Registration</a> algorithm with |job|'s [=job/scope url=] and |job|'s [=job/use cache=].
       1. Invoke <a>Update</a> algorithm passing |job| as the argument.
   </section>
 
@@ -2181,10 +2193,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             Note: See the definition of the Service-Worker header in Appendix B: Extended HTTP headers.
 
           1. Set |request|'s <a>skip-service-worker flag</a> and |request|'s [=request/redirect mode=] to "<code>error</code>".
-          1. If |newestWorker| is not null and |registration|'s <a>last update check time</a> is not null, then:
-              1. If the time difference in seconds calculated by the current time minus |registration|'s <a>last update check time</a> is greater than 86400, or *force bypass cache flag* is set, set |request|'s [=request/cache mode=] to "<code>reload</code>".
+          1. Set |request|'s [=request/cache mode=] to "<code>no-cache</code>" if any of the following are true:
+              * |registration|'s [=service worker registration/use cache=] is false.
+              * |job|'s [=force bypass cache flag=] is set.
+              * |newestWorker| is not null, and |registration|'s [=last update check time=] is not null and the time difference in seconds calculated by the current time minus |registration|’s [=last update check time=] is greater than 86400.
 
-              Note: Even if the cache mode is not set to "reload", the user agent obeys Cache-Control header's max-age value in the network layer to determine if it should bypass the browser cache.
+              Note: Even if the cache mode is not set to "<code>no-cache</code>", the user agent obeys Cache-Control header's max-age value in the network layer to determine if it should bypass the browser cache.
 
           1. [=/Fetch=] |request|, and asynchronously wait to run the remaining steps as part of fetch's <a>process response</a> for the [=/response=] |response|.
           1. <a>Extract a MIME type</a> from the |response|'s [=response/header list=]. If this MIME type (ignoring parameters) is not one of <code>text/javascript</code>, <code>application/x-javascript</code>, and <code>application/javascript</code>, then:
@@ -2281,7 +2295,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Let |redundantWorker| be null.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and |worker| as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>installing worker</a> and *installing* as the arguments.
-      1. <a>Assert</a>: |job|'s [=job/job promise=] is not null.
+      1. Assert: |job|'s [=job/job promise=] is not null.
       1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
       1. <a>Queue a task</a> to <a>fire an event</a> named <code>updatefound</code> at all the {{ServiceWorkerRegistration}} objects for all the [=/service worker clients=] whose <a>creation URL</a> <a lt="Match Service Worker Registration">matches</a> |registration|'s [=service worker registration/scope url=] and all the [=/service workers=] whose <a>containing service worker registration</a> is |registration|.
       1. Let |installingWorker| be |registration|'s <a>installing worker</a>.
@@ -2555,8 +2569,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: None
 
-      1. <a>Assert</a>: <a>scope to registration map</a> contains a value equal to |registration|.
-      1. <a>Assert</a>: |registration|'s <a>active worker</a> is not null.
+      1. Assert: <a>scope to registration map</a> contains a value equal to |registration|.
+      1. Assert: |registration|'s <a>active worker</a> is not null.
       1. Let |activeWorker| be |registration|'s <a>active worker</a>.
       1. If |activeWorker|'s <a>set of event types to handle</a> does not contain |event|'s {{Event/type}}, then:
           1. Return and continue running these steps <a>in parallel</a>.
@@ -2640,12 +2654,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       : Input
       :: |scope|, a [=/URL=]
+      :: |useCache|, a boolean
       : Output
       :: |registration|, a [=/service worker registration=]
 
       1. Run the following steps atomically.
       1. Let |scopeString| be <a lt="URL serializer">serialized</a> |scope| with the *exclude fragment flag* set.
-      1. Let |registration| be a new [=/service worker registration=] whose [=service worker registration/scope url=] is set to |scope|.
+      1. Let |registration| be a new [=/service worker registration=] whose [=service worker registration/scope url=] is set to |scope| and [=service worker registration/use cache=] is set to |useCache|.
       1. [=map/Set=] <a>scope to registration map</a>[|scopeString|] to |registration|.
       1. Return |registration|.
   </section>
@@ -2761,7 +2776,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: None
 
-      1. <a>Assert</a>: |client| is not null.
+      1. Assert: |client| is not null.
       1. If |client| is a type of <a>environment settings object</a>, <a>queue a task</a> to <a>fire an event</a> named <code>controllerchange</code> at the {{ServiceWorkerContainer}} object |client| is [=ServiceWorkerContainer/service worker client|associated=] with.
 
     The <a>task</a> *must* use |client|'s <a>responsible event loop</a> and the <a>DOM manipulation task source</a>.

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -797,7 +797,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       };
     </pre>
 
-    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]).
+    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]). A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for importscripts flag</dfn>. It is initially unset.
 
     Note: {{ServiceWorkerGlobalScope}} object provides generic, event-driven, time-limited script execution contexts that run at an origin. Once successfully <a>registered</a>, a [=/service worker=] is started, kept alive and killed by their relationship to events, not [=/service worker clients=]. Any type of synchronous requests must not be initiated inside of a [=/service worker=].
 
@@ -1905,7 +1905,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
         1. Let |serviceWorker| be |request|'s [=request/client=]'s [=environment settings object/global object=]'s [=ServiceWorkerGlobalScope/service worker=].
         1. If |serviceWorker|'s <a>imported scripts updated flag</a> is unset, then:
+            1. Let |registration| be |serviceWorker|'s [=containing service worker registration=].
+            1. Set |request|'s [=request/cache mode=] to "<code>no-cache</code>" if any of the following are true:
+                * |registration|'s [=service worker registration/use cache=] is false.
+                * The [=current global object=]'s [=force bypass cache for importscripts flag=] is set.
+                * |registration|'s [=last update check time=] is not null and the time difference in seconds calculated by the current time minus |registration|’s [=last update check time=] is greater than 86400.
             1. Let |response| be the result of <a lt="fetch">fetching</a> |request|.
+            1. If |response|’s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|’s [=service worker registration/last update check time=] to the current time.
             1. If |response|'s <a>unsafe response</a>'s [=response/type=] is not "<code>error</code>", and |response|'s [=response/status=] is an <a>ok status</a>, then:
                 1. [=map/Set=] <a>script resource map</a>[|request|'s [=request/url=]] to |response|
             1. Return |response|.
@@ -2024,7 +2030,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A <a>job</a> has a <dfn id="dfn-job-list-of-equivalent-jobs">list of equivalent jobs</dfn> (a list of <a>jobs</a>). It is initially the empty list.
 
-    A <a>job</a> has a <dfn id="dfn-job-force-bypass-cache-flag">force bypass cache flag</dfn> It is initially unset.
+    A <a>job</a> has a <dfn id="dfn-job-force-bypass-cache-flag">force bypass cache flag</dfn>. It is initially unset.
   </div>
 
 
@@ -2250,7 +2256,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Set |worker|'s [=service worker/script url=] to |job|'s [=job/script url=], |worker|'s <a>script resource</a> to |script|, and |worker|'s <a>type</a> to |job|'s <a>worker type</a>.
           1. Set |worker|'s <a>script resource</a>'s <a>HTTPS state</a> to |httpsState|.
           1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
-          1. Invoke <a>Run Service Worker</a> algorithm with |worker| as the argument.
+          1. Invoke <a>Run Service Worker</a> algorithm given |worker|, and with the *force bypass cache for importscripts flag* set if |job|'s [=job/force bypass cache flag=] is set.
           1. If an uncaught runtime script error occurs during the above step, then:
               1. Invoke <a>Reject Job Promise</a> with |job| and a <code>TypeError</code>.
               1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
@@ -2299,7 +2305,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
       1. <a>Queue a task</a> to <a>fire an event</a> named <code>updatefound</code> at all the {{ServiceWorkerRegistration}} objects for all the [=/service worker clients=] whose <a>creation URL</a> <a lt="Match Service Worker Registration">matches</a> |registration|'s [=service worker registration/scope url=] and all the [=/service workers=] whose <a>containing service worker registration</a> is |registration|.
       1. Let |installingWorker| be |registration|'s <a>installing worker</a>.
-      1. Invoke <a>Run Service Worker</a> algorithm with |installingWorker| as the argument.
+      1. Invoke <a>Run Service Worker</a> algorithm given |installingWorker|, and with the *force bypass cache for importscripts flag* set if |job|'s [=job/force bypass cache flag=] is set.
       1. <a>Queue a task</a> |task| to run the following substeps:
           1. Let |e| be the result of <a>creating an event</a> with {{ExtendableEvent}}.
           1. Initialize |e|’s {{Event/type}} attribute to {{install!!event}}.
@@ -2382,6 +2388,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       : Input
       :: |serviceWorker|, a [=/service worker=]
+      :: *force bypass cache for importscripts flag*, an optional flag unset by default
       : Output
       :: None
 
@@ -2419,6 +2426,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Set |workerGlobalScope|'s [=WorkerGlobalScope/HTTPS state=] to |serviceWorker|'s <a>script resource</a>'s <a>HTTPS state</a>.
       1. Set |workerGlobalScope|'s [=WorkerGlobalScope/referrer policy=] to |serviceWorker|'s <a>script resource</a>'s [=script resource/referrer policy=].
       1. Set |workerGlobalScope|'s [=WorkerGlobalScope/type=] to |serviceWorker|'s <a>type</a>.
+      1. Set |workerGlobalScope|'s [=ServiceWorkerGlobalScope/force bypass cache for importscripts flag=] if its *force bypass cache for importscripts flag* is set.
       1. Create a new {{WorkerLocation}} object and associate it with |workerGlobalScope|.
       1. If |serviceWorker| is an <a>active worker</a>, and there are any <a>tasks</a> queued in |serviceWorker|'s <a>containing service worker registration</a>'s [=service worker registration/task queues=], <a lt="queue a task">queue</a> them to |serviceWorker|'s <a>event loop</a>'s [=/task queues=] in the same order using their original <a>task sources</a>.
       1. If |script| is a <a>classic script</a>, then <a lt="run a classic script">run the classic script</a> |script|. Otherwise, it is a <a>module script</a>; <a lt="run a module script">run the module script</a> |script|.

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-02">2 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-06">6 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1511,9 +1511,10 @@ pre.idl.highlight { color: #708090; }
         <li><a href="#navigator-service-worker-waiting"><span class="secno">3.2.2</span> <span class="content"><code class="idl"><span>waiting</span></code></span></a>
         <li><a href="#navigator-service-worker-active"><span class="secno">3.2.3</span> <span class="content"><code class="idl"><span>active</span></code></span></a>
         <li><a href="#service-worker-registration-scope"><span class="secno">3.2.4</span> <span class="content"><code class="idl"><span>scope</span></code></span></a>
-        <li><a href="#service-worker-registration-update"><span class="secno">3.2.5</span> <span class="content"><code class="idl"><span>update()</span></code></span></a>
-        <li><a href="#navigator-service-worker-unregister"><span class="secno">3.2.6</span> <span class="content"><code class="idl"><span>unregister()</span></code></span></a>
-        <li><a href="#service-worker-registration-event-handler"><span class="secno">3.2.7</span> <span class="content">Event handler</span></a>
+        <li><a href="#service-worker-registration-usecache"><span class="secno">3.2.5</span> <span class="content"><code class="idl"><span>useCache</span></code></span></a>
+        <li><a href="#service-worker-registration-update"><span class="secno">3.2.6</span> <span class="content"><code class="idl"><span>update()</span></code></span></a>
+        <li><a href="#navigator-service-worker-unregister"><span class="secno">3.2.7</span> <span class="content"><code class="idl"><span>unregister()</span></code></span></a>
+        <li><a href="#service-worker-registration-event-handler"><span class="secno">3.2.8</span> <span class="content">Event handler</span></a>
        </ol>
       <li><a href="#navigator-serviceworker"><span class="secno">3.3</span> <span class="content"><code class="idl"><span>navigator.serviceWorker</span></code></span></a>
       <li>
@@ -1754,11 +1755,11 @@ pre.idl.highlight { color: #708090; }
      <h3 class="heading settled" data-level="2.2" id="service-worker-registration-concept"><span class="secno">2.2. </span><span class="content">Service Worker Registration</span><a class="self-link" href="#service-worker-registration-concept"></a></h3>
      <p>A <dfn class="dfn-paneled" data-dfn-for="" data-dfn-type="dfn" data-export="" id="dfn-service-worker-registration">service worker registration</dfn> is a tuple of a <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-1">scope url</a> and a set of <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-30">service workers</a>, an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-1">installing worker</a>, a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-1">waiting worker</a>, and an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-1">active worker</a>. A user agent <em>may</em> enable many <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-2">service worker registrations</a> at a single origin so long as the <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-2">scope url</a> of the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-3">service worker registration</a> differs. A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-4">service worker registration</a> of an identical <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-3">scope url</a> when one already exists in the user agent causes the existing <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-5">service worker registration</a> to be replaced.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-6">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-scope-url">scope url</dfn> (a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>).</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-7">service worker registration</a> has an associated <dfn data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-registration-script-url">registering script url<a class="self-link" href="#dfn-registration-script-url"></a></dfn> (a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>).</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-8">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-installing-worker">installing worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-31">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-1">state</a> is <em>installing</em>. It is initially set to null.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-9">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-waiting-worker">waiting worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-32">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-2">state</a> is <em>installed</em>. It is initially set to null.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-10">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-active-worker">active worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-33">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-3">state</a> is either <em>activating</em> or <em>activated</em>. It is initially set to null.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-11">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-last-update-check-time">last update check time</dfn>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-7">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-installing-worker">installing worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-31">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-1">state</a> is <em>installing</em>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-8">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-waiting-worker">waiting worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-32">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-2">state</a> is <em>installed</em>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-9">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-active-worker">active worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-33">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-3">state</a> is either <em>activating</em> or <em>activated</em>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-10">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-last-update-check-time">last update check time</dfn>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-11">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-use-cache">use cache</dfn> (a boolean). It is initially set to false.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-12">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-uninstalling-flag">uninstalling flag</dfn>. It is initially unset.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-13">service worker registration</a> has one or more <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-service-worker-registration-task-queue">task queues</dfn> that back up the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> from its <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-2">active worker</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>. (The target task sources for this back up operation are the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-1">handle fetch task source</a> and the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-1">handle functional event task source</a>.) The user agent dumps the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-3">active worker</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> to the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-14">service worker registration</a>'s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-1">task queues</a> when the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-4">active worker</a> is <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-2">terminated</a> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">re-queues those tasks</a> to the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-5">active worker</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> when the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-6">active worker</a> spins off. Unlike the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> owned by <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loops</a>, the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-15">service worker registration</a>'s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-2">task queues</a> are not processed by any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loops</a> in and of itself.</p>
      <section>
@@ -1932,6 +1933,7 @@ pre.idl.highlight { color: #708090; }
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#serviceworker" id="ref-for-serviceworker-12">ServiceWorker</a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="ServiceWorker?" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-1">active</a>;
 
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-serviceworkerregistration-scope" id="ref-for-dom-serviceworkerregistration-scope-1">scope</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-serviceworkerregistration-usecache" id="ref-for-dom-serviceworkerregistration-usecache-1">useCache</a>;
 
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject">NewObject</a>] <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-serviceworkerregistration-update" id="ref-for-dom-serviceworkerregistration-update-1">update</a>();
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject">NewObject</a>] <span class="kt">Promise</span>&lt;<span class="kt">boolean</span>> <a class="nv idl-code" data-link-type="method" href="#dom-serviceworkerregistration-unregister" id="ref-for-dom-serviceworkerregistration-unregister-1">unregister</a>();
@@ -1961,14 +1963,18 @@ pre.idl.highlight { color: #708090; }
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export="" id="dom-serviceworkerregistration-scope"><code>scope</code></dfn> attribute <em>must</em> return <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-1">service worker registration</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-6">scope url</a>.</p>
       <div class="example" id="example-2dbb4b8b"><a class="self-link" href="#example-2dbb4b8b"></a> In the example in <a href="#service-worker-url">§3.1.1 scriptURL</a>, the value of <code>registration.scope</code>, obtained from <code>navigator.serviceWorker.ready.then(registration => console.log(registration.scope))</code> for example, will be "<code>https://example.com/</code>". </div>
      </section>
+     <section class="algorithm" data-algorithm="service-worker-registration-usecache">
+      <h4 class="heading settled" data-level="3.2.5" id="service-worker-registration-usecache"><span class="secno">3.2.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-usecache" id="ref-for-dom-serviceworkerregistration-usecache-2">useCache</a></code></span><a class="self-link" href="#service-worker-registration-usecache"></a></h4>
+      <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export="" id="dom-serviceworkerregistration-usecache"><code>useCache</code></dfn> attribute <em>must</em> return <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-2">service worker registration</a>'s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-1">use cache</a>.</p>
+     </section>
      <section class="algorithm" data-algorithm="service-worker-registration-update">
-      <h4 class="heading settled" data-level="3.2.5" id="service-worker-registration-update"><span class="secno">3.2.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-update" id="ref-for-dom-serviceworkerregistration-update-2">update()</a></code></span><a class="self-link" href="#service-worker-registration-update"></a></h4>
+      <h4 class="heading settled" data-level="3.2.6" id="service-worker-registration-update"><span class="secno">3.2.6. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-update" id="ref-for-dom-serviceworkerregistration-update-2">update()</a></code></span><a class="self-link" href="#service-worker-registration-update"></a></h4>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="method" data-export="" id="dom-serviceworkerregistration-update"><code>update()</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
         <p>Let <var>p</var> be a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>.</p>
        <li data-md="">
-        <p>Let <var>registration</var> be the <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-2">service worker registration</a>.</p>
+        <p>Let <var>registration</var> be the <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-3">service worker registration</a>.</p>
        <li data-md="">
         <p>Let <var>newestWorker</var> be the result of running <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-1">Get Newest Worker</a> algorithm passing <var>registration</var> as its argument.</p>
        <li data-md="">
@@ -1986,14 +1992,14 @@ pre.idl.highlight { color: #708090; }
       </ol>
      </section>
      <section class="algorithm" data-algorithm="navigator-service-worker-unregister">
-      <h4 class="heading settled" data-level="3.2.6" id="navigator-service-worker-unregister"><span class="secno">3.2.6. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-unregister" id="ref-for-dom-serviceworkerregistration-unregister-2">unregister()</a></code></span><a class="self-link" href="#navigator-service-worker-unregister"></a></h4>
+      <h4 class="heading settled" data-level="3.2.7" id="navigator-service-worker-unregister"><span class="secno">3.2.7. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-unregister" id="ref-for-dom-serviceworkerregistration-unregister-2">unregister()</a></code></span><a class="self-link" href="#navigator-service-worker-unregister"></a></h4>
       <p class="note" role="note">Note: The <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-unregister" id="ref-for-dom-serviceworkerregistration-unregister-3">unregister()</a></code> method unregisters the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-34">service worker registration</a>. It is important to note that the currently <a data-link-type="dfn" href="#dfn-control" id="ref-for-dfn-control-2">controlled</a> <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-20">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-3">containing service worker registration</a> is effective until all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-21">service worker clients</a> (including itself) using this <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-35">service worker registration</a> unload. That is, the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-unregister" id="ref-for-dom-serviceworkerregistration-unregister-4">unregister()</a></code> method only affects subsequent <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#navigate">navigations</a>.</p>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="method" data-export="" id="dom-serviceworkerregistration-unregister"><code>unregister()</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
         <p>Let <var>p</var> be a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>.</p>
        <li data-md="">
-        <p>Let <var>job</var> be the result of running <a data-link-type="dfn" href="#create-job" id="ref-for-create-job-2">Create Job</a> with <em>unregister</em>, the <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-8">scope url</a> of the <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-3">service worker registration</a>, null, <var>p</var>, and the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>.</p>
+        <p>Let <var>job</var> be the result of running <a data-link-type="dfn" href="#create-job" id="ref-for-create-job-2">Create Job</a> with <em>unregister</em>, the <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-8">scope url</a> of the <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-4">service worker registration</a>, null, <var>p</var>, and the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>.</p>
        <li data-md="">
         <p>Invoke <a data-link-type="dfn" href="#schedule-job" id="ref-for-schedule-job-2">Schedule Job</a> with <var>job</var>.</p>
        <li data-md="">
@@ -2001,7 +2007,7 @@ pre.idl.highlight { color: #708090; }
       </ol>
      </section>
      <section>
-      <h4 class="heading settled" data-level="3.2.7" id="service-worker-registration-event-handler"><span class="secno">3.2.7. </span><span class="content">Event handler</span><a class="self-link" href="#service-worker-registration-event-handler"></a></h4>
+      <h4 class="heading settled" data-level="3.2.8" id="service-worker-registration-event-handler"><span class="secno">3.2.8. </span><span class="content">Event handler</span><a class="self-link" href="#service-worker-registration-event-handler"></a></h4>
       <p>The following is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> (and its corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event type</a>) that <em>must</em> be supported, as <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">event handler IDL attributes</a>, by all objects implementing <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-6">ServiceWorkerRegistration</a></code> interface:</p>
       <table class="data">
        <thead>
@@ -2049,7 +2055,8 @@ pre.idl.highlight { color: #708090; }
 </pre>
 <pre class="idl highlight def" id="registration-option-list-dictionary"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-registrationoptions">RegistrationOptions</dfn> {
   <span class="kt">USVString</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="RegistrationOptions" data-dfn-type="dict-member" data-export="" data-type="USVString " id="dom-registrationoptions-scope">scope</dfn>;
-  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/workers.html#workertype">WorkerType</a> <dfn class="nv idl-code" data-default="&quot;classic&quot;" data-dfn-for="RegistrationOptions" data-dfn-type="dict-member" data-export="" data-type="WorkerType " id="dom-registrationoptions-type">type<a class="self-link" href="#dom-registrationoptions-type"></a></dfn> = "classic";
+  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/workers.html#workertype">WorkerType</a> <dfn class="nv dfn-paneled idl-code" data-default="&quot;classic&quot;" data-dfn-for="RegistrationOptions" data-dfn-type="dict-member" data-export="" data-type="WorkerType " id="dom-registrationoptions-type">type</dfn> = "classic";
+  <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-default="false" data-dfn-for="RegistrationOptions" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-registrationoptions-usecache">useCache</dfn> = <span class="kt">false</span>;
 };
 </pre>
      <p>The user agent <em>must</em> create a <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-5">ServiceWorkerContainer</a></code> object when a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#navigator">Navigator</a></code> object or a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">WorkerNavigator</a></code> object is created and associate it with that object.</p>
@@ -2140,6 +2147,10 @@ pre.idl.highlight { color: #708090; }
         <p>If any of the strings in <var>scopeURL</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path">path</a> contains either <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> "<code>%2f</code>" or <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a> "<code>%5c</code>", reject <var>p</var> with a <code>TypeError</code> and abort these steps.</p>
        <li data-md="">
         <p>Let <var>job</var> be the result of running <a data-link-type="dfn" href="#create-job" id="ref-for-create-job-3">Create Job</a> with <em>register</em>, <var>scopeURL</var>, <var>scriptURL</var>, <var>p</var>, and <var>client</var>.</p>
+       <li data-md="">
+        <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-2">worker type</a> to <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-registrationoptions-type" id="ref-for-dom-registrationoptions-type-1">type</a></code>.</p>
+       <li data-md="">
+        <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-use-cache" id="ref-for-dfn-job-use-cache-1">use cache</a> to <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-registrationoptions-usecache" id="ref-for-dom-registrationoptions-usecache-1">useCache</a></code>.</p>
        <li data-md="">
         <p>Invoke <a data-link-type="dfn" href="#schedule-job" id="ref-for-schedule-job-3">Schedule Job</a> with <var>job</var>.</p>
        <li data-md="">
@@ -2257,7 +2268,7 @@ pre.idl.highlight { color: #708090; }
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="event" data-export="" id="service-worker-registration-updatefound-event"><code>updatefound</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code>
-        <td>The <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-4">service worker registration</a>'s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-4">installing worker</a> changes. (See step 8 of the <a data-link-type="dfn" href="#install" id="ref-for-install-1">Install</a> algorithm.)
+        <td>The <a data-link-type="dfn" href="#serviceworkerregistration-service-worker-registration" id="ref-for-serviceworkerregistration-service-worker-registration-5">service worker registration</a>'s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-4">installing worker</a> changes. (See step 8 of the <a data-link-type="dfn" href="#install" id="ref-for-install-1">Install</a> algorithm.)
      </table>
      <p>The following events are dispatched on <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-14">ServiceWorkerContainer</a></code> object:</p>
      <table class="data">
@@ -4035,19 +4046,20 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-2">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-scope-url">scope url</dfn> (a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>).</p>
      <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-3">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-script-url">script url</dfn> (a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>).</p>
      <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-4">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-worker-type">worker type</dfn> ("<code>classic</code>" or "<code>module</code>").</p>
-     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-5">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-client">client</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-36">service worker client</a>). It is initially null.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-6">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-promise">job promise</dfn> (a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>). It is initially null.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-7">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-list-of-equivalent-jobs">list of equivalent jobs</dfn> (a list of <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-8">jobs</a>). It is initially the empty list.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-9">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-force-bypass-cache-flag">force bypass cache flag</dfn> It is initially unset.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-5">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-use-cache">use cache</dfn> (a boolean).</p>
+     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-6">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-client">client</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-36">service worker client</a>). It is initially null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-7">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-promise">job promise</dfn> (a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>). It is initially null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-8">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-list-of-equivalent-jobs">list of equivalent jobs</dfn> (a list of <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-9">jobs</a>). It is initially the empty list.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-10">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-force-bypass-cache-flag">force bypass cache flag</dfn> It is initially unset.</p>
     </div>
-    <p>Two <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-10">jobs</a> are <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dfn-job-equivalent">equivalent</dfn> when their <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-1">job type</a> is the same and:</p>
+    <p>Two <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-11">jobs</a> are <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dfn-job-equivalent">equivalent</dfn> when their <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-1">job type</a> is the same and:</p>
     <ul>
      <li data-md="">
-      <p>For <em>register</em> and <em>update</em> <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-11">jobs</a>, both their <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-1">scope url</a> and the <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-1">script url</a> are the same.</p>
+      <p>For <em>register</em> and <em>update</em> <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-12">jobs</a>, both their <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-1">scope url</a> and the <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-1">script url</a> are the same.</p>
      <li data-md="">
-      <p>For <em>unregister</em> <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-12">jobs</a>, their <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-2">scope url</a> is the same.</p>
+      <p>For <em>unregister</em> <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-13">jobs</a>, their <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-2">scope url</a> is the same.</p>
     </ul>
-    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dfn-job-queue">job queue</dfn> is a thread safe queue used to synchronize the set of concurrent <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-13">jobs</a>. The <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-1">job queue</a> contains <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-14">jobs</a> as its elements. The <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-2">job queue</a> <em>should</em> satisfy the general properties of FIFO queue. A user agent <em>must</em> maintain a separate <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-3">job queue</a> for each <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-50">service worker registration</a> keyed by its <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-12">scope url</a>. A <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-4">job queue</a> is initially empty. Unless stated otherwise, the <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-5">job queue</a> referenced from the algorithm steps is a <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-6">job queue</a> for the <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-15">job</a>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-3">scope url</a>.</p>
+    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dfn-job-queue">job queue</dfn> is a thread safe queue used to synchronize the set of concurrent <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-14">jobs</a>. The <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-1">job queue</a> contains <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-15">jobs</a> as its elements. The <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-2">job queue</a> <em>should</em> satisfy the general properties of FIFO queue. A user agent <em>must</em> maintain a separate <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-3">job queue</a> for each <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-50">service worker registration</a> keyed by its <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-12">scope url</a>. A <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-4">job queue</a> is initially empty. Unless stated otherwise, the <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-5">job queue</a> referenced from the algorithm steps is a <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-6">job queue</a> for the <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-16">job</a>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-3">scope url</a>.</p>
     <section class="algorithm" data-algorithm="Create Job">
      <h3 class="heading settled" id="create-job-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="create-job">Create Job</dfn></span><a class="self-link" href="#create-job-algorithm"></a></h3>
      <dl>
@@ -4066,11 +4078,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-16">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-17">job</a></p>
      </dl>
      <ol>
       <li data-md="">
-       <p>Let <var>job</var> be a new <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-17">job</a>.</p>
+       <p>Let <var>job</var> be a new <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-18">job</a>.</p>
       <li data-md="">
        <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-3">job type</a> to <var>jobType</var>.</p>
       <li data-md="">
@@ -4091,7 +4103,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-18">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-19">job</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -4130,7 +4142,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p><a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">Assert</a>: the <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-11">job queue</a> is not empty.</p>
+       <p class="assertion">Assert: the <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-11">job queue</a> is not empty.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to run these steps:</p>
        <ol>
@@ -4152,7 +4164,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-19">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-20">job</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -4160,7 +4172,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p><a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">Assert</a>: the top element in the <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-13">job queue</a> is <var>job</var>.</p>
+       <p class="assertion">Assert: the top element in the <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-13">job queue</a> is <var>job</var>.</p>
       <li data-md="">
        <p>Pop the top element from the <a data-link-type="dfn" href="#dfn-job-queue" id="ref-for-dfn-job-queue-14">job queue</a>.</p>
       <li data-md="">
@@ -4173,7 +4185,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-20">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-21">job</a></p>
       <dd data-md="">
        <p><var>value</var>, any</p>
       <dt data-md="">
@@ -4198,7 +4210,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-21">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-22">job</a></p>
       <dd data-md="">
        <p><var>reason</var>, an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a></p>
       <dt data-md="">
@@ -4223,7 +4235,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-22">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-23">job</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -4264,7 +4276,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Let <var>newestWorker</var> be the result of running the <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-2">Get Newest Worker</a> algorithm passing <var>registration</var> as the argument.</p>
         <li data-md="">
-         <p>If <var>newestWorker</var> is not null and <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-5">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-3">script url</a> with the <em>exclude fragments flag</em> set, then:</p>
+         <p>If <var>newestWorker</var> is not null, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-5">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-3">script url</a> with the <em>exclude fragments flag</em> set, and <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-use-cache" id="ref-for-dfn-job-use-cache-2">use cache</a>'s value equals <var>registration</var>’s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-2">use cache</a>'s value, then:</p>
          <ol>
           <li data-md="">
            <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-1">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-17">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
@@ -4276,7 +4288,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Else:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#set-registration" id="ref-for-set-registration-1">Set Registration</a> algorithm passing <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-7">scope url</a> as its argument.</p>
+         <p>Invoke <a data-link-type="dfn" href="#set-registration" id="ref-for-set-registration-1">Set Registration</a> algorithm with <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-7">scope url</a> and <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-use-cache" id="ref-for-dfn-job-use-cache-3">use cache</a>.</p>
        </ol>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#update" id="ref-for-update-2">Update</a> algorithm passing <var>job</var> as the argument.</p>
@@ -4288,7 +4300,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-23">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-24">job</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -4320,7 +4332,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>referrerPolicy</var> be the empty string.</p>
       <li data-md="">
-       <p>Switching on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-2">worker type</a>, run these substeps with the following options:</p>
+       <p>Switching on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-3">worker type</a>, run these substeps with the following options:</p>
        <dl>
         <dt data-md="">
          <p>"<code>classic</code>"</p>
@@ -4339,12 +4351,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#skip-service-worker-flag">skip-service-worker flag</a> and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">redirect mode</a> to "<code>error</code>".</p>
         <li data-md="">
-         <p>If <var>newestWorker</var> is not null and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-1">last update check time</a> is not null, then:</p>
-         <ol>
+         <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">cache mode</a> to "<code>no-cache</code>" if any of the following are true:</p>
+         <ul>
           <li data-md="">
-           <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-2">last update check time</a> is greater than 86400, or <em>force bypass cache flag</em> is set, set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">cache mode</a> to "<code>reload</code>".</p>
-         </ol>
-         <p class="note" role="note">Note: Even if the cache mode is not set to "reload", the user agent obeys Cache-Control header’s max-age value in the network layer to determine if it should bypass the browser cache.</p>
+           <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-3">use cache</a> is false.</p>
+          <li data-md="">
+           <p><var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-1">force bypass cache flag</a> is set.</p>
+          <li data-md="">
+           <p><var>newestWorker</var> is not null, and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-1">last update check time</a> is not null and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-2">last update check time</a> is greater than 86400.</p>
+         </ul>
+         <p class="note" role="note">Note: Even if the cache mode is not set to "<code>no-cache</code>", the user agent obeys Cache-Control header’s max-age value in the network layer to determine if it should bypass the browser cache.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> <var>request</var>, and asynchronously wait to run the remaining steps as part of fetch’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#process-response">process response</a> for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> <var>response</var>.</p>
         <li data-md="">
@@ -4431,7 +4447,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Generate a unique opaque string and set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-id" id="ref-for-dfn-service-worker-id-1">id</a> to the value.</p>
         <li data-md="">
-         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-6">script url</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-12">script url</a>, <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-7">script resource</a> to <var>script</var>, and <var>worker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-2">type</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-3">worker type</a>.</p>
+         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-6">script url</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-12">script url</a>, <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-7">script resource</a> to <var>script</var>, and <var>worker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-2">type</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-4">worker type</a>.</p>
         <li data-md="">
          <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-8">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state-1">HTTPS state</a> to <var>httpsState</var>.</p>
         <li data-md="">
@@ -4477,9 +4493,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>job</var> be the result of running <a data-link-type="dfn" href="#create-job" id="ref-for-create-job-4">Create Job</a> with <em>update</em>, <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-14">scope url</a>, <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-7">script url</a>, null, and null.</p>
       <li data-md="">
-       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-4">worker type</a> to <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-3">type</a>.</p>
+       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-5">worker type</a> to <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-3">type</a>.</p>
       <li data-md="">
-       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-1">force bypass cache flag</a> if its <em>force bypass cache flag</em> is set.</p>
+       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-2">force bypass cache flag</a> if its <em>force bypass cache flag</em> is set.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#schedule-job" id="ref-for-schedule-job-4">Schedule Job</a> with <var>job</var>.</p>
      </ol>
@@ -4490,7 +4506,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-24">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-25">job</a></p>
       <dd data-md="">
        <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-88">service worker</a></p>
       <dd data-md="">
@@ -4512,7 +4528,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-1">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-7">installing worker</a> and <em>installing</em> as the arguments.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">Assert</a>: <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-7">job promise</a> is not null.</p>
+       <p class="assertion">Assert: <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-7">job promise</a> is not null.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-3">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-19">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
       <li data-md="">
@@ -5013,9 +5029,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p><a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">Assert</a>: <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-7">scope to registration map</a> contains a value equal to <var>registration</var>.</p>
+       <p class="assertion">Assert: <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-7">scope to registration map</a> contains a value equal to <var>registration</var>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">Assert</a>: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a> is not null.</p>
+       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a> is not null.</p>
       <li data-md="">
        <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-31">active worker</a>.</p>
       <li data-md="">
@@ -5115,7 +5131,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-25">job</a></p>
+       <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-26">job</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5158,6 +5174,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Input</p>
       <dd data-md="">
        <p><var>scope</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a></p>
+      <dd data-md="">
+       <p><var>useCache</var>, a boolean</p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5169,7 +5187,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>scopeString</var> be <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <var>scope</var> with the <em>exclude fragment flag</em> set.</p>
       <li data-md="">
-       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-57">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-17">scope url</a> is set to <var>scope</var>.</p>
+       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-57">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-17">scope url</a> is set to <var>scope</var> and <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-4">use cache</a> is set to <var>useCache</var>.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set">Set</a> <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-9">scope to registration map</a>[<var>scopeString</var>] to <var>registration</var>.</p>
       <li data-md="">
@@ -5374,7 +5392,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p><a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">Assert</a>: <var>client</var> is not null.</p>
+       <p class="assertion">Assert: <var>client</var> is not null.</p>
       <li data-md="">
        <p>If <var>client</var> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>controllerchange</code> at the <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-16">ServiceWorkerContainer</a></code> object <var>client</var> is <a data-link-type="dfn" href="#serviceworkercontainer-service-worker-client" id="ref-for-serviceworkercontainer-service-worker-client-8">associated</a> with.</p>
      </ol>
@@ -6050,7 +6068,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="#dom-serviceworkerglobalscope-onmessage">attribute for ServiceWorkerGlobalScope</a><span>, in §4.1.4</span>
     </ul>
    <li><a href="#dom-serviceworker-onstatechange">onstatechange</a><span>, in §3.1.4</span>
-   <li><a href="#dom-serviceworkerregistration-onupdatefound">onupdatefound</a><span>, in §3.2.7</span>
+   <li><a href="#dom-serviceworkerregistration-onupdatefound">onupdatefound</a><span>, in §3.2.8</span>
    <li><a href="#dom-cachestorage-open">open(cacheName)</a><span>, in §5.5.3</span>
    <li><a href="#dom-clients-openwindow">openWindow(url)</a><span>, in §4.3.3</span>
    <li><a href="#dom-cachebatchoperation-options">options</a><span>, in §5.4</span>
@@ -6084,7 +6102,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dom-serviceworkerstate-redundant">redundant</a><span>, in §3.1</span>
    <li><a href="#dfn-referrer-policy">referrer policy</a><span>, in §2.1</span>
    <li><a href="#register">Register</a><span>, in §Unnumbered section</span>
-   <li><a href="#dfn-registration-script-url">registering script url</a><span>, in §2.2</span>
    <li><a href="#dom-serviceworkercontainer-register">register(scriptURL)</a><span>, in §3.4.3</span>
    <li><a href="#dom-serviceworkercontainer-register">register(scriptURL, options)</a><span>, in §3.4.3</span>
    <li>
@@ -6209,14 +6226,26 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="#dom-cachebatchoperation-type">dict-member for CacheBatchOperation</a><span>, in §5.4</span>
     </ul>
    <li><a href="#dfn-uninstalling-flag">uninstalling flag</a><span>, in §2.2</span>
-   <li><a href="#dom-serviceworkerregistration-unregister">unregister()</a><span>, in §3.2.6</span>
+   <li><a href="#dom-serviceworkerregistration-unregister">unregister()</a><span>, in §3.2.7</span>
    <li><a href="#unregister">Unregister</a><span>, in §Unnumbered section</span>
-   <li><a href="#dom-serviceworkerregistration-update">update()</a><span>, in §3.2.5</span>
+   <li><a href="#dom-serviceworkerregistration-update">update()</a><span>, in §3.2.6</span>
    <li><a href="#update">Update</a><span>, in §Unnumbered section</span>
    <li><a href="#service-worker-registration-updatefound-event">updatefound</a><span>, in §3.5</span>
    <li><a href="#update-registration-state">Update Registration State</a><span>, in §Unnumbered section</span>
    <li><a href="#update-worker-state">Update Worker State</a><span>, in §Unnumbered section</span>
    <li><a href="#dom-client-url">url</a><span>, in §4.2.1</span>
+   <li>
+    use cache
+    <ul>
+     <li><a href="#dfn-use-cache">dfn for service worker registration</a><span>, in §2.2</span>
+     <li><a href="#dfn-job-use-cache">dfn for job</a><span>, in §Unnumbered section</span>
+    </ul>
+   <li>
+    useCache
+    <ul>
+     <li><a href="#dom-serviceworkerregistration-usecache">attribute for ServiceWorkerRegistration</a><span>, in §3.2.5</span>
+     <li><a href="#dom-registrationoptions-usecache">dict-member for RegistrationOptions</a><span>, in §3.4</span>
+    </ul>
    <li><a href="#dfn-use">used</a><span>, in §2.4</span>
    <li><a href="#dfn-use">uses</a><span>, in §2.4</span>
    <li><a href="#dfn-use">using</a><span>, in §2.4</span>
@@ -6267,7 +6296,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <a data-link-type="biblio">[ECMASCRIPT]</a> defines the following terms:
     <ul>
      <li><a href="http://tc39.github.io/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist">[[call]]</a>
-     <li><a href="http://tc39.github.io/ecma262/#sec-algorithm-conventions">assert</a>
      <li><a href="http://tc39.github.io/ecma262/#sec-detacharraybuffer">detacharraybuffer</a>
      <li><a href="http://tc39.github.io/ecma262/#sec-execution-contexts">execution context</a>
      <li><a href="http://tc39.github.io/ecma262/#sec-initializehostdefinedrealm">initializehostdefinedrealm</a>
@@ -6603,6 +6631,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#serviceworker">ServiceWorker</a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="ServiceWorker?" href="#dom-serviceworkerregistration-active">active</a>;
 
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-serviceworkerregistration-scope">scope</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-serviceworkerregistration-usecache">useCache</a>;
 
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject">NewObject</a>] <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <a class="nv idl-code" data-link-type="method" href="#dom-serviceworkerregistration-update">update</a>();
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject">NewObject</a>] <span class="kt">Promise</span>&lt;<span class="kt">boolean</span>> <a class="nv idl-code" data-link-type="method" href="#dom-serviceworkerregistration-unregister">unregister</a>();
@@ -6640,6 +6669,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 <span class="kt">dictionary</span> <a class="nv" href="#dictdef-registrationoptions">RegistrationOptions</a> {
   <span class="kt">USVString</span> <a class="nv" data-type="USVString " href="#dom-registrationoptions-scope">scope</a>;
   <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/workers.html#workertype">WorkerType</a> <a class="nv" data-default="&quot;classic&quot;" data-type="WorkerType " href="#dom-registrationoptions-type">type</a> = "classic";
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-registrationoptions-usecache">useCache</a> = <span class="kt">false</span>;
 };
 
 [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Global">Global</a>=(<a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/workers.html#worker">Worker</a>,<a class="n" data-link-type="idl-name" href="#serviceworker">ServiceWorker</a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
@@ -6838,7 +6868,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-state-1">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-state-2">(2)</a> <a href="#ref-for-dfn-state-3">(3)</a>
     <li><a href="#ref-for-dfn-state-4">3.1. ServiceWorker</a>
-    <li><a href="#ref-for-dfn-state-5">3.2.5. update()</a>
+    <li><a href="#ref-for-dfn-state-5">3.2.6. update()</a>
     <li><a href="#ref-for-dfn-state-6">Handle Fetch</a> <a href="#ref-for-dfn-state-7">(2)</a>
     <li><a href="#ref-for-dfn-state-8">Handle Functional Event</a> <a href="#ref-for-dfn-state-9">(2)</a>
     <li><a href="#ref-for-dfn-state-10">Update Worker State</a> <a href="#ref-for-dfn-state-11">(2)</a> <a href="#ref-for-dfn-state-12">(3)</a>
@@ -6848,7 +6878,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dfn-script-url">#dfn-script-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-script-url-1">3.1.1. scriptURL</a>
-    <li><a href="#ref-for-dfn-script-url-2">3.2.5. update()</a>
+    <li><a href="#ref-for-dfn-script-url-2">3.2.6. update()</a>
     <li><a href="#ref-for-dfn-script-url-3">Register</a>
     <li><a href="#ref-for-dfn-script-url-4">Update</a> <a href="#ref-for-dfn-script-url-5">(2)</a> <a href="#ref-for-dfn-script-url-6">(3)</a>
     <li><a href="#ref-for-dfn-script-url-7">Soft Update</a>
@@ -6858,7 +6888,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-type">
    <b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-type-1">3.2.5. update()</a>
+    <li><a href="#ref-for-dfn-type-1">3.2.6. update()</a>
     <li><a href="#ref-for-dfn-type-2">Update</a>
     <li><a href="#ref-for-dfn-type-3">Soft Update</a>
     <li><a href="#ref-for-dfn-type-4">Run Service Worker</a>
@@ -6869,7 +6899,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-1">2.1. Service Worker</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-2">2.4. Selection and Use</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-3">3.2.6. unregister()</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-3">3.2.7. unregister()</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-4">4.1.2. registration</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-5">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-containing-service-worker-registration-6">(2)</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-7">4.3.4. claim()</a>
@@ -6988,7 +7018,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-registration-20">2.4. Selection and Use</a> <a href="#ref-for-dfn-service-worker-registration-21">(2)</a> <a href="#ref-for-dfn-service-worker-registration-22">(3)</a> <a href="#ref-for-dfn-service-worker-registration-23">(4)</a> <a href="#ref-for-dfn-service-worker-registration-24">(5)</a> <a href="#ref-for-dfn-service-worker-registration-25">(6)</a> <a href="#ref-for-dfn-service-worker-registration-26">(7)</a> <a href="#ref-for-dfn-service-worker-registration-27">(8)</a>
     <li><a href="#ref-for-dfn-service-worker-registration-28">2.6. User Agent Shutdown</a> <a href="#ref-for-dfn-service-worker-registration-29">(2)</a> <a href="#ref-for-dfn-service-worker-registration-30">(3)</a>
     <li><a href="#ref-for-dfn-service-worker-registration-31">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-dfn-service-worker-registration-32">(2)</a> <a href="#ref-for-dfn-service-worker-registration-33">(3)</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-34">3.2.6. unregister()</a> <a href="#ref-for-dfn-service-worker-registration-35">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-34">3.2.7. unregister()</a> <a href="#ref-for-dfn-service-worker-registration-35">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-registration-36">3.4. ServiceWorkerContainer</a> <a href="#ref-for-dfn-service-worker-registration-37">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-registration-38">3.4.2. ready</a>
     <li><a href="#ref-for-dfn-service-worker-registration-39">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-dfn-service-worker-registration-40">(2)</a>
@@ -7018,8 +7048,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-scope-url-4">2.2.1. Lifetime</a>
     <li><a href="#ref-for-dfn-scope-url-5">2.4. Selection and Use</a>
     <li><a href="#ref-for-dfn-scope-url-6">3.2.4. scope</a>
-    <li><a href="#ref-for-dfn-scope-url-7">3.2.5. update()</a>
-    <li><a href="#ref-for-dfn-scope-url-8">3.2.6. unregister()</a>
+    <li><a href="#ref-for-dfn-scope-url-7">3.2.6. update()</a>
+    <li><a href="#ref-for-dfn-scope-url-8">3.2.7. unregister()</a>
     <li><a href="#ref-for-dfn-scope-url-9">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-dfn-scope-url-10">(2)</a>
     <li><a href="#ref-for-dfn-scope-url-11">Appendix A: Algorithms</a> <a href="#ref-for-dfn-scope-url-12">(2)</a>
     <li><a href="#ref-for-dfn-scope-url-13">Update</a>
@@ -7094,6 +7124,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-last-update-check-time-8">Handle Functional Event</a> <a href="#ref-for-dfn-last-update-check-time-9">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="dfn-use-cache">
+   <b><a href="#dfn-use-cache">#dfn-use-cache</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-use-cache-1">3.2.5. useCache</a>
+    <li><a href="#ref-for-dfn-use-cache-2">Register</a>
+    <li><a href="#ref-for-dfn-use-cache-3">Update</a>
+    <li><a href="#ref-for-dfn-use-cache-4">Set Registration</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="dfn-uninstalling-flag">
    <b><a href="#dfn-uninstalling-flag">#dfn-uninstalling-flag</a></b><b>Referenced in:</b>
    <ul>
@@ -7121,7 +7160,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-client-3">2.2.1. Lifetime</a>
     <li><a href="#ref-for-dfn-service-worker-client-4">2.3. Service Worker Client</a> <a href="#ref-for-dfn-service-worker-client-5">(2)</a> <a href="#ref-for-dfn-service-worker-client-6">(3)</a> <a href="#ref-for-dfn-service-worker-client-7">(4)</a> <a href="#ref-for-dfn-service-worker-client-8">(5)</a> <a href="#ref-for-dfn-service-worker-client-9">(6)</a> <a href="#ref-for-dfn-service-worker-client-10">(7)</a>
     <li><a href="#ref-for-dfn-service-worker-client-11">2.4. Selection and Use</a> <a href="#ref-for-dfn-service-worker-client-12">(2)</a> <a href="#ref-for-dfn-service-worker-client-13">(3)</a> <a href="#ref-for-dfn-service-worker-client-14">(4)</a> <a href="#ref-for-dfn-service-worker-client-15">(5)</a> <a href="#ref-for-dfn-service-worker-client-16">(6)</a> <a href="#ref-for-dfn-service-worker-client-17">(7)</a> <a href="#ref-for-dfn-service-worker-client-18">(8)</a> <a href="#ref-for-dfn-service-worker-client-19">(9)</a>
-    <li><a href="#ref-for-dfn-service-worker-client-20">3.2.6. unregister()</a> <a href="#ref-for-dfn-service-worker-client-21">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-client-20">3.2.7. unregister()</a> <a href="#ref-for-dfn-service-worker-client-21">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-client-22">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dfn-service-worker-client-23">3.5. Events</a> <a href="#ref-for-dfn-service-worker-client-24">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-client-25">4.1. ServiceWorkerGlobalScope</a>
@@ -7198,7 +7237,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dfn-control">#dfn-control</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-control-1">2.4. Selection and Use</a>
-    <li><a href="#ref-for-dfn-control-2">3.2.6. unregister()</a>
+    <li><a href="#ref-for-dfn-control-2">3.2.7. unregister()</a>
     <li><a href="#ref-for-dfn-control-3">3.5. Events</a>
     <li><a href="#ref-for-dfn-control-4">Service Worker Script Response</a>
    </ul>
@@ -7327,7 +7366,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-serviceworkerregistration-1">2.2.1. Lifetime</a>
     <li><a href="#ref-for-serviceworkerregistration-2">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-serviceworkerregistration-3">(2)</a> <a href="#ref-for-serviceworkerregistration-4">(3)</a> <a href="#ref-for-serviceworkerregistration-5">(4)</a>
-    <li><a href="#ref-for-serviceworkerregistration-6">3.2.7. Event handler</a>
+    <li><a href="#ref-for-serviceworkerregistration-6">3.2.8. Event handler</a>
     <li><a href="#ref-for-serviceworkerregistration-7">3.4. ServiceWorkerContainer</a> <a href="#ref-for-serviceworkerregistration-8">(2)</a> <a href="#ref-for-serviceworkerregistration-9">(3)</a>
     <li><a href="#ref-for-serviceworkerregistration-10">3.4.2. ready</a>
     <li><a href="#ref-for-serviceworkerregistration-11">3.4.4. getRegistration(clientURL)</a>
@@ -7346,9 +7385,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#serviceworkerregistration-service-worker-registration">#serviceworkerregistration-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-1">3.2.4. scope</a>
-    <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-2">3.2.5. update()</a>
-    <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-3">3.2.6. unregister()</a>
-    <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-4">3.5. Events</a>
+    <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-2">3.2.5. useCache</a>
+    <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-3">3.2.6. update()</a>
+    <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-4">3.2.7. unregister()</a>
+    <li><a href="#ref-for-serviceworkerregistration-service-worker-registration-5">3.5. Events</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerregistration-installing">
@@ -7382,18 +7422,25 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dom-serviceworkerregistration-scope-2">3.2.4. scope</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-usecache">
+   <b><a href="#dom-serviceworkerregistration-usecache">#dom-serviceworkerregistration-usecache</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-serviceworkerregistration-usecache-1">3.2. ServiceWorkerRegistration</a>
+    <li><a href="#ref-for-dom-serviceworkerregistration-usecache-2">3.2.5. useCache</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerregistration-update">
    <b><a href="#dom-serviceworkerregistration-update">#dom-serviceworkerregistration-update</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-update-1">3.2. ServiceWorkerRegistration</a>
-    <li><a href="#ref-for-dom-serviceworkerregistration-update-2">3.2.5. update()</a>
+    <li><a href="#ref-for-dom-serviceworkerregistration-update-2">3.2.6. update()</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerregistration-unregister">
    <b><a href="#dom-serviceworkerregistration-unregister">#dom-serviceworkerregistration-unregister</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-unregister-1">3.2. ServiceWorkerRegistration</a>
-    <li><a href="#ref-for-dom-serviceworkerregistration-unregister-2">3.2.6. unregister()</a> <a href="#ref-for-dom-serviceworkerregistration-unregister-3">(2)</a> <a href="#ref-for-dom-serviceworkerregistration-unregister-4">(3)</a>
+    <li><a href="#ref-for-dom-serviceworkerregistration-unregister-2">3.2.7. unregister()</a> <a href="#ref-for-dom-serviceworkerregistration-unregister-3">(2)</a> <a href="#ref-for-dom-serviceworkerregistration-unregister-4">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerregistration-onupdatefound">
@@ -7429,6 +7476,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dom-registrationoptions-scope">#dom-registrationoptions-scope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-registrationoptions-scope-1">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-dom-registrationoptions-scope-2">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-registrationoptions-type">
+   <b><a href="#dom-registrationoptions-type">#dom-registrationoptions-type</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-registrationoptions-type-1">3.4.3. register(scriptURL, options)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-registrationoptions-usecache">
+   <b><a href="#dom-registrationoptions-usecache">#dom-registrationoptions-usecache</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-registrationoptions-usecache-1">3.4.3. register(scriptURL, options)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serviceworkercontainer-service-worker-client">
@@ -7524,7 +7583,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="service-worker-registration-updatefound-event">
    <b><a href="#service-worker-registration-updatefound-event">#service-worker-registration-updatefound-event</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-service-worker-registration-updatefound-event-1">3.2.7. Event handler</a>
+    <li><a href="#ref-for-service-worker-registration-updatefound-event-1">3.2.8. Event handler</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="service-worker-container-controllerchange-event">
@@ -7538,7 +7597,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope-1">2.1. Service Worker</a>
     <li><a href="#ref-for-serviceworkerglobalscope-2">3.1.3. postMessage(message, transfer)</a> <a href="#ref-for-serviceworkerglobalscope-3">(2)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-4">3.2.5. update()</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-4">3.2.6. update()</a>
     <li><a href="#ref-for-serviceworkerglobalscope-5">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-serviceworkerglobalscope-6">(2)</a> <a href="#ref-for-serviceworkerglobalscope-7">(3)</a> <a href="#ref-for-serviceworkerglobalscope-8">(4)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-9">4.1.4. Event handlers</a>
     <li><a href="#ref-for-serviceworkerglobalscope-10">4.3. Clients</a>
@@ -7554,7 +7613,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#serviceworkerglobalscope-service-worker">#serviceworkerglobalscope-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-1">3.1.3. postMessage(message, transfer)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-2">3.2.5. update()</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-2">3.2.6. update()</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-3">4.1.2. registration</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-4">4.2.5. postMessage(message, transfer)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-5">4.2.10. navigate(url)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-6">(2)</a>
@@ -8344,16 +8403,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-job">
    <b><a href="#dfn-job">#dfn-job</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-job-1">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job-2">(2)</a> <a href="#ref-for-dfn-job-3">(3)</a> <a href="#ref-for-dfn-job-4">(4)</a> <a href="#ref-for-dfn-job-5">(5)</a> <a href="#ref-for-dfn-job-6">(6)</a> <a href="#ref-for-dfn-job-7">(7)</a> <a href="#ref-for-dfn-job-8">(8)</a> <a href="#ref-for-dfn-job-9">(9)</a> <a href="#ref-for-dfn-job-10">(10)</a> <a href="#ref-for-dfn-job-11">(11)</a> <a href="#ref-for-dfn-job-12">(12)</a> <a href="#ref-for-dfn-job-13">(13)</a> <a href="#ref-for-dfn-job-14">(14)</a> <a href="#ref-for-dfn-job-15">(15)</a>
-    <li><a href="#ref-for-dfn-job-16">Create Job</a> <a href="#ref-for-dfn-job-17">(2)</a>
-    <li><a href="#ref-for-dfn-job-18">Schedule Job</a>
-    <li><a href="#ref-for-dfn-job-19">Finish Job</a>
-    <li><a href="#ref-for-dfn-job-20">Resolve Job Promise</a>
-    <li><a href="#ref-for-dfn-job-21">Reject Job Promise</a>
-    <li><a href="#ref-for-dfn-job-22">Register</a>
-    <li><a href="#ref-for-dfn-job-23">Update</a>
-    <li><a href="#ref-for-dfn-job-24">Install</a>
-    <li><a href="#ref-for-dfn-job-25">Unregister</a>
+    <li><a href="#ref-for-dfn-job-1">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job-2">(2)</a> <a href="#ref-for-dfn-job-3">(3)</a> <a href="#ref-for-dfn-job-4">(4)</a> <a href="#ref-for-dfn-job-5">(5)</a> <a href="#ref-for-dfn-job-6">(6)</a> <a href="#ref-for-dfn-job-7">(7)</a> <a href="#ref-for-dfn-job-8">(8)</a> <a href="#ref-for-dfn-job-9">(9)</a> <a href="#ref-for-dfn-job-10">(10)</a> <a href="#ref-for-dfn-job-11">(11)</a> <a href="#ref-for-dfn-job-12">(12)</a> <a href="#ref-for-dfn-job-13">(13)</a> <a href="#ref-for-dfn-job-14">(14)</a> <a href="#ref-for-dfn-job-15">(15)</a> <a href="#ref-for-dfn-job-16">(16)</a>
+    <li><a href="#ref-for-dfn-job-17">Create Job</a> <a href="#ref-for-dfn-job-18">(2)</a>
+    <li><a href="#ref-for-dfn-job-19">Schedule Job</a>
+    <li><a href="#ref-for-dfn-job-20">Finish Job</a>
+    <li><a href="#ref-for-dfn-job-21">Resolve Job Promise</a>
+    <li><a href="#ref-for-dfn-job-22">Reject Job Promise</a>
+    <li><a href="#ref-for-dfn-job-23">Register</a>
+    <li><a href="#ref-for-dfn-job-24">Update</a>
+    <li><a href="#ref-for-dfn-job-25">Install</a>
+    <li><a href="#ref-for-dfn-job-26">Unregister</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-type">
@@ -8387,9 +8446,17 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-job-worker-type">
    <b><a href="#dfn-job-worker-type">#dfn-job-worker-type</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-job-worker-type-1">3.2.5. update()</a>
-    <li><a href="#ref-for-dfn-job-worker-type-2">Update</a> <a href="#ref-for-dfn-job-worker-type-3">(2)</a>
-    <li><a href="#ref-for-dfn-job-worker-type-4">Soft Update</a>
+    <li><a href="#ref-for-dfn-job-worker-type-1">3.2.6. update()</a>
+    <li><a href="#ref-for-dfn-job-worker-type-2">3.4.3. register(scriptURL, options)</a>
+    <li><a href="#ref-for-dfn-job-worker-type-3">Update</a> <a href="#ref-for-dfn-job-worker-type-4">(2)</a>
+    <li><a href="#ref-for-dfn-job-worker-type-5">Soft Update</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-job-use-cache">
+   <b><a href="#dfn-job-use-cache">#dfn-job-use-cache</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-job-use-cache-1">3.4.3. register(scriptURL, options)</a>
+    <li><a href="#ref-for-dfn-job-use-cache-2">Register</a> <a href="#ref-for-dfn-job-use-cache-3">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-client">
@@ -8424,7 +8491,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-job-force-bypass-cache-flag">
    <b><a href="#dfn-job-force-bypass-cache-flag">#dfn-job-force-bypass-cache-flag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-1">Soft Update</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-1">Update</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-2">Soft Update</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-equivalent">
@@ -8445,8 +8513,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="create-job">
    <b><a href="#create-job">#create-job</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-create-job-1">3.2.5. update()</a>
-    <li><a href="#ref-for-create-job-2">3.2.6. unregister()</a>
+    <li><a href="#ref-for-create-job-1">3.2.6. update()</a>
+    <li><a href="#ref-for-create-job-2">3.2.7. unregister()</a>
     <li><a href="#ref-for-create-job-3">3.4.3. register(scriptURL, options)</a>
     <li><a href="#ref-for-create-job-4">Soft Update</a>
    </ul>
@@ -8454,8 +8522,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="schedule-job">
    <b><a href="#schedule-job">#schedule-job</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-schedule-job-1">3.2.5. update()</a>
-    <li><a href="#ref-for-schedule-job-2">3.2.6. unregister()</a>
+    <li><a href="#ref-for-schedule-job-1">3.2.6. update()</a>
+    <li><a href="#ref-for-schedule-job-2">3.2.7. unregister()</a>
     <li><a href="#ref-for-schedule-job-3">3.4.3. register(scriptURL, options)</a>
     <li><a href="#ref-for-schedule-job-4">Soft Update</a>
    </ul>
@@ -8672,7 +8740,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="get-newest-worker">
    <b><a href="#get-newest-worker">#get-newest-worker</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-get-newest-worker-1">3.2.5. update()</a>
+    <li><a href="#ref-for-get-newest-worker-1">3.2.6. update()</a>
     <li><a href="#ref-for-get-newest-worker-2">Register</a>
     <li><a href="#ref-for-get-newest-worker-3">Update</a>
     <li><a href="#ref-for-get-newest-worker-4">Soft Update</a>

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 18bde035bc0169bb31c49099bf3e6ec57ff9ec7f" name="generator">
+  <meta content="Bikeshed version 0feafaae1a97b66d9da46b325858f9805ac01fb2" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-06">6 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-08">8 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2342,8 +2342,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dom-serviceworkerglobalscope-onmessage" id="ref-for-dom-serviceworkerglobalscope-onmessage-1">onmessage</a>; // event.source of the message events is Client object
 };
 </pre>
-     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-6">ServiceWorkerGlobalScope</a></code> object represents the global execution context of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-51">service worker</a>. A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-7">ServiceWorkerGlobalScope</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="dfn" data-noexport="" id="serviceworkerglobalscope-service-worker">service worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-52">service worker</a>).</p>
-     <p class="note" role="note">Note: <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-8">ServiceWorkerGlobalScope</a></code> object provides generic, event-driven, time-limited script execution contexts that run at an origin. Once successfully <a data-link-type="dfn" href="#register" id="ref-for-register-2">registered</a>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-53">service worker</a> is started, kept alive and killed by their relationship to events, not <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-25">service worker clients</a>. Any type of synchronous requests must not be initiated inside of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-54">service worker</a>.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-6">ServiceWorkerGlobalScope</a></code> object represents the global execution context of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-51">service worker</a>. A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-7">ServiceWorkerGlobalScope</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="dfn" data-noexport="" id="serviceworkerglobalscope-service-worker">service worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-52">service worker</a>). A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-8">ServiceWorkerGlobalScope</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="dfn" data-noexport="" id="serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">force bypass cache for importscripts flag</dfn>. It is initially unset.</p>
+     <p class="note" role="note">Note: <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-9">ServiceWorkerGlobalScope</a></code> object provides generic, event-driven, time-limited script execution contexts that run at an origin. Once successfully <a data-link-type="dfn" href="#register" id="ref-for-register-2">registered</a>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-53">service worker</a> is started, kept alive and killed by their relationship to events, not <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-25">service worker clients</a>. Any type of synchronous requests must not be initiated inside of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-54">service worker</a>.</p>
      <section>
       <h4 class="heading settled" data-level="4.1.1" id="service-worker-global-scope-clients"><span class="secno">4.1.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-clients" id="ref-for-dom-serviceworkerglobalscope-clients-2">clients</a></code></span><a class="self-link" href="#service-worker-global-scope-clients"></a></h4>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export="" id="dom-serviceworkerglobalscope-clients"><code>clients</code></dfn> attribute <em>must</em> return the <code class="idl"><a data-link-type="idl" href="#clients" id="ref-for-clients-2">Clients</a></code> object that is associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
@@ -2373,7 +2373,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </section>
      <section>
       <h4 class="heading settled" data-level="4.1.4" id="service-worker-global-scope-event-handlers"><span class="secno">4.1.4. </span><span class="content">Event handlers</span><a class="self-link" href="#service-worker-global-scope-event-handlers"></a></h4>
-      <p>The following are the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handlers</a> (and their corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event types</a>) that <em>must</em> be supported, as <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">event handler IDL attributes</a>, by all objects implementing the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-9">ServiceWorkerGlobalScope</a></code> interface:</p>
+      <p>The following are the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handlers</a> (and their corresponding <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">event handler event types</a>) that <em>must</em> be supported, as <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">event handler IDL attributes</a>, by all objects implementing the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-10">ServiceWorkerGlobalScope</a></code> interface:</p>
       <table class="data">
        <thead>
         <tr>
@@ -2625,7 +2625,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <dfn class="s dfn-paneled idl-code" data-dfn-for="ClientType" data-dfn-type="enum-value" data-export="" data-lt="&quot;all&quot;|all" id="dom-clienttype-all">"all"</dfn>
 };
 </pre>
-     <p>The user agent <em>must</em> create a <code class="idl"><a data-link-type="idl" href="#clients" id="ref-for-clients-4">Clients</a></code> object when a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-10">ServiceWorkerGlobalScope</a></code> object is created and associate it with that object.</p>
+     <p>The user agent <em>must</em> create a <code class="idl"><a data-link-type="idl" href="#clients" id="ref-for-clients-4">Clients</a></code> object when a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-11">ServiceWorkerGlobalScope</a></code> object is created and associate it with that object.</p>
      <section class="algorithm" data-algorithm="clients-get">
       <h4 class="heading settled" data-level="4.3.1" id="clients-get"><span class="secno">4.3.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-clients-get" id="ref-for-dom-clients-get-2">get(id)</a></code></span><a class="self-link" href="#clients-get"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Clients" data-dfn-type="method" data-export="" id="dom-clients-get"><code>get(<var>id</var>)</code></dfn> method <em>must</em> run these steps:</p>
@@ -2965,7 +2965,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> <var>f</var> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-4">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-5">installing worker</a> as <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-4">waiting worker</a>) until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-5">extend lifetime promises</a> resolve successfully. (See step 11.3.1 of <a data-link-type="dfn" href="#install" id="ref-for-install-3">Install</a> algorithm.) If <var>f</var> rejects, the installation fails. This is primarily used to ensure that a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-62">service worker</a> is not considered <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-5">waiting worker</a>) until all of the core caches it depends on are populated.</p>
       <li data-md="">
-       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-6">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-17">active worker</a> as <em>activated</em> until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-7">extend lifetime promises</a> settle. (See step 12.3 of <a data-link-type="dfn" href="#activate" id="ref-for-activate-5">Activate</a> algorithm.) This is primarily used to ensure that any <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-2">functional events</a> are not dispatched to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-11">ServiceWorkerGlobalScope</a></code> object that represents the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-63">service worker</a> until it upgrades database schemas and deletes the outdated cache entries.</p>
+       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-6">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-17">active worker</a> as <em>activated</em> until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-7">extend lifetime promises</a> settle. (See step 12.3 of <a data-link-type="dfn" href="#activate" id="ref-for-activate-5">Activate</a> algorithm.) This is primarily used to ensure that any <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-2">functional events</a> are not dispatched to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-12">ServiceWorkerGlobalScope</a></code> object that represents the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-63">service worker</a> until it upgrades database schemas and deletes the outdated cache entries.</p>
      </ul>
     </section>
     <section>
@@ -3194,7 +3194,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="4.7" id="execution-context-events"><span class="secno">4.7. </span><span class="content">Events</span><a class="self-link" href="#execution-context-events"></a></h3>
-     <p>The following events are dispatched on <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-12">ServiceWorkerGlobalScope</a></code> object:</p>
+     <p>The following events are dispatched on <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-13">ServiceWorkerGlobalScope</a></code> object:</p>
      <table class="data">
       <thead>
        <tr>
@@ -3948,7 +3948,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </section>
      <section>
       <h4 class="heading settled" data-level="6.3.2" id="importscripts"><span class="secno">6.3.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-importscripts">importScripts(urls)</a></code></span><a class="self-link" href="#importscripts"></a></h4>
-      <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="method" data-export="" id="importscripts-method"><code>importScripts(<var>urls</var>)</code></dfn> method is called on a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-13">ServiceWorkerGlobalScope</a></code> object, the user agent <em>must</em> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">import scripts into worker global scope</a>, given this <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-14">ServiceWorkerGlobalScope</a></code> object and <var>urls</var>, and with the following steps to <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a> given the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> <var>request</var>:</p>
+      <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="method" data-export="" id="importscripts-method"><code>importScripts(<var>urls</var>)</code></dfn> method is called on a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-14">ServiceWorkerGlobalScope</a></code> object, the user agent <em>must</em> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">import scripts into worker global scope</a>, given this <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-15">ServiceWorkerGlobalScope</a></code> object and <var>urls</var>, and with the following steps to <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a> given the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> <var>request</var>:</p>
       <ol>
        <li data-md="">
         <p>Let <var>serviceWorker</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-19">service worker</a>.</p>
@@ -3956,7 +3956,21 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>If <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-imported-scripts-updated-flag" id="ref-for-dfn-imported-scripts-updated-flag-1">imported scripts updated flag</a> is unset, then:</p>
         <ol>
          <li data-md="">
+          <p>Let <var>registration</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-10">containing service worker registration</a>.</p>
+         <li data-md="">
+          <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">cache mode</a> to "<code>no-cache</code>" if any of the following are true:</p>
+          <ul>
+           <li data-md="">
+            <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-2">use cache</a> is false.</p>
+           <li data-md="">
+            <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">current global object</a>'s <a data-link-type="dfn" href="#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag" id="ref-for-serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag-1">force bypass cache for importscripts flag</a> is set.</p>
+           <li data-md="">
+            <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-1">last update check time</a> is not null and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-2">last update check time</a> is greater than 86400.</p>
+          </ul>
+         <li data-md="">
           <p>Let <var>response</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetching</a> <var>request</var>.</p>
+         <li data-md="">
+          <p>If <var>response</var>’s <a href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-3">last update check time</a> to the current time.</p>
          <li data-md="">
           <p>If <var>response</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#unsafe-response">unsafe response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type">type</a> is not "<code>error</code>", and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status">status</a> is an <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#ok-status">ok status</a>, then:</p>
           <ol>
@@ -4023,7 +4037,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="7.3" id="extension-to-service-worker-global-scope"><span class="secno">7.3. </span><span class="content">Define Event Handler</span><a class="self-link" href="#extension-to-service-worker-global-scope"></a></h3>
-     <p>Specifications <em>may</em> define an event handler attribute for the corresponding <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-6">functional event</a> using <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-partial-interface">partial interface</a> definition to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-15">ServiceWorkerGlobalScope</a></code> interface:</p>
+     <p>Specifications <em>may</em> define an event handler attribute for the corresponding <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-6">functional event</a> using <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-partial-interface">partial interface</a> definition to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-16">ServiceWorkerGlobalScope</a></code> interface:</p>
 <pre class="example idl highlight def" data-no-idl="" id="example-bdf67845"><a class="self-link" href="#example-bdf67845"></a><span class="kt">partial</span> <span class="kt">interface</span> <span class="nv">ServiceWorkerGlobalScope</span> {
   <span class="kt">attribute</span> <span class="n">EventHandler</span> <span class="nv">onfunctionalevent</span>;
 };
@@ -4032,7 +4046,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="7.4" id="request-functional-event-dispatch"><span class="secno">7.4. </span><span class="content">Request Functional Event Dispatch</span><a class="self-link" href="#request-functional-event-dispatch"></a></h3>
      <p>To request a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-7">functional event</a> dispatch to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-86">service worker</a>, specifications <em>may</em> invoke <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-2">Handle Functional Event</a> algorithm with its <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-47">service worker registration</a> <var>registration</var> and the algorithm <var>callbackSteps</var> as the arguments.</p>
-     <p>Specifications <em>may</em> define an algorithm <var>callbackSteps</var> where the corresponding <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-8">functional event</a> can be created and fired with specification specific objects. The algorithm is passed <var>globalObject</var> (a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-16">ServiceWorkerGlobalScope</a></code> object) at which it <em>may</em> fire its <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-9">functional events</a>. This algorithm is called on a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-3">Handle Functional Event</a> algorithm.</p>
+     <p>Specifications <em>may</em> define an algorithm <var>callbackSteps</var> where the corresponding <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-8">functional event</a> can be created and fired with specification specific objects. The algorithm is passed <var>globalObject</var> (a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-17">ServiceWorkerGlobalScope</a></code> object) at which it <em>may</em> fire its <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-9">functional events</a>. This algorithm is called on a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-3">Handle Functional Event</a> algorithm.</p>
      <p class="note" role="note">Note: See an <a href="https://notifications.spec.whatwg.org/#activating-a-notification">example</a> hook defined in <a data-link-type="biblio" href="#biblio-notifications">Notifications API</a>.</p>
     </section>
    </section>
@@ -4050,7 +4064,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-6">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-client">client</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-36">service worker client</a>). It is initially null.</p>
      <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-7">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-promise">job promise</dfn> (a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>). It is initially null.</p>
      <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-8">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-list-of-equivalent-jobs">list of equivalent jobs</dfn> (a list of <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-9">jobs</a>). It is initially the empty list.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-10">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-force-bypass-cache-flag">force bypass cache flag</dfn> It is initially unset.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-10">job</a> has a <dfn class="dfn-paneled" data-dfn-for="job" data-dfn-type="dfn" data-noexport="" id="dfn-job-force-bypass-cache-flag">force bypass cache flag</dfn>. It is initially unset.</p>
     </div>
     <p>Two <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-11">jobs</a> are <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dfn-job-equivalent">equivalent</dfn> when their <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-1">job type</a> is the same and:</p>
     <ul>
@@ -4276,7 +4290,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Let <var>newestWorker</var> be the result of running the <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-2">Get Newest Worker</a> algorithm passing <var>registration</var> as the argument.</p>
         <li data-md="">
-         <p>If <var>newestWorker</var> is not null, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-5">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-3">script url</a> with the <em>exclude fragments flag</em> set, and <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-use-cache" id="ref-for-dfn-job-use-cache-2">use cache</a>'s value equals <var>registration</var>’s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-2">use cache</a>'s value, then:</p>
+         <p>If <var>newestWorker</var> is not null, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-5">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-3">script url</a> with the <em>exclude fragments flag</em> set, and <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-use-cache" id="ref-for-dfn-job-use-cache-2">use cache</a>'s value equals <var>registration</var>’s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-3">use cache</a>'s value, then:</p>
          <ol>
           <li data-md="">
            <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-1">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-17">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
@@ -4354,11 +4368,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">cache mode</a> to "<code>no-cache</code>" if any of the following are true:</p>
          <ul>
           <li data-md="">
-           <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-3">use cache</a> is false.</p>
+           <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-4">use cache</a> is false.</p>
           <li data-md="">
            <p><var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-1">force bypass cache flag</a> is set.</p>
           <li data-md="">
-           <p><var>newestWorker</var> is not null, and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-1">last update check time</a> is not null and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-2">last update check time</a> is greater than 86400.</p>
+           <p><var>newestWorker</var> is not null, and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-4">last update check time</a> is not null and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-5">last update check time</a> is greater than 86400.</p>
          </ul>
          <p class="note" role="note">Note: Even if the cache mode is not set to "<code>no-cache</code>", the user agent obeys Cache-Control header’s max-age value in the network layer to determine if it should bypass the browser cache.</p>
         <li data-md="">
@@ -4415,7 +4429,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <p>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
          </ol>
         <li data-md="">
-         <p>If <var>response</var>’s <a href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-3">last update check time</a> to the current time.</p>
+         <p>If <var>response</var>’s <a href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-6">last update check time</a> to the current time.</p>
          <p class="issue" id="issue-3c7457a0"><a class="self-link" href="#issue-3c7457a0"></a> The response’s cache state concept had been removed from fetch. The fetch issue <a href="https://github.com/whatwg/fetch/issues/376">#376</a> tracks the request to restore the concept or add some similar way to check this state.</p>
         <li data-md="">
          <p>Return true.</p>
@@ -4453,7 +4467,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-10">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy-1">referrer policy</a> to <var>referrerPolicy</var>.</p>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-3">Run Service Worker</a> algorithm with <var>worker</var> as the argument.</p>
+         <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-3">Run Service Worker</a> algorithm given <var>worker</var>, and with the <em>force bypass cache for importscripts flag</em> set if <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-2">force bypass cache flag</a> is set.</p>
         <li data-md="">
          <p>If an uncaught runtime script error occurs during the above step, then:</p>
          <ol>
@@ -4495,7 +4509,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-5">worker type</a> to <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-3">type</a>.</p>
       <li data-md="">
-       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-2">force bypass cache flag</a> if its <em>force bypass cache flag</em> is set.</p>
+       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-3">force bypass cache flag</a> if its <em>force bypass cache flag</em> is set.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#schedule-job" id="ref-for-schedule-job-4">Schedule Job</a> with <var>job</var>.</p>
      </ol>
@@ -4532,11 +4546,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-3">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-19">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-38">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-15">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-89">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-10">containing service worker registration</a> is <var>registration</var>.</p>
+       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-38">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-15">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-89">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-11">containing service worker registration</a> is <var>registration</var>.</p>
       <li data-md="">
        <p>Let <var>installingWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-8">installing worker</a>.</p>
       <li data-md="">
-       <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-4">Run Service Worker</a> algorithm with <var>installingWorker</var> as the argument.</p>
+       <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-4">Run Service Worker</a> algorithm given <var>installingWorker</var>, and with the <em>force bypass cache for importscripts flag</em> set if <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-4">force bypass cache flag</a> is set.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps:</p>
        <ol>
@@ -4692,6 +4706,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Input</p>
       <dd data-md="">
        <p><var>serviceWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-90">service worker</a></p>
+      <dd data-md="">
+       <p><em>force bypass cache for importscripts flag</em>, an optional flag unset by default</p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -4710,7 +4726,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Call the JavaScript <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-initializehostdefinedrealm">InitializeHostDefinedRealm()</a> abstract operation with the following customizations:</p>
        <ul>
         <li data-md="">
-         <p>For the global object, create a new <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-17">ServiceWorkerGlobalScope</a></code> object. Let <var>workerGlobalScope</var> be the created object.</p>
+         <p>For the global object, create a new <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-18">ServiceWorkerGlobalScope</a></code> object. Let <var>workerGlobalScope</var> be the created object.</p>
         <li data-md="">
          <p>Let <var>realmExecutionContext</var> be the created <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-execution-contexts">JavaScript execution context</a>.</p>
        </ul>
@@ -4767,9 +4783,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type">type</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-4">type</a>.</p>
       <li data-md="">
+       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag" id="ref-for-serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag-2">force bypass cache for importscripts flag</a> if its <em>force bypass cache for importscripts flag</em> is set.</p>
+      <li data-md="">
        <p>Create a new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">WorkerLocation</a></code> object and associate it with <var>workerGlobalScope</var>.</p>
       <li data-md="">
-       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-11">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
+       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-12">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
       <li data-md="">
        <p>If <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>, then <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">run the classic script</a> <var>script</var>. Otherwise, it is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">module script</a>; <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">run the module script</a> <var>script</var>.</p>
        <p class="note" role="note">Note: In addition to the usual possibilities of returning a value or failing due to an exception, this could be prematurely aborted by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">kill a worker</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">terminate a worker</a> algorithms.</p>
@@ -4808,7 +4826,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>serviceWorkerGlobalScope</var>’s closing flag to true.</p>
       <li data-md="">
-       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-12">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
+       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-13">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
        <p class="note" role="note">Note: This effectively means that the fetch events and the other functional events such as push events are backed up by the registration’s task queues while the other tasks including message events are discarded.</p>
       <li data-md="">
        <p>Abort the script currently running in <var>serviceWorker</var>.</p>
@@ -4913,12 +4931,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-28">active worker</a>.</p>
        </ol>
-       <p class="note" role="note">Note: From this point, the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-43">service worker client</a> starts to <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-6">use</a> its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-13">containing service worker registration</a>.</p>
+       <p class="note" role="note">Note: From this point, the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-43">service worker client</a> starts to <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-6">use</a> its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a>.</p>
       <li data-md="">
        <p>Else if <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is non-null, set <var>registration</var> to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a>.</p>
+         <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is non-null, set <var>registration</var> to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-15">containing service worker registration</a>.</p>
         <li data-md="">
          <p>Else, return null.</p>
        </ol>
@@ -4930,7 +4948,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Return null and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-4">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-1">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-7">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-1">Soft Update</a> algorithm with <var>registration</var>.</p>
         <li data-md="">
          <p>Abort these steps.</p>
        </ol>
@@ -4989,7 +5007,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Else, return null and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-5">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-2">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-8">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-2">Soft Update</a> algorithm with <var>registration</var>.</p>
         <li data-md="">
          <p>Abort these steps.</p>
        </ol>
@@ -4999,7 +5017,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-6">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-3">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-9">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-3">Soft Update</a> algorithm with <var>registration</var>.</p>
        </ol>
       <li data-md="">
        <p>Else:</p>
@@ -5007,7 +5025,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Return <var>response</var> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-7">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-4">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-10">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-4">Soft Update</a> algorithm with <var>registration</var>.</p>
        </ol>
      </ol>
     </section>
@@ -5040,7 +5058,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Return and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
         <li data-md="">
-         <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-8">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-5">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-11">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-5">Soft Update</a> algorithm with <var>registration</var>.</p>
         <li data-md="">
          <p>Abort these steps.</p>
        </ol>
@@ -5061,7 +5079,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded.</p>
       <li data-md="">
-       <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-9">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-6">Soft Update</a> algorithm with <var>registration</var>.</p>
+       <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-12">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update-6">Soft Update</a> algorithm with <var>registration</var>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle Service Worker Client Unload">
@@ -5187,7 +5205,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>scopeString</var> be <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <var>scope</var> with the <em>exclude fragment flag</em> set.</p>
       <li data-md="">
-       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-57">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-17">scope url</a> is set to <var>scope</var> and <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-4">use cache</a> is set to <var>useCache</var>.</p>
+       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-57">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-17">scope url</a> is set to <var>scope</var> and <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-5">use cache</a> is set to <var>useCache</var>.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set">Set</a> <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-9">scope to registration map</a>[<var>scopeString</var>] to <var>registration</var>.</p>
       <li data-md="">
@@ -5956,6 +5974,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dom-windowclient-focused">focused</a><span>, in §4.2.7</span>
    <li><a href="#dfn-service-worker-client-focusstate">focus state</a><span>, in §4.2</span>
    <li><a href="#dfn-job-force-bypass-cache-flag">force bypass cache flag</a><span>, in §Unnumbered section</span>
+   <li><a href="#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">force bypass cache for importscripts flag</a><span>, in §4.1</span>
    <li><a href="#dfn-functional-events">functional events</a><span>, in §2.1</span>
    <li><a href="#dom-clients-get">get(id)</a><span>, in §4.3.1</span>
    <li><a href="#get-newest-worker">Get Newest Worker</a><span>, in §Unnumbered section</span>
@@ -6403,6 +6422,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation url</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">current global object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-data">data</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#discard-a-document">discard a document</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">dom manipulation task source</a>
@@ -6905,10 +6925,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-containing-service-worker-registration-5">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-containing-service-worker-registration-6">(2)</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-7">4.3.4. claim()</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-8">4.7. Events</a> <a href="#ref-for-dfn-containing-service-worker-registration-9">(2)</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-10">Install</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-11">Run Service Worker</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-12">Terminate Service Worker</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-13">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration-14">(2)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-10">6.3.2. importScripts(urls)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-11">Install</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-12">Run Service Worker</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-13">Terminate Service Worker</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-14">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration-15">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-service-worker-id">
@@ -7120,18 +7141,20 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-last-update-check-time">
    <b><a href="#dfn-last-update-check-time">#dfn-last-update-check-time</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-last-update-check-time-1">Update</a> <a href="#ref-for-dfn-last-update-check-time-2">(2)</a> <a href="#ref-for-dfn-last-update-check-time-3">(3)</a>
-    <li><a href="#ref-for-dfn-last-update-check-time-4">Handle Fetch</a> <a href="#ref-for-dfn-last-update-check-time-5">(2)</a> <a href="#ref-for-dfn-last-update-check-time-6">(3)</a> <a href="#ref-for-dfn-last-update-check-time-7">(4)</a>
-    <li><a href="#ref-for-dfn-last-update-check-time-8">Handle Functional Event</a> <a href="#ref-for-dfn-last-update-check-time-9">(2)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time-1">6.3.2. importScripts(urls)</a> <a href="#ref-for-dfn-last-update-check-time-2">(2)</a> <a href="#ref-for-dfn-last-update-check-time-3">(3)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time-4">Update</a> <a href="#ref-for-dfn-last-update-check-time-5">(2)</a> <a href="#ref-for-dfn-last-update-check-time-6">(3)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time-7">Handle Fetch</a> <a href="#ref-for-dfn-last-update-check-time-8">(2)</a> <a href="#ref-for-dfn-last-update-check-time-9">(3)</a> <a href="#ref-for-dfn-last-update-check-time-10">(4)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time-11">Handle Functional Event</a> <a href="#ref-for-dfn-last-update-check-time-12">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-use-cache">
    <b><a href="#dfn-use-cache">#dfn-use-cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-use-cache-1">3.2.5. useCache</a>
-    <li><a href="#ref-for-dfn-use-cache-2">Register</a>
-    <li><a href="#ref-for-dfn-use-cache-3">Update</a>
-    <li><a href="#ref-for-dfn-use-cache-4">Set Registration</a>
+    <li><a href="#ref-for-dfn-use-cache-2">6.3.2. importScripts(urls)</a>
+    <li><a href="#ref-for-dfn-use-cache-3">Register</a>
+    <li><a href="#ref-for-dfn-use-cache-4">Update</a>
+    <li><a href="#ref-for-dfn-use-cache-5">Set Registration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-uninstalling-flag">
@@ -7599,15 +7622,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworkerglobalscope-1">2.1. Service Worker</a>
     <li><a href="#ref-for-serviceworkerglobalscope-2">3.1.3. postMessage(message, transfer)</a> <a href="#ref-for-serviceworkerglobalscope-3">(2)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-4">3.2.6. update()</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-5">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-serviceworkerglobalscope-6">(2)</a> <a href="#ref-for-serviceworkerglobalscope-7">(3)</a> <a href="#ref-for-serviceworkerglobalscope-8">(4)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-9">4.1.4. Event handlers</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-10">4.3. Clients</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-11">4.4. ExtendableEvent</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-12">4.7. Events</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-13">6.3.2. importScripts(urls)</a> <a href="#ref-for-serviceworkerglobalscope-14">(2)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-15">7.3. Define Event Handler</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-16">7.4. Request Functional Event Dispatch</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-17">Run Service Worker</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-5">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-serviceworkerglobalscope-6">(2)</a> <a href="#ref-for-serviceworkerglobalscope-7">(3)</a> <a href="#ref-for-serviceworkerglobalscope-8">(4)</a> <a href="#ref-for-serviceworkerglobalscope-9">(5)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-10">4.1.4. Event handlers</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-11">4.3. Clients</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-12">4.4. ExtendableEvent</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-13">4.7. Events</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-14">6.3.2. importScripts(urls)</a> <a href="#ref-for-serviceworkerglobalscope-15">(2)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-16">7.3. Define Event Handler</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-17">7.4. Request Functional Event Dispatch</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-18">Run Service Worker</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serviceworkerglobalscope-service-worker">
@@ -7625,6 +7648,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-16">4.7. Events</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-17">(2)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-18">(3)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-19">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-20">Run Service Worker</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">
+   <b><a href="#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag-1">6.3.2. importScripts(urls)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag-2">Run Service Worker</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-clients">
@@ -8492,8 +8522,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-job-force-bypass-cache-flag">
    <b><a href="#dfn-job-force-bypass-cache-flag">#dfn-job-force-bypass-cache-flag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-1">Update</a>
-    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-2">Soft Update</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-1">Update</a> <a href="#ref-for-dfn-job-force-bypass-cache-flag-2">(2)</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-3">Soft Update</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag-4">Install</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-equivalent">

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-08">8 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-09">9 December 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -4432,7 +4432,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        </ol>
        <p>Else, continue the rest of these steps after the algorithm’s asynchronous completion, with <var>script</var> being the asynchronous completion value.</p>
       <li data-md="">
-       <p>If <var>newestWorker</var> is not null, <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-5">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-11">script url</a> with the <em>exclude fragments flag</em> set, and <var>script</var> is a byte-for-byte match with <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-6">script resource</a>, then:</p>
+       <p>If <var>newestWorker</var> is not null, <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-5">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-11">script url</a> with the <em>exclude fragments flag</em> set, and <var>script</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-classic-script-source-text">source text</a> is a byte-for-byte match with <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-6">script resource</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-classic-script-source-text">source text</a>, if <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>, and <var>script</var>’s <a data-link-type="dfn">module record</a>'s [[ECMAScriptCode]] is a byte-for-byte match with <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-7">script resource</a>'s <a data-link-type="dfn">module record</a>'s [[ECMAScriptCode]] otherwise, then:</p>
        <ol>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-2">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-18">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
@@ -4447,11 +4447,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Generate a unique opaque string and set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-id" id="ref-for-dfn-service-worker-id-1">id</a> to the value.</p>
         <li data-md="">
-         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-6">script url</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-12">script url</a>, <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-7">script resource</a> to <var>script</var>, and <var>worker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-2">type</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-4">worker type</a>.</p>
+         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-6">script url</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-12">script url</a>, <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-8">script resource</a> to <var>script</var>, and <var>worker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-2">type</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-4">worker type</a>.</p>
         <li data-md="">
-         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-8">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state-1">HTTPS state</a> to <var>httpsState</var>.</p>
+         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-9">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state-1">HTTPS state</a> to <var>httpsState</var>.</p>
         <li data-md="">
-         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-9">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy-1">referrer policy</a> to <var>referrerPolicy</var>.</p>
+         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-10">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy-1">referrer policy</a> to <var>referrerPolicy</var>.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-3">Run Service Worker</a> algorithm with <var>worker</var> as the argument.</p>
         <li data-md="">
@@ -4699,7 +4699,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>Let <var>script</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-10">script resource</a>.</p>
+       <p>Let <var>script</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-11">script resource</a>.</p>
       <li data-md="">
        <p class="assertion">Assert: <var>script</var> is not null.</p>
       <li data-md="">
@@ -4761,9 +4761,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">url</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-9">script url</a>.</p>
       <li data-md="">
-       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state">HTTPS state</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-11">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state-2">HTTPS state</a>.</p>
+       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state">HTTPS state</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-12">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state-2">HTTPS state</a>.</p>
       <li data-md="">
-       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-referrer-policy">referrer policy</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-12">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy-2">referrer policy</a>.</p>
+       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-referrer-policy">referrer policy</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-13">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy-2">referrer policy</a>.</p>
       <li data-md="">
        <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type">type</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-4">type</a>.</p>
       <li data-md="">
@@ -5770,18 +5770,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <h2 class="heading settled" id="extended-http-headers"><span class="content">Appendix B: Extended HTTP headers</span><a class="self-link" href="#extended-http-headers"></a></h2>
     <section>
      <h3 class="heading settled" id="service-worker-script-request"><span class="content">Service Worker Script Request</span><a class="self-link" href="#service-worker-script-request"></a></h3>
-     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-13">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker"><code>Service-Worker</code><a class="self-link" href="#service-worker"></a></dfn>`</p>
       <dd data-md="">
-       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> request.</p>
+       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request.</p>
        <p class="note" role="note">Note: This header helps administrators log the requests and detect threats.</p>
      </dl>
     </section>
     <section>
      <h3 class="heading settled" id="service-worker-script-response"><span class="content">Service Worker Script Response</span><a class="self-link" href="#service-worker-script-response"></a></h3>
-     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker-allowed"><code>Service-Worker-Allowed</code><a class="self-link" href="#service-worker-allowed"></a></dfn>`</p>
@@ -5828,7 +5828,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" id="syntax"><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
-     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-109">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> requests and responses:</p>
+     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-109">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-17">script resource</a> requests and responses:</p>
 <pre>Service-Worker = %x73.63.72.69.70.74 ; "script", case-sensitive
 </pre>
      <p class="note" role="note">Note: The validation of the Service-Worker-Allowed header’s values is done by URL parsing algorithm (in Update algorithm) instead of using ABNF.</p>
@@ -6458,6 +6458,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#shared-workers">shared worker</a>
      <li><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source">source</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#source-browsing-context">source browsing context</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-classic-script-source-text">source text</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">target browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>
@@ -6952,11 +6953,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-script-resource-1">2.1. Service Worker</a> <a href="#ref-for-dfn-script-resource-2">(2)</a> <a href="#ref-for-dfn-script-resource-3">(3)</a>
     <li><a href="#ref-for-dfn-script-resource-4">6.2. Content Security Policy</a> <a href="#ref-for-dfn-script-resource-5">(2)</a>
-    <li><a href="#ref-for-dfn-script-resource-6">Update</a> <a href="#ref-for-dfn-script-resource-7">(2)</a> <a href="#ref-for-dfn-script-resource-8">(3)</a> <a href="#ref-for-dfn-script-resource-9">(4)</a>
-    <li><a href="#ref-for-dfn-script-resource-10">Run Service Worker</a> <a href="#ref-for-dfn-script-resource-11">(2)</a> <a href="#ref-for-dfn-script-resource-12">(3)</a>
-    <li><a href="#ref-for-dfn-script-resource-13">Service Worker Script Request</a> <a href="#ref-for-dfn-script-resource-14">(2)</a>
-    <li><a href="#ref-for-dfn-script-resource-15">Service Worker Script Response</a>
-    <li><a href="#ref-for-dfn-script-resource-16">Syntax</a>
+    <li><a href="#ref-for-dfn-script-resource-6">Update</a> <a href="#ref-for-dfn-script-resource-7">(2)</a> <a href="#ref-for-dfn-script-resource-8">(3)</a> <a href="#ref-for-dfn-script-resource-9">(4)</a> <a href="#ref-for-dfn-script-resource-10">(5)</a>
+    <li><a href="#ref-for-dfn-script-resource-11">Run Service Worker</a> <a href="#ref-for-dfn-script-resource-12">(2)</a> <a href="#ref-for-dfn-script-resource-13">(3)</a>
+    <li><a href="#ref-for-dfn-script-resource-14">Service Worker Script Request</a> <a href="#ref-for-dfn-script-resource-15">(2)</a>
+    <li><a href="#ref-for-dfn-script-resource-16">Service Worker Script Response</a>
+    <li><a href="#ref-for-dfn-script-resource-17">Syntax</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-has-ever-been-evaluated-flag">


### PR DESCRIPTION
This introduces service worker registration's use cache field and its
related APIs: options.useCache to register method and
registration.useCache for ServiceWorkerRegistration objects. This
changes the default cache mode of fetching SW scripts to "no-cache".
After the change, 24 hours limit and job's force bypass cache flag rules
are still enforced. register() method's options value set to
{ useCache: true } re-enables the previous default behavior provided
before this change.

Fixes #893 #894.