### PR TITLE
Link to v1 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To understand the design and how you might build apps with service workers, see 
 
 ## Spec and API development
 
-For the nitty-gritty of the API, the [draft W3C specification](https://w3c.github.io/ServiceWorker/) is authoritative. For implementers and developers who seek a more stable version, [Service Workers 1](https://w3c.github.io/ServiceWorker/) is a right document with which the contributors only focus on fixing bugs and resolving compatibility issues.
+For the nitty-gritty of the API, the [draft W3C specification](https://w3c.github.io/ServiceWorker/) is authoritative. For implementers and developers who seek a more stable version, [Service Workers 1](https://w3c.github.io/ServiceWorker/v1/) is a right document with which the contributors only focus on fixing bugs and resolving compatibility issues.
 
 Spec development happens via [issues in this repository](https://github.com/w3c/ServiceWorker/issues). For general discussion, please use the [public-webapps@w3.org mailing list](http://lists.w3.org/Archives/Public/public-webapps/) with a `Subject:` prefix of `[service-workers]`.
 


### PR DESCRIPTION
CONTRIBUTING.md had the right link, but this didn't.

Followup to commit 3d10320a49ca9cef533d3ca3b2b5ca7677076b36.