### PR TITLE
Improve handling of extend lifetime promises

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2855,8 +2855,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: None
 
-      1. Wait, [=in parallel=], until |promise| is settled and |promise|'s <code>then</code> methods, if any, in the task where |promise| has been settled have executed.
-      2. [=Queue a microtask=], on |promise|'s [=relevant settings object=]'s [=responsible event loop=], to decrease |event|'s [=ExtendableEvent/pending promises count=] by one.
+      1. Wait until |promise| is settled [=in parallel=].
+      2. [=Queue a task=], on |promise|'s [=relevant settings object=]'s [=responsible event loop=], to decrease |event|'s [=ExtendableEvent/pending promises count=] by one.
   </section>
 
   <section algorithm>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1289,15 +1289,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     An {{ExtendableEvent}} object has an associated <dfn for="ExtendableEvent">extend lifetime promises</dfn> (an array of <a>promises</a>). It is initially an empty array.
 
-    An {{ExtendableEvent}} object has an associated <dfn for="ExtendableEvent" id="extensions-allowed-flag">extensions allowed flag</dfn>. It is initially set.
-
     An {{ExtendableEvent}} object has an associated <dfn for="ExtendableEvent">pending promises count</dfn> (the number of pending promises in the [=ExtendableEvent/extend lifetime promises=]). It is initially set to zero.
 
     [=/Service workers=] have two <a>lifecycle events</a>, {{install!!event}} and {{activate!!event}}. [=/Service workers=] use the {{ExtendableEvent}} interface for {{activate!!event}} event and {{install!!event}} event.
 
     <a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> *may* also use or extend the {{ExtendableEvent}} interface.
-
-    Note: To extend the lifetime of a [=/service worker=], algorithms that <a>dispatch</a> events using the {{ExtendableEvent}} interface run [=Extend Service Worker Lifetime=] algorithm after <a>dispatching</a> the event. See <a>Handle Fetch</a>, <a>Handle Foreign Fetch</a>, and <a>Handle Functional Event</a>.
 
     <section algorithm="wait-until-method">
       <h4 id="wait-until-method">{{ExtendableEvent/waitUntil()|event.waitUntil(f)}}</h4>
@@ -1306,9 +1302,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       <dfn method for="ExtendableEvent"><code>waitUntil(|f|)</code></dfn> method *must* run these steps:
 
-        1. If the <a>extensions allowed flag</a> is unset, then:
+        1. If the [=ExtendableEvent/pending promises count=] is zero and the [=dispatch flag=] is unset, then:
             1. <a>Throw</a> an "{{InvalidStateError}}" exception.
             1. Abort these steps.
+
+            Note: If no lifetime extension promise has been added in the task that called the event handlers), calling {{ExtendableEvent/waitUntil()}} in subsequent asynchronous tasks will throw.
+
         1. Add |f| to the [=ExtendableEvent/extend lifetime promises=].
         1. Increase the [=ExtendableEvent/pending promises count=] by one.
 
@@ -1316,6 +1315,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
         1. Run [=Handle Extend Lifetime Promise=] with the [=context object=] and |f|.
         1. Return.
+
+        The user agent *should not* <a lt="terminate service worker">terminate</a> the [=/service worker=] associated with |event|'s <a>relevant settings object</a>'s [=environment settings object/global object=] when |event|'s [=dispatch flag=] is set or |event|'s [=ExtendableEvent/pending promises count=] is not zero. However, the user agent *may* impose a time limit to this lifetime extension.
     </section>
 
     [=/Service workers=] and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> *may* define their own behaviors, allowing the [=ExtendableEvent/extend lifetime promises=] to suggest operation length, and the rejected state of any of the <a>promise</a> in [=ExtendableEvent/extend lifetime promises=] to suggest operation failure.
@@ -2696,9 +2697,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Let |e| be the result of <a>creating an event</a> with {{InstallEvent}}.
           1. Initialize |e|’s {{Event/type}} attribute to {{install!!event}}.
           1. <a>Dispatch</a> |e| at |installingWorker|'s [=service worker/global object=].
-          1. Invoke [=Extend Service Worker Lifetime=] with |e|.
           1. *WaitForAsynchronousExtensions*: Run the following substeps <a>in parallel</a>:
-              1. Wait until |e|'s <a>extensions allowed flag</a> is unset.
+              1. Wait until |e|'s [=ExtendableEvent/pending promises count=] is zero.
               1. If the result of <a>waiting for all</a> of |e|'s <a>extend lifetime promises</a> rejected, set |installFailed| to true.
 
           If |task| is discarded or the script has been aborted by the <a lt="Terminate Service Worker">termination</a> of |installingWorker|, set |installFailed| to true.
@@ -2762,8 +2762,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Let |e| be the result of <a>creating an event</a> with {{ExtendableEvent}}.
           1. Initialize |e|’s {{Event/type}} attribute to {{activate!!event}}.
           1. <a>Dispatch</a> |e| at |activeWorker|'s [=service worker/global object=].
-          1. Invoke [=Extend Service Worker Lifetime=] with |e|.
-          1. *WaitForAsynchronousExtensions*: Wait, <a>in parallel</a>, until |e|'s <a>extensions allowed flag</a> is unset.
+          1. *WaitForAsynchronousExtensions*: Wait, <a>in parallel</a>, until |e|'s [=ExtendableEvent/pending promises count=] is zero.
       1. Wait for |task| to have executed or been discarded, or the script to have been aborted by the <a lt="terminate service worker">termination</a> of |activeWorker|.
       1. Wait for the step labeled *WaitForAsynchronousExtensions* to complete.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>active worker</a> and *activated* as the arguments.
@@ -2848,21 +2847,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   </section>
 
   <section algorithm>
-    <h3 id="extend-service-worker-lifetime-algorithm"><dfn>Extend Service Worker Lifetime</dfn></h3>
-
-      : Input
-      :: |event|, an {{ExtendableEvent}} object
-      : Output
-      :: None
-
-      1. If |event|'s [=ExtendableEvent/pending promises count=] is zero, unset |event|'s [=ExtendableEvent/extensions allowed flag=] and abort these steps.
-
-          Note: If no lifetime extension promise has been added up to this point (i.e., at the end of the task that called the event handlers), the [=ExtendableEvent/extensions allowed flag=] is immediately unset. Calling {{ExtendableEvent/waitUntil()}} in subsequent asynchronous tasks will throw.
-      
-      The user agent *should not* <a lt="terminate service worker">terminate</a> the [=/service worker=] associated with |event|'s <a>relevant settings object</a>'s [=environment settings object/global object=] until |event|'s <a>extensions allowed flag</a> is unset. However, the user agent *may* impose a time limit to this lifetime extension.
-  </section>
-
-  <section algorithm>
     <h3 id="handle-extend-lifetime-promise-algorithm"><dfn>Handle Extend Lifetime Promise</dfn></h3>
 
       : Input
@@ -2871,14 +2855,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: None
 
-      1. Wait until |promise| is settled [=in parallel=].
-      2. [=Queue a microtask=] to run the following substeps:
-          1. Decrease |event|'s [=ExtendableEvent/pending promises count=] by one.
-          1. For each |reaction| in |promise|.\[[PromiseFulfillReactions]]:
-              1. Append |reaction|.\[[Capability]].\[[Promise]] to |event|'s [=ExtendableEvent/extend lifetime promises=].
-              1. Increase |event|'s [=ExtendableEvent/pending promises count=] by one.
-              1. Invoke [=Handle Extend Lifetime Promise=] with |event| and |reaction|.\[[Capability]].\[[Promise]].
-          1. If |event|'s [=ExtendableEvent/pending promises count=] is zero, unset |event|'s [=ExtendableEvent/extensions allowed flag=].
+      1. Wait, [=in parallel=], until |promise| is settled and |promise|'s <code>then</code> methods, if any, in the task where |promise| has been settled have executed.
+      2. [=Queue a microtask=], on |promise|'s [=relevant settings object=]'s [=responsible event loop=], to decrease |event|'s [=ExtendableEvent/pending promises count=] by one.
   </section>
 
   <section algorithm>
@@ -2959,7 +2937,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. If |request| is a <a>navigation request</a>, initialize |e|'s {{FetchEvent/targetClientId}} attribute to |request|'s [=request/target client id=], and to the empty string otherwise.
           1. Let the {{FetchEvent/isReload}} attribute of |e| be initialized to <code>true</code> if |request|'s [=request/client=] is a <a>window client</a> and the event was dispatched with the user's intention for the page reload, and <code>false</code> otherwise.
           1. <a>Dispatch</a> |e| at |activeWorker|'s [=service worker/global object=].
-          1. Invoke [=Extend Service Worker Lifetime=] with |e|.
           1. If |e|'s [=FetchEvent/respond-with entered flag=] is set, set |respondWithEntered| to true.
           1. If |e|'s [=FetchEvent/wait to respond flag=] is set, then:
               1. Wait until |e|'s [=FetchEvent/wait to respond flag=] is unset.
@@ -3023,7 +3000,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Initialize |e|’s {{ForeignFetchEvent/request}} attribute to |r|.
           1. Initialize |e|’s {{ForeignFetchEvent/origin}} attribute to the  <a lt="Unicode serialization of an origin">Unicode serialization</a> of |request|'s [=request/origin=].
           1. <a>Dispatch</a> |e| at |activeWorker|'s [=service worker/global object=].
-          1. Invoke [=Extend Service Worker Lifetime=] with |e|.
           1. If |e|'s [=ForeignFetchEvent/respond-with entered flag=] is set, set |respondWithEntered| to true.
           1. If |e|'s <a>wait to respond flag</a> is set, wait until |e|'s <a>wait to respond flag</a> is unset.
           1. Let |internalResponse| be |e|'s [=ForeignFetchEvent/potential response=].
@@ -3085,7 +3061,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Invoke <a>Run Service Worker</a> algorithm with |activeWorker| as the argument.
       1. <a>Queue a task</a> |task| to run these substeps:
           1. Invoke |callbackSteps| with |activeWorker|'s [=service worker/global object=] as its argument.
-          1. Invoke [=Extend Service Worker Lifetime=] with |event|.
 
           The |task| *must* use |activeWorker|'s <a>event loop</a> and the <a>handle functional event task source</a>.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1311,10 +1311,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Add |f| to the [=ExtendableEvent/extend lifetime promises=].
         1. Increase the [=ExtendableEvent/pending promises count=] by one.
 
-            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done within [=Handle Extend Lifetime Promise=] algorithm.
+            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done in the task queued by the reaction to the promise.
 
-        1. Run [=Handle Extend Lifetime Promise=] with the [=context object=] and |f|.
-        1. Return.
+        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |f|, [=queue a task=], on |f|’s [=relevant settings object=]'s [=responsible event loop=] using the [=handle functional event task source=], to decrease the [=ExtendableEvent/pending promises count=] by one.
 
         The user agent *should not* <a lt="terminate service worker">terminate</a> the [=/service worker=] associated with |event|'s <a>relevant settings object</a>'s [=environment settings object/global object=] when |event|'s [=dispatch flag=] is set or |event|'s [=ExtendableEvent/pending promises count=] is not zero. However, the user agent *may* impose a time limit to this lifetime extension.
     </section>
@@ -1461,9 +1460,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Add |r| to the <a>extend lifetime promises</a>.
         1. Increase the [=ExtendableEvent/pending promises count=] by one.
 
-            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done within [=Handle Extend Lifetime Promise=] algorithm.
+            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done in the task queued by the reaction to the promise.
 
-        1. Run [=Handle Extend Lifetime Promise=] with the [=context object=] and |r|.
+        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |r|, [=queue a task=], on |r|’s [=relevant settings object=]'s [=responsible event loop=] using the [=handle fetch task source=], to decrease the [=ExtendableEvent/pending promises count=] by one.
 
             Note: {{FetchEvent/respondWith(r)|event.respondWith(r)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(r)}} is called.
 
@@ -1577,9 +1576,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Add |r| to the <a>extend lifetime promises</a>.
         1. Increase the [=ExtendableEvent/pending promises count=] by one.
 
-            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done within [=Handle Extend Lifetime Promise=] algorithm.
+            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done in the task queued by the reaction to the promise.
 
-        1. Run [=Handle Extend Lifetime Promise=] with the [=context object=] and |r|.
+        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |r|, [=queue a task=], on |r|’s [=relevant settings object=]'s [=responsible event loop=] using the [=handle fetch task source=], to decrease the [=ExtendableEvent/pending promises count=] by one.
+
+            Note: {{ForeignFetchEvent/respondWith(r)|event.respondWith(r)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(r)}} is called.
+
         1. Set the <a>stop propagation flag</a> and <a>stop immediate propagation flag</a>.
         1. Set the [=ForeignFetchEvent/respond-with entered flag=].
         1. Set the [=ForeignFetchEvent/wait to respond flag=].
@@ -2844,19 +2846,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           Note: This effectively means that the fetch events and the other functional events such as push events are backed up by the registration's task queues while the other tasks including message events are discarded.
 
       1. Abort the script currently running in |serviceWorker|.
-  </section>
-
-  <section algorithm>
-    <h3 id="handle-extend-lifetime-promise-algorithm"><dfn>Handle Extend Lifetime Promise</dfn></h3>
-
-      : Input
-      :: |event|, an {{ExtendableEvent}} object
-      :: |promise|, a [=promise=]
-      : Output
-      :: None
-
-      1. Wait until |promise| is settled [=in parallel=].
-      2. [=Queue a task=], on |promise|'s [=relevant settings object=]'s [=responsible event loop=], to decrease |event|'s [=ExtendableEvent/pending promises count=] by one.
   </section>
 
   <section algorithm>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1289,7 +1289,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     An {{ExtendableEvent}} object has an associated <dfn for="ExtendableEvent">extend lifetime promises</dfn> (an array of <a>promises</a>). It is initially an empty array.
 
-    An {{ExtendableEvent}} object has an associated <dfn id="extensions-allowed-flag">extensions allowed flag</dfn>. It is initially set.
+    An {{ExtendableEvent}} object has an associated <dfn for="ExtendableEvent" id="extensions-allowed-flag">extensions allowed flag</dfn>. It is initially set.
+
+    An {{ExtendableEvent}} object has an associated <dfn for="ExtendableEvent">pending promises count</dfn> (the number of pending promises in the [=ExtendableEvent/extend lifetime promises=]). It is initially set to zero.
 
     [=/Service workers=] have two <a>lifecycle events</a>, {{install!!event}} and {{activate!!event}}. [=/Service workers=] use the {{ExtendableEvent}} interface for {{activate!!event}} event and {{install!!event}} event.
 
@@ -1308,6 +1310,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             1. <a>Throw</a> an "{{InvalidStateError}}" exception.
             1. Abort these steps.
         1. Add |f| to the [=ExtendableEvent/extend lifetime promises=].
+        1. Increase the [=ExtendableEvent/pending promises count=] by one.
+
+            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done within [=Handle Extend Lifetime Promise=] algorithm.
+
+        1. Run [=Handle Extend Lifetime Promise=] with the [=context object=] and |f|.
+        1. Return.
     </section>
 
     [=/Service workers=] and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> *may* define their own behaviors, allowing the [=ExtendableEvent/extend lifetime promises=] to suggest operation length, and the rejected state of any of the <a>promise</a> in [=ExtendableEvent/extend lifetime promises=] to suggest operation failure.
@@ -1450,6 +1458,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             1. <a>Throw</a> an "{{InvalidStateError}}" exception.
             1. Abort these steps.
         1. Add |r| to the <a>extend lifetime promises</a>.
+        1. Increase the [=ExtendableEvent/pending promises count=] by one.
+
+            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done within [=Handle Extend Lifetime Promise=] algorithm.
+
+        1. Run [=Handle Extend Lifetime Promise=] with the [=context object=] and |r|.
 
             Note: {{FetchEvent/respondWith(r)|event.respondWith(r)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(r)}} is called.
 
@@ -1561,6 +1574,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             1. <a>Throw</a> an "{{InvalidStateError}}" exception.
             1. Abort these steps.
         1. Add |r| to the <a>extend lifetime promises</a>.
+        1. Increase the [=ExtendableEvent/pending promises count=] by one.
+
+            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done within [=Handle Extend Lifetime Promise=] algorithm.
+
+        1. Run [=Handle Extend Lifetime Promise=] with the [=context object=] and |r|.
         1. Set the <a>stop propagation flag</a> and <a>stop immediate propagation flag</a>.
         1. Set the [=ForeignFetchEvent/respond-with entered flag=].
         1. Set the [=ForeignFetchEvent/wait to respond flag=].
@@ -2837,15 +2855,30 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: None
 
-      1. If |event|'s <a>extend lifetime promises</a> is empty, unset |event|'s <a>extensions allowed flag</a> and abort these steps.
-      1. Let |extendLifetimePromises| be an empty array.
-      1. Run the following substeps <a>in parallel</a>:
-          1. *SetupPromiseArray*: Set |extendLifetimePromises| to a copy of |event|'s <a>extend lifetime promises</a>.
-          1. Wait until all the <a>promises</a> in |extendLifetimePromises| settle.
-          1. If the length of |extendLifetimePromises| does not equal the length of |event|'s <a>extend lifetime promises</a>, jump to the step labeled *SetupPromiseArray*.
-          1. Unset |event|'s <a>extensions allowed flag</a>.
+      1. If |event|'s [=ExtendableEvent/pending promises count=] is zero, unset |event|'s [=ExtendableEvent/extensions allowed flag=] and abort these steps.
 
+          Note: If no lifetime extension promise has been added up to this point (i.e., at the end of the task that called the event handlers), the [=ExtendableEvent/extensions allowed flag=] is immediately unset. Calling {{ExtendableEvent/waitUntil()}} in subsequent asynchronous tasks will throw.
+      
       The user agent *should not* <a lt="terminate service worker">terminate</a> the [=/service worker=] associated with |event|'s <a>relevant settings object</a>'s [=environment settings object/global object=] until |event|'s <a>extensions allowed flag</a> is unset. However, the user agent *may* impose a time limit to this lifetime extension.
+  </section>
+
+  <section algorithm>
+    <h3 id="handle-extend-lifetime-promise-algorithm"><dfn>Handle Extend Lifetime Promise</dfn></h3>
+
+      : Input
+      :: |event|, an {{ExtendableEvent}} object
+      :: |promise|, a [=promise=]
+      : Output
+      :: None
+
+      1. Wait until |promise| is settled [=in parallel=].
+      2. [=Queue a microtask=] to run the following substeps:
+          1. Decrease |event|'s [=ExtendableEvent/pending promises count=] by one.
+          1. For each |reaction| in |promise|.\[[PromiseFulfillReactions]]:
+              1. Append |reaction|.\[[Capability]].\[[Promise]] to |event|'s [=ExtendableEvent/extend lifetime promises=].
+              1. Increase |event|'s [=ExtendableEvent/pending promises count=] by one.
+              1. Invoke [=Handle Extend Lifetime Promise=] with |event| and |reaction|.\[[Capability]].\[[Promise]].
+          1. If |event|'s [=ExtendableEvent/pending promises count=] is zero, unset |event|'s [=ExtendableEvent/extensions allowed flag=].
   </section>
 
   <section algorithm>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-09">9 January 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-11">11 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1689,7 +1689,6 @@ pre.idl.highlight { color: #708090; }
       <li><a href="#activation-algorithm"><span class="secno"></span> <span class="content"><span>Activate</span></span></a>
       <li><a href="#run-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Run Service Worker</span></span></a>
       <li><a href="#terminate-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Terminate Service Worker</span></span></a>
-      <li><a href="#handle-extend-lifetime-promise-algorithm"><span class="secno"></span> <span class="content"><span>Handle Extend Lifetime Promise</span></span></a>
       <li><a href="#on-fetch-request-algorithm"><span class="secno"></span> <span class="content"><span>Handle Fetch</span></span></a>
       <li><a href="#on-foreign-fetch-request-algorithm"><span class="secno"></span> <span class="content"><span>Handle Foreign Fetch</span></span></a>
       <li><a href="#handle-functional-event-algorithm"><span class="secno"></span> <span class="content"><span>Handle Functional Event</span></span></a>
@@ -3058,13 +3057,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>Add <var>f</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-8">extend lifetime promises</a>.</p>
        <li data-md="">
         <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-2">pending promises count</a> by one.</p>
-        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-3">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-1">Handle Extend Lifetime Promise</a> algorithm.</p>
+        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-3">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done in the task queued by the reaction to the promise.</p>
        <li data-md="">
-        <p>Run <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-2">Handle Extend Lifetime Promise</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> and <var>f</var>.</p>
-       <li data-md="">
-        <p>Return.</p>
+        <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>f</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>f</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, to decrease the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> by one.</p>
       </ol>
-      <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-3">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> when <var>event</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is set or <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> is not zero. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
+      <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-3">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> when <var>event</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is set or <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-5">pending promises count</a> is not zero. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
      </section>
      <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-61">Service workers</a> and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> define their own behaviors, allowing the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-2">extend lifetime promises</a> to suggest operation length, and the rejected state of any of the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> in <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-3">extend lifetime promises</a> to suggest operation failure.</p>
      <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-62">Service workers</a> define the following behaviors for <code><a data-link-type="dfn" href="#install" id="ref-for-install-2">install</a></code> event and <code><a data-link-type="dfn" href="#activate" id="ref-for-activate-4">activate</a></code> event, respectively:</p>
@@ -3225,10 +3222,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-9">extend lifetime promises</a>.</p>
        <li data-md="">
-        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-5">pending promises count</a> by one.</p>
-        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-6">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-3">Handle Extend Lifetime Promise</a> algorithm.</p>
+        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-6">pending promises count</a> by one.</p>
+        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-7">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done in the task queued by the reaction to the promise.</p>
        <li data-md="">
-        <p>Run <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-4">Handle Extend Lifetime Promise</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> and <var>r</var>.</p>
+        <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>r</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>r</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a>, to decrease the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> by one.</p>
         <p class="note" role="note">Note: <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-3">event.respondWith(r)</a></code> extends the lifetime of the event by default as if <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">event.waitUntil(r)</a></code> is called.</p>
        <li data-md="">
         <p>Set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-propagation-flag">stop propagation flag</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">stop immediate propagation flag</a>.</p>
@@ -3401,10 +3398,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-10">extend lifetime promises</a>.</p>
         <li data-md="">
-         <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-7">pending promises count</a> by one.</p>
-         <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-5">Handle Extend Lifetime Promise</a> algorithm.</p>
+         <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-9">pending promises count</a> by one.</p>
+         <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-10">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done in the task queued by the reaction to the promise.</p>
         <li data-md="">
-         <p>Run <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-6">Handle Extend Lifetime Promise</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> and <var>r</var>.</p>
+         <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>r</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>r</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a>, to decrease the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-11">pending promises count</a> by one.</p>
+         <p class="note" role="note">Note: <code class="idl"><a data-link-type="idl" href="#dom-foreignfetchevent-respondwith" id="ref-for-dom-foreignfetchevent-respondwith-3">event.respondWith(r)</a></code> extends the lifetime of the event by default as if <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">event.waitUntil(r)</a></code> is called.</p>
         <li data-md="">
          <p>Set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-propagation-flag">stop propagation flag</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">stop immediate propagation flag</a>.</p>
         <li data-md="">
@@ -3535,7 +3533,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/comms.html#messageport">MessagePort</a>> <dfn class="nv idl-code" data-default="None" data-dfn-for="ExtendableMessageEventInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MessagePort> " id="dom-extendablemessageeventinit-ports">ports<a class="self-link" href="#dom-extendablemessageeventinit-ports"></a></dfn> = [];
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-72">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-73">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-12">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-72">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-73">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-12">ExtendableEvent</a></code> interface.</p>
      <section>
       <h4 class="heading settled" data-level="4.8.1" id="extendablemessage-event-data"><span class="secno">4.8.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendablemessageevent-data" id="ref-for-dom-extendablemessageevent-data-3">event.data</a></code></span><a class="self-link" href="#extendablemessage-event-data"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ExtendableMessageEvent" data-dfn-type="attribute" data-export="" id="dom-extendablemessageevent-data">data</dfn> attribute <em>must</em> return the value it was initialized to. When the object is created, this attribute <em>must</em> be initialized to null. It represents the message being sent.</p>
@@ -5089,7 +5087,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><em>WaitForAsynchronousExtensions</em>: Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
          <ol>
           <li data-md="">
-           <p>Wait until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-9">pending promises count</a> is zero.</p>
+           <p>Wait until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-12">pending promises count</a> is zero.</p>
           <li data-md="">
            <p>If the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#waiting-for-all">waiting for all</a> of <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-11">extend lifetime promises</a> rejected, set <var>installFailed</var> to true.</p>
          </ol>
@@ -5210,7 +5208,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-2">global object</a>.</p>
         <li data-md="">
-         <p><em>WaitForAsynchronousExtensions</em>: Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-10">pending promises count</a> is zero.</p>
+         <p><em>WaitForAsynchronousExtensions</em>: Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-13">pending promises count</a> is zero.</p>
        </ol>
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded, or the script to have been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">termination</a> of <var>activeWorker</var>.</p>
@@ -5347,31 +5345,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>serviceWorkerGlobalScope</var>’s closing flag to true.</p>
       <li data-md="">
-       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
+       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-4">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-5">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-4">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
        <p class="note" role="note">Note: This effectively means that the fetch events and the other functional events such as push events are backed up by the registration’s task queues while the other tasks including message events are discarded.</p>
       <li data-md="">
        <p>Abort the script currently running in <var>serviceWorker</var>.</p>
-     </ol>
-    </section>
-    <section class="algorithm" data-algorithm="Handle Extend Lifetime Promise">
-     <h3 class="heading settled" id="handle-extend-lifetime-promise-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="handle-extend-lifetime-promise">Handle Extend Lifetime Promise</dfn></span><a class="self-link" href="#handle-extend-lifetime-promise-algorithm"></a></h3>
-     <dl>
-      <dt data-md="">
-       <p>Input</p>
-      <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code> object</p>
-      <dd data-md="">
-       <p><var>promise</var>, a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a></p>
-      <dt data-md="">
-       <p>Output</p>
-      <dd data-md="">
-       <p>None</p>
-     </dl>
-     <ol>
-      <li data-md="">
-       <p>Wait until <var>promise</var> is settled <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>promise</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a>, to decrease <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-11">pending promises count</a> by one.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle Fetch">
@@ -5539,7 +5516,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>If <var>e</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#canceled-flag">canceled flag</a> is set, set <var>eventCanceled</var> to true.</p>
        </ol>
        <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-8">termination</a> of <var>activeWorker</var>, set <var>handleFetchFailed</var> to true.</p>
-       <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-4">handle fetch task source</a>.</p>
+       <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-6">handle fetch task source</a>.</p>
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded.</p>
       <li data-md="">
@@ -5683,7 +5660,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <p>If <var>e</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#canceled-flag">canceled flag</a> is set, set <var>eventCanceled</var> to true.</p>
         </ol>
         <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-9">termination</a> of <var>activeWorker</var>, set <var>handleFetchFailed</var> to true.</p>
-        <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-5">handle fetch task source</a>.</p>
+        <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-7">handle fetch task source</a>.</p>
        <li data-md="">
         <p>Wait for <var>task</var> to have executed or been discarded.</p>
        <li data-md="">
@@ -5723,7 +5700,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-17">ExtendableEvent</a></code> object</p>
+       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code> object</p>
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-62">service worker registration</a></p>
       <dd data-md="">
@@ -5761,7 +5738,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Invoke <var>callbackSteps</var> with <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-7">global object</a> as its argument.</p>
        </ol>
-       <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-4">handle functional event task source</a>.</p>
+       <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-5">handle functional event task source</a>.</p>
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded.</p>
       <li data-md="">
@@ -6053,7 +6030,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
              <p><em>installing</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installing" id="ref-for-dom-serviceworkerstate-installing-1">"installing"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> is not active until all of the core caches are populated.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> is not active until all of the core caches are populated.</p>
             <dt data-md="">
              <p><em>installed</em></p>
             <dd data-md="">
@@ -6063,7 +6040,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
              <p><em>activating</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activating" id="ref-for-dom-serviceworkerstate-activating-1">"activating"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-12">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-9">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-12">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
             <dt data-md="">
              <p><em>activated</em></p>
             <dd data-md="">
@@ -6719,7 +6696,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="#dfn-service-worker-global-object">dfn for service worker</a><span>, in §2.1</span>
      <li><a href="#cachestorage-global-object">dfn for CacheStorage</a><span>, in §6.5</span>
     </ul>
-   <li><a href="#handle-extend-lifetime-promise">Handle Extend Lifetime Promise</a><span>, in §Unnumbered section</span>
    <li><a href="#handle-fetch">Handle Fetch</a><span>, in §Unnumbered section</span>
    <li><a href="#dfn-handle-fetch-task-source">handle fetch task source</a><span>, in §2.5</span>
    <li><a href="#handle-foreign-fetch">Handle Foreign Fetch</a><span>, in §Unnumbered section</span>
@@ -7350,6 +7326,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise">reject</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise">resolve</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#transforming-by">transforming</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">upon fulfillment</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">upon rejection</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#waiting-for-all">waiting for all</a>
     </ul>
    <li>
@@ -8231,17 +8209,20 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dfn-handle-fetch-task-source">#dfn-handle-fetch-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-handle-fetch-task-source-1">2.2. Service Worker Registration</a>
-    <li><a href="#ref-for-dfn-handle-fetch-task-source-2">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-fetch-task-source-3">(2)</a>
-    <li><a href="#ref-for-dfn-handle-fetch-task-source-4">Handle Fetch</a>
-    <li><a href="#ref-for-dfn-handle-fetch-task-source-5">Handle Foreign Fetch</a>
+    <li><a href="#ref-for-dfn-handle-fetch-task-source-2">4.6.7. event.respondWith(r)</a>
+    <li><a href="#ref-for-dfn-handle-fetch-task-source-3">4.7.3. event.respondWith(r)</a>
+    <li><a href="#ref-for-dfn-handle-fetch-task-source-4">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-fetch-task-source-5">(2)</a>
+    <li><a href="#ref-for-dfn-handle-fetch-task-source-6">Handle Fetch</a>
+    <li><a href="#ref-for-dfn-handle-fetch-task-source-7">Handle Foreign Fetch</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-handle-functional-event-task-source">
    <b><a href="#dfn-handle-functional-event-task-source">#dfn-handle-functional-event-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-handle-functional-event-task-source-1">2.2. Service Worker Registration</a>
-    <li><a href="#ref-for-dfn-handle-functional-event-task-source-2">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-functional-event-task-source-3">(2)</a>
-    <li><a href="#ref-for-dfn-handle-functional-event-task-source-4">Handle Functional Event</a>
+    <li><a href="#ref-for-dfn-handle-functional-event-task-source-2">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-dfn-handle-functional-event-task-source-3">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-functional-event-task-source-4">(2)</a>
+    <li><a href="#ref-for-dfn-handle-functional-event-task-source-5">Handle Functional Event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serviceworker">
@@ -8966,8 +8947,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-extendableevent-13">4.9. Events</a>
     <li><a href="#ref-for-extendableevent-14">8.2. Define Functional Event</a>
     <li><a href="#ref-for-extendableevent-15">Activate</a>
-    <li><a href="#ref-for-extendableevent-16">Handle Extend Lifetime Promise</a>
-    <li><a href="#ref-for-extendableevent-17">Handle Functional Event</a>
+    <li><a href="#ref-for-extendableevent-16">Handle Functional Event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-extendableeventinit">
@@ -8993,12 +8973,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="extendableevent-pending-promises-count">
    <b><a href="#extendableevent-pending-promises-count">#extendableevent-pending-promises-count</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-extendableevent-pending-promises-count-2">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count-3">(3)</a> <a href="#ref-for-extendableevent-pending-promises-count-4">(4)</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-5">4.6.7. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-6">(2)</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-7">4.7.3. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-8">(2)</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-9">Install</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-10">Activate</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-11">Handle Extend Lifetime Promise</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-extendableevent-pending-promises-count-2">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count-3">(3)</a> <a href="#ref-for-extendableevent-pending-promises-count-4">(4)</a> <a href="#ref-for-extendableevent-pending-promises-count-5">(5)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-6">4.6.7. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-7">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count-8">(3)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-9">4.7.3. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-10">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count-11">(3)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-12">Install</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-13">Activate</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-extendableevent-waituntil">
@@ -9007,8 +8986,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dom-extendableevent-waituntil-1">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dom-extendableevent-waituntil-2">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-dom-extendableevent-waituntil-3">(2)</a> <a href="#ref-for-dom-extendableevent-waituntil-4">(3)</a>
     <li><a href="#ref-for-dom-extendableevent-waituntil-5">4.6.7. event.respondWith(r)</a>
-    <li><a href="#ref-for-dom-extendableevent-waituntil-6">4.8. ExtendableMessageEvent</a>
-    <li><a href="#ref-for-dom-extendableevent-waituntil-7">Update Worker State</a> <a href="#ref-for-dom-extendableevent-waituntil-8">(2)</a>
+    <li><a href="#ref-for-dom-extendableevent-waituntil-6">4.7.3. event.respondWith(r)</a>
+    <li><a href="#ref-for-dom-extendableevent-waituntil-7">4.8. ExtendableMessageEvent</a>
+    <li><a href="#ref-for-dom-extendableevent-waituntil-8">Update Worker State</a> <a href="#ref-for-dom-extendableevent-waituntil-9">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="installevent">
@@ -9242,7 +9222,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dom-foreignfetchevent-respondwith">#dom-foreignfetchevent-respondwith</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foreignfetchevent-respondwith-1">4.7. ForeignFetchEvent</a>
-    <li><a href="#ref-for-dom-foreignfetchevent-respondwith-2">4.7.3. event.respondWith(r)</a>
+    <li><a href="#ref-for-dom-foreignfetchevent-respondwith-2">4.7.3. event.respondWith(r)</a> <a href="#ref-for-dom-foreignfetchevent-respondwith-3">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="extendablemessageevent">
@@ -9895,14 +9875,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-terminate-service-worker-9">Handle Foreign Fetch</a>
     <li><a href="#ref-for-terminate-service-worker-10">Handle Service Worker Client Unload</a>
     <li><a href="#ref-for-terminate-service-worker-11">Clear Registration</a> <a href="#ref-for-terminate-service-worker-12">(2)</a> <a href="#ref-for-terminate-service-worker-13">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="handle-extend-lifetime-promise">
-   <b><a href="#handle-extend-lifetime-promise">#handle-extend-lifetime-promise</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-handle-extend-lifetime-promise-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-handle-extend-lifetime-promise-2">(2)</a>
-    <li><a href="#ref-for-handle-extend-lifetime-promise-3">4.6.7. event.respondWith(r)</a> <a href="#ref-for-handle-extend-lifetime-promise-4">(2)</a>
-    <li><a href="#ref-for-handle-extend-lifetime-promise-5">4.7.3. event.respondWith(r)</a> <a href="#ref-for-handle-extend-lifetime-promise-6">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-fetch">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1690,6 +1690,7 @@ pre.idl.highlight { color: #708090; }
       <li><a href="#run-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Run Service Worker</span></span></a>
       <li><a href="#terminate-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Terminate Service Worker</span></span></a>
       <li><a href="#extend-service-worker-lifetime-algorithm"><span class="secno"></span> <span class="content"><span>Extend Service Worker Lifetime</span></span></a>
+      <li><a href="#handle-extend-lifetime-promise-algorithm"><span class="secno"></span> <span class="content"><span>Handle Extend Lifetime Promise</span></span></a>
       <li><a href="#on-fetch-request-algorithm"><span class="secno"></span> <span class="content"><span>Handle Fetch</span></span></a>
       <li><a href="#on-foreign-fetch-request-algorithm"><span class="secno"></span> <span class="content"><span>Handle Foreign Fetch</span></span></a>
       <li><a href="#handle-functional-event-algorithm"><span class="secno"></span> <span class="content"><span>Handle Functional Event</span></span></a>
@@ -3037,10 +3038,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 };
 </pre>
      <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-2">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-extend-lifetime-promises">extend lifetime promises</dfn> (an array of <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a>). It is initially an empty array.</p>
-     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-3">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="extensions-allowed-flag">extensions allowed flag</dfn>. It is initially set.</p>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-59">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-60">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
-     <p><a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> also use or extend the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-5">ExtendableEvent</a></code> interface.</p>
-     <p class="note" role="note">Note: To extend the lifetime of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-61">service worker</a>, algorithms that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> events using the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a></code> interface run <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-1">Extend Service Worker Lifetime</a> algorithm after <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> the event. See <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-2">Handle Fetch</a>, <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-1">Handle Foreign Fetch</a>, and <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-1">Handle Functional Event</a>.</p>
+     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-3">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extensions-allowed-flag">extensions allowed flag</dfn>. It is initially set.</p>
+     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-pending-promises-count">pending promises count</dfn> (the number of pending promises in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-1">extend lifetime promises</a>). It is initially set to zero.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-59">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-60">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-5">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
+     <p><a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> also use or extend the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a></code> interface.</p>
+     <p class="note" role="note">Note: To extend the lifetime of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-61">service worker</a>, algorithms that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> events using the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-7">ExtendableEvent</a></code> interface run <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-1">Extend Service Worker Lifetime</a> algorithm after <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> the event. See <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-2">Handle Fetch</a>, <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-1">Handle Foreign Fetch</a>, and <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-1">Handle Functional Event</a>.</p>
      <section class="algorithm" data-algorithm="wait-until-method">
       <h4 class="heading settled" data-level="4.4.1" id="wait-until-method"><span class="secno">4.4.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-2">event.waitUntil(f)</a></code></span><a class="self-link" href="#wait-until-method"></a></h4>
       <p><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-3">waitUntil()</a></code> method extends the lifetime of the event.</p>
@@ -3055,7 +3057,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <p>Abort these steps.</p>
         </ol>
        <li data-md="">
-        <p>Add <var>f</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-1">extend lifetime promises</a>.</p>
+        <p>Add <var>f</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-8">extend lifetime promises</a>.</p>
+       <li data-md="">
+        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-1">pending promises count</a> by one.</p>
+        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-2">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-1">Handle Extend Lifetime Promise</a> algorithm.</p>
+       <li data-md="">
+        <p>Run <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-2">Handle Extend Lifetime Promise</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> and <var>f</var>.</p>
+       <li data-md="">
+        <p>Return.</p>
       </ol>
      </section>
      <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-62">Service workers</a> and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> define their own behaviors, allowing the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-2">extend lifetime promises</a> to suggest operation length, and the rejected state of any of the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> in <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-3">extend lifetime promises</a> to suggest operation failure.</p>
@@ -3070,7 +3079,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.5" id="installevent-interface"><span class="secno">4.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#installevent" id="ref-for-installevent-1">InstallEvent</a></code></span><a class="self-link" href="#installevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="InstallEvent" data-dfn-type="constructor" data-export="" data-lt="InstallEvent(type, eventInitDict)|InstallEvent(type)" id="dom-installevent-installevent">Constructor<a class="self-link" href="#dom-installevent-installevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="InstallEvent/InstallEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-installevent-installevent-type-eventinitdict-type">type<a class="self-link" href="#dom-installevent-installevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-extendableeventinit" id="ref-for-dictdef-extendableeventinit-2">ExtendableEventInit</a> <dfn class="nv idl-code" data-dfn-for="InstallEvent/InstallEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-installevent-installevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-installevent-installevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="installevent">InstallEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-7">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="installevent">InstallEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-8">ExtendableEvent</a> {
   <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-installevent-registerforeignfetch" id="ref-for-dom-installevent-registerforeignfetch-1">registerForeignFetch</a>(<a class="n" data-link-type="idl-name" href="#dictdef-foreignfetchoptions" id="ref-for-dictdef-foreignfetchoptions-1">ForeignFetchOptions</a> <dfn class="nv idl-code" data-dfn-for="InstallEvent/registerForeignFetch(options)" data-dfn-type="argument" data-export="" id="dom-installevent-registerforeignfetch-options-options">options<a class="self-link" href="#dom-installevent-registerforeignfetch-options-options"></a></dfn>);
 };
 
@@ -3138,7 +3147,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.6" id="fetchevent-interface"><span class="secno">4.6. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-1">FetchEvent</a></code></span><a class="self-link" href="#fetchevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="FetchEvent" data-dfn-type="constructor" data-export="" data-lt="FetchEvent(type, eventInitDict)" id="dom-fetchevent-fetchevent">Constructor<a class="self-link" href="#dom-fetchevent-fetchevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="FetchEvent/FetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-fetchevent-fetchevent-type-eventinitdict-type">type<a class="self-link" href="#dom-fetchevent-fetchevent-type-eventinitdict-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-fetcheventinit" id="ref-for-dictdef-fetcheventinit-1">FetchEventInit</a> <dfn class="nv idl-code" data-dfn-for="FetchEvent/FetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-fetchevent-fetchevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-fetchevent-fetchevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="fetchevent">FetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-8">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="fetchevent">FetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-9">ExtendableEvent</a> {
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#request">Request</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Request" href="#dom-fetchevent-request" id="ref-for-dom-fetchevent-request-1">request</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">Promise</span>&lt;<span class="kt">any</span>> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Promise<any>" href="#dom-fetchevent-preloadresponse" id="ref-for-dom-fetchevent-preloadresponse-1">preloadResponse</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-fetchevent-clientid" id="ref-for-dom-fetchevent-clientid-1">clientId</a>;
@@ -3158,7 +3167,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="FetchEventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-fetcheventinit-isreload">isReload<a class="self-link" href="#dom-fetcheventinit-isreload"></a></dfn> = <span class="kt">false</span>;
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-68">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-69">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-9">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-68">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-69">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-10">ExtendableEvent</a></code> interface.</p>
      <p>Each event using <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-3">FetchEvent</a></code> interface has an associated <dfn class="dfn-paneled" data-dfn-for="FetchEvent" data-dfn-type="dfn" data-noexport="" id="fetchevent-potential-response">potential response</dfn> (a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>), initially set to null, and the following associated flags that are initially unset:</p>
      <ul>
       <li data-md="">
@@ -3215,7 +3224,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <p>Abort these steps.</p>
         </ol>
        <li data-md="">
-        <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-8">extend lifetime promises</a>.</p>
+        <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-9">extend lifetime promises</a>.</p>
+       <li data-md="">
+        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-3">pending promises count</a> by one.</p>
+        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-3">Handle Extend Lifetime Promise</a> algorithm.</p>
+       <li data-md="">
+        <p>Run <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-4">Handle Extend Lifetime Promise</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> and <var>r</var>.</p>
         <p class="note" role="note">Note: <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-3">event.respondWith(r)</a></code> extends the lifetime of the event by default as if <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-4">event.waitUntil(r)</a></code> is called.</p>
        <li data-md="">
         <p>Set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-propagation-flag">stop propagation flag</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">stop immediate propagation flag</a>.</p>
@@ -3327,7 +3341,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.7" id="foreignfetchevent-interface"><span class="secno">4.7. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#foreignfetchevent" id="ref-for-foreignfetchevent-1">ForeignFetchEvent</a></code></span><a class="self-link" href="#foreignfetchevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="ForeignFetchEvent" data-dfn-type="constructor" data-export="" data-lt="ForeignFetchEvent(type, eventInitDict)" id="dom-foreignfetchevent-foreignfetchevent">Constructor<a class="self-link" href="#dom-foreignfetchevent-foreignfetchevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="ForeignFetchEvent/ForeignFetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-foreignfetchevent-foreignfetchevent-type-eventinitdict-type">type<a class="self-link" href="#dom-foreignfetchevent-foreignfetchevent-type-eventinitdict-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-foreignfetcheventinit" id="ref-for-dictdef-foreignfetcheventinit-1">ForeignFetchEventInit</a> <dfn class="nv idl-code" data-dfn-for="ForeignFetchEvent/ForeignFetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-foreignfetchevent-foreignfetchevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-foreignfetchevent-foreignfetchevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="foreignfetchevent">ForeignFetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-10">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="foreignfetchevent">ForeignFetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a> {
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#request">Request</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Request" href="#dom-foreignfetchevent-request" id="ref-for-dom-foreignfetchevent-request-1">request</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-foreignfetchevent-origin" id="ref-for-dom-foreignfetchevent-origin-1">origin</a>;
 
@@ -3345,7 +3359,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">sequence</span>&lt;<span class="kt">ByteString</span>> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ForeignFetchResponse" data-dfn-type="dict-member" data-export="" data-type="sequence<ByteString> " id="dom-foreignfetchresponse-headers">headers</dfn>;
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-70">Service workers</a> have a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-4">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-2">foreignfetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-3">foreignfetch</a></code> events, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-71">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#foreignfetchevent" id="ref-for-foreignfetchevent-2">ForeignFetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-70">Service workers</a> have a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-4">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-2">foreignfetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-3">foreignfetch</a></code> events, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-71">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#foreignfetchevent" id="ref-for-foreignfetchevent-2">ForeignFetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-12">ExtendableEvent</a></code> interface.</p>
      <p>Each event using <code class="idl"><a data-link-type="idl" href="#foreignfetchevent" id="ref-for-foreignfetchevent-3">ForeignFetchEvent</a></code> interface has an associated <dfn class="dfn-paneled" data-dfn-for="ForeignFetchEvent" data-dfn-type="dfn" data-noexport="" id="foreignfetchevent-potential-response">potential response</dfn> (a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>), initially set to null, an associated <dfn class="dfn-paneled" data-dfn-for="ForeignFetchEvent" data-dfn-type="dfn" data-noexport="" id="foreignfetchevent-origin">origin</dfn> (a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-USVString">USVString</a></code> or null), initially set to null, an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="list-of-exposed-headers">list of exposed headers</dfn> (whose element type is a byte string), initially set to an empty list, and the following associated flags that are initially unset:</p>
      <ul>
       <li data-md="">
@@ -3386,7 +3400,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <p>Abort these steps.</p>
          </ol>
         <li data-md="">
-         <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-9">extend lifetime promises</a>.</p>
+         <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-10">extend lifetime promises</a>.</p>
+        <li data-md="">
+         <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-5">pending promises count</a> by one.</p>
+         <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-6">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-5">Handle Extend Lifetime Promise</a> algorithm.</p>
+        <li data-md="">
+         <p>Run <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-6">Handle Extend Lifetime Promise</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> and <var>r</var>.</p>
         <li data-md="">
          <p>Set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-propagation-flag">stop propagation flag</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">stop immediate propagation flag</a>.</p>
         <li data-md="">
@@ -3501,7 +3520,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.8" id="extendablemessageevent-interface"><span class="secno">4.8. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-2">ExtendableMessageEvent</a></code></span><a class="self-link" href="#extendablemessageevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent" data-dfn-type="constructor" data-export="" data-lt="ExtendableMessageEvent(type, eventInitDict)|ExtendableMessageEvent(type)" id="dom-extendablemessageevent-extendablemessageevent">Constructor<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent/ExtendableMessageEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-type">type<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-extendablemessageeventinit" id="ref-for-dictdef-extendablemessageeventinit-1">ExtendableMessageEventInit</a> <dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent/ExtendableMessageEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="extendablemessageevent">ExtendableMessageEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-12">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="extendablemessageevent">ExtendableMessageEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-13">ExtendableEvent</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">any</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="any" href="#dom-extendablemessageevent-data" id="ref-for-dom-extendablemessageevent-data-2">data</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-extendablemessageevent-origin" id="ref-for-dom-extendablemessageevent-origin-2">origin</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-extendablemessageevent-lasteventid" id="ref-for-dom-extendablemessageevent-lasteventid-1">lastEventId</a>;
@@ -3517,7 +3536,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/comms.html#messageport">MessagePort</a>> <dfn class="nv idl-code" data-default="None" data-dfn-for="ExtendableMessageEventInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MessagePort> " id="dom-extendablemessageeventinit-ports">ports<a class="self-link" href="#dom-extendablemessageeventinit-ports"></a></dfn> = [];
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-72">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-73">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-13">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-72">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-73">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-14">ExtendableEvent</a></code> interface.</p>
      <section>
       <h4 class="heading settled" data-level="4.8.1" id="extendablemessage-event-data"><span class="secno">4.8.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendablemessageevent-data" id="ref-for-dom-extendablemessageevent-data-3">event.data</a></code></span><a class="self-link" href="#extendablemessage-event-data"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ExtendableMessageEvent" data-dfn-type="attribute" data-export="" id="dom-extendablemessageevent-data">data</dfn> attribute <em>must</em> return the value it was initialized to. When the object is created, this attribute <em>must</em> be initialized to null. It represents the message being sent.</p>
@@ -3555,7 +3574,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-2">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-17">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-6">installing worker</a> changes. (See step 11.2 of the <a data-link-type="dfn" href="#install" id="ref-for-install-4">Install</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-activate-event"><code>activate</code></dfn>
-        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-14">ExtendableEvent</a></code>
+        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-15">ExtendableEvent</a></code>
         <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-3">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-18">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-10">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-21">active worker</a> changes. (See step 12.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-6">Activate</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-fetch-event"><code>fetch</code></dfn>
@@ -4476,7 +4495,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="8.2" id="extension-to-extendable-event"><span class="secno">8.2. </span><span class="content">Define Functional Event</span><a class="self-link" href="#extension-to-extendable-event"></a></h3>
-     <p>Specifications <em>may</em> define a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-7">functional event</a> by extending <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-15">ExtendableEvent</a></code> interface:</p>
+     <p>Specifications <em>may</em> define a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-7">functional event</a> by extending <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code> interface:</p>
 <pre class="example idl highlight def" data-no-idl="" id="example-3de376f0"><a class="self-link" href="#example-3de376f0"></a>// e.g. define FunctionalEvent interface
 <span class="kt">interface</span> <span class="nv">FunctionalEvent</span> : <span class="n">ExtendableEvent</span> {
   // add a functional event’s own attributes and methods
@@ -5075,7 +5094,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <li data-md="">
            <p>Wait until <var>e</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-2">extensions allowed flag</a> is unset.</p>
           <li data-md="">
-           <p>If the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#waiting-for-all">waiting for all</a> of <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-10">extend lifetime promises</a> rejected, set <var>installFailed</var> to true.</p>
+           <p>If the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#waiting-for-all">waiting for all</a> of <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-11">extend lifetime promises</a> rejected, set <var>installFailed</var> to true.</p>
          </ol>
        </ol>
        <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-3">termination</a> of <var>installingWorker</var>, set <var>installFailed</var> to true.</p>
@@ -5188,7 +5207,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code>.</p>
+         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-17">ExtendableEvent</a></code>.</p>
         <li data-md="">
          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> attribute to <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-5">activate</a></code>.</p>
         <li data-md="">
@@ -5345,7 +5364,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-17">ExtendableEvent</a></code> object</p>
+       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-18">ExtendableEvent</a></code> object</p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5353,23 +5372,47 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-11">extend lifetime promises</a> is empty, unset <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-4">extensions allowed flag</a> and abort these steps.</p>
-      <li data-md="">
-       <p>Let <var>extendLifetimePromises</var> be an empty array.</p>
-      <li data-md="">
-       <p>Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
-       <ol>
-        <li data-md="">
-         <p><em>SetupPromiseArray</em>: Set <var>extendLifetimePromises</var> to a copy of <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-12">extend lifetime promises</a>.</p>
-        <li data-md="">
-         <p>Wait until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in <var>extendLifetimePromises</var> settle.</p>
-        <li data-md="">
-         <p>If the length of <var>extendLifetimePromises</var> does not equal the length of <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-13">extend lifetime promises</a>, jump to the step labeled <em>SetupPromiseArray</em>.</p>
-        <li data-md="">
-         <p>Unset <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-5">extensions allowed flag</a>.</p>
-       </ol>
+       <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-7">pending promises count</a> is zero, unset <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-4">extensions allowed flag</a> and abort these steps.</p>
+       <p class="note" role="note">Note: If no lifetime extension promise has been added up to this point (i.e., at the end of the task that called the event handlers), the <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-5">extensions allowed flag</a> is immediately unset. Calling <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">waitUntil()</a></code> in subsequent asynchronous tasks will throw.</p>
      </ol>
      <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> until <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-6">extensions allowed flag</a> is unset. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
+    </section>
+    <section class="algorithm" data-algorithm="Handle Extend Lifetime Promise">
+     <h3 class="heading settled" id="handle-extend-lifetime-promise-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="handle-extend-lifetime-promise">Handle Extend Lifetime Promise</dfn></span><a class="self-link" href="#handle-extend-lifetime-promise-algorithm"></a></h3>
+     <dl>
+      <dt data-md="">
+       <p>Input</p>
+      <dd data-md="">
+       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-19">ExtendableEvent</a></code> object</p>
+      <dd data-md="">
+       <p><var>promise</var>, a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a></p>
+      <dt data-md="">
+       <p>Output</p>
+      <dd data-md="">
+       <p>None</p>
+     </dl>
+     <ol>
+      <li data-md="">
+       <p>Wait until <var>promise</var> is settled <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
+      <li data-md="">
+       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">Queue a microtask</a> to run the following substeps:</p>
+       <ol>
+        <li data-md="">
+         <p>Decrease <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> by one.</p>
+        <li data-md="">
+         <p>For each <var>reaction</var> in <var>promise</var>.[[PromiseFulfillReactions]]:</p>
+         <ol>
+          <li data-md="">
+           <p>Append <var>reaction</var>.[[Capability]].[[Promise]] to <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-12">extend lifetime promises</a>.</p>
+          <li data-md="">
+           <p>Increase <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-9">pending promises count</a> by one.</p>
+          <li data-md="">
+           <p>Invoke <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-7">Handle Extend Lifetime Promise</a> with <var>event</var> and <var>reaction</var>.[[Capability]].[[Promise]].</p>
+         </ol>
+        <li data-md="">
+         <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-10">pending promises count</a> is zero, unset <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-7">extensions allowed flag</a>.</p>
+       </ol>
+     </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle Fetch">
      <h3 class="heading settled" id="on-fetch-request-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="handle-fetch">Handle Fetch</dfn></span><a class="self-link" href="#on-fetch-request-algorithm"></a></h3>
@@ -5724,7 +5767,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-18">ExtendableEvent</a></code> object</p>
+       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-20">ExtendableEvent</a></code> object</p>
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-62">service worker registration</a></p>
       <dd data-md="">
@@ -6056,7 +6099,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
              <p><em>installing</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installing" id="ref-for-dom-serviceworkerstate-installing-1">"installing"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a> is not active until all of the core caches are populated.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a> is not active until all of the core caches are populated.</p>
             <dt data-md="">
              <p><em>installed</em></p>
             <dd data-md="">
@@ -6066,7 +6109,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
              <p><em>activating</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activating" id="ref-for-dom-serviceworkerstate-activating-1">"activating"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-12">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-12">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
             <dt data-md="">
              <p><em>activated</em></p>
             <dd data-md="">
@@ -6724,6 +6767,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="#dfn-service-worker-global-object">dfn for service worker</a><span>, in §2.1</span>
      <li><a href="#cachestorage-global-object">dfn for CacheStorage</a><span>, in §6.5</span>
     </ul>
+   <li><a href="#handle-extend-lifetime-promise">Handle Extend Lifetime Promise</a><span>, in §Unnumbered section</span>
    <li><a href="#handle-fetch">Handle Fetch</a><span>, in §Unnumbered section</span>
    <li><a href="#dfn-handle-fetch-task-source">handle fetch task source</a><span>, in §2.5</span>
    <li><a href="#handle-foreign-fetch">Handle Foreign Fetch</a><span>, in §Unnumbered section</span>
@@ -6860,6 +6904,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="#dom-extendablemessageevent-origin">attribute for ExtendableMessageEvent</a><span>, in §4.8.2</span>
     </ul>
    <li><a href="#dom-foreignfetchoptions-origins">origins</a><span>, in §4.5</span>
+   <li><a href="#extendableevent-pending-promises-count">pending promises count</a><span>, in §4.4</span>
    <li>
     ports
     <ul>
@@ -7292,6 +7337,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context">parent browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a>
      <li><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports">ports</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">realm</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">realm execution context</a>
@@ -8961,16 +9007,17 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="extendableevent">
    <b><a href="#extendableevent">#extendableevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendableevent-1">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-2">(2)</a> <a href="#ref-for-extendableevent-3">(3)</a> <a href="#ref-for-extendableevent-4">(4)</a> <a href="#ref-for-extendableevent-5">(5)</a> <a href="#ref-for-extendableevent-6">(6)</a>
-    <li><a href="#ref-for-extendableevent-7">4.5. InstallEvent</a>
-    <li><a href="#ref-for-extendableevent-8">4.6. FetchEvent</a> <a href="#ref-for-extendableevent-9">(2)</a>
-    <li><a href="#ref-for-extendableevent-10">4.7. ForeignFetchEvent</a> <a href="#ref-for-extendableevent-11">(2)</a>
-    <li><a href="#ref-for-extendableevent-12">4.8. ExtendableMessageEvent</a> <a href="#ref-for-extendableevent-13">(2)</a>
-    <li><a href="#ref-for-extendableevent-14">4.9. Events</a>
-    <li><a href="#ref-for-extendableevent-15">8.2. Define Functional Event</a>
-    <li><a href="#ref-for-extendableevent-16">Activate</a>
-    <li><a href="#ref-for-extendableevent-17">Extend Service Worker Lifetime</a>
-    <li><a href="#ref-for-extendableevent-18">Handle Functional Event</a>
+    <li><a href="#ref-for-extendableevent-1">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-2">(2)</a> <a href="#ref-for-extendableevent-3">(3)</a> <a href="#ref-for-extendableevent-4">(4)</a> <a href="#ref-for-extendableevent-5">(5)</a> <a href="#ref-for-extendableevent-6">(6)</a> <a href="#ref-for-extendableevent-7">(7)</a>
+    <li><a href="#ref-for-extendableevent-8">4.5. InstallEvent</a>
+    <li><a href="#ref-for-extendableevent-9">4.6. FetchEvent</a> <a href="#ref-for-extendableevent-10">(2)</a>
+    <li><a href="#ref-for-extendableevent-11">4.7. ForeignFetchEvent</a> <a href="#ref-for-extendableevent-12">(2)</a>
+    <li><a href="#ref-for-extendableevent-13">4.8. ExtendableMessageEvent</a> <a href="#ref-for-extendableevent-14">(2)</a>
+    <li><a href="#ref-for-extendableevent-15">4.9. Events</a>
+    <li><a href="#ref-for-extendableevent-16">8.2. Define Functional Event</a>
+    <li><a href="#ref-for-extendableevent-17">Activate</a>
+    <li><a href="#ref-for-extendableevent-18">Extend Service Worker Lifetime</a>
+    <li><a href="#ref-for-extendableevent-19">Handle Extend Lifetime Promise</a>
+    <li><a href="#ref-for-extendableevent-20">Handle Functional Event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-extendableeventinit">
@@ -8986,12 +9033,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="extendableevent-extend-lifetime-promises">
    <b><a href="#extendableevent-extend-lifetime-promises">#extendableevent-extend-lifetime-promises</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-1">4.4.1. event.waitUntil(f)</a>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-2">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-3">(2)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-4">(3)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-5">(4)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-6">(5)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-7">(6)</a>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-8">4.6.7. event.respondWith(r)</a>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-9">4.7.3. event.respondWith(r)</a>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-10">Install</a>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-11">Extend Service Worker Lifetime</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-12">(2)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-13">(3)</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-1">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-2">(2)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-3">(3)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-4">(4)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-5">(5)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-6">(6)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-7">(7)</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-8">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-9">4.6.7. event.respondWith(r)</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-10">4.7.3. event.respondWith(r)</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-11">Install</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-12">Handle Extend Lifetime Promise</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="extensions-allowed-flag">
@@ -9001,6 +9048,17 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-extensions-allowed-flag-2">Install</a>
     <li><a href="#ref-for-extensions-allowed-flag-3">Activate</a>
     <li><a href="#ref-for-extensions-allowed-flag-4">Extend Service Worker Lifetime</a> <a href="#ref-for-extensions-allowed-flag-5">(2)</a> <a href="#ref-for-extensions-allowed-flag-6">(3)</a>
+    <li><a href="#ref-for-extensions-allowed-flag-7">Handle Extend Lifetime Promise</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="extendableevent-pending-promises-count">
+   <b><a href="#extendableevent-pending-promises-count">#extendableevent-pending-promises-count</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-extendableevent-pending-promises-count-2">(2)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-3">4.6.7. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-4">(2)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-5">4.7.3. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-6">(2)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-7">Extend Service Worker Lifetime</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-8">Handle Extend Lifetime Promise</a> <a href="#ref-for-extendableevent-pending-promises-count-9">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count-10">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-extendableevent-waituntil">
@@ -9010,7 +9068,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dom-extendableevent-waituntil-2">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-dom-extendableevent-waituntil-3">(2)</a>
     <li><a href="#ref-for-dom-extendableevent-waituntil-4">4.6.7. event.respondWith(r)</a>
     <li><a href="#ref-for-dom-extendableevent-waituntil-5">4.8. ExtendableMessageEvent</a>
-    <li><a href="#ref-for-dom-extendableevent-waituntil-6">Update Worker State</a> <a href="#ref-for-dom-extendableevent-waituntil-7">(2)</a>
+    <li><a href="#ref-for-dom-extendableevent-waituntil-6">Extend Service Worker Lifetime</a>
+    <li><a href="#ref-for-dom-extendableevent-waituntil-7">Update Worker State</a> <a href="#ref-for-dom-extendableevent-waituntil-8">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="installevent">
@@ -9908,6 +9967,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-extend-service-worker-lifetime-4">Handle Fetch</a>
     <li><a href="#ref-for-extend-service-worker-lifetime-5">Handle Foreign Fetch</a>
     <li><a href="#ref-for-extend-service-worker-lifetime-6">Handle Functional Event</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="handle-extend-lifetime-promise">
+   <b><a href="#handle-extend-lifetime-promise">#handle-extend-lifetime-promise</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-handle-extend-lifetime-promise-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-handle-extend-lifetime-promise-2">(2)</a>
+    <li><a href="#ref-for-handle-extend-lifetime-promise-3">4.6.7. event.respondWith(r)</a> <a href="#ref-for-handle-extend-lifetime-promise-4">(2)</a>
+    <li><a href="#ref-for-handle-extend-lifetime-promise-5">4.7.3. event.respondWith(r)</a> <a href="#ref-for-handle-extend-lifetime-promise-6">(2)</a>
+    <li><a href="#ref-for-handle-extend-lifetime-promise-7">Handle Extend Lifetime Promise</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-fetch">

--- a/docs/index.html
+++ b/docs/index.html
@@ -5369,9 +5369,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>promise</var> is settled and <var>promise</var>’s <code>then</code> methods, if any, in the task where <var>promise</var> has been settled have executed.</p>
+       <p>Wait until <var>promise</var> is settled <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">Queue a microtask</a>, on <var>promise</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a>, to decrease <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-11">pending promises count</a> by one.</p>
+       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>promise</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a>, to decrease <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-11">pending promises count</a> by one.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle Fetch">
@@ -7289,7 +7289,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context">parent browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a>
      <li><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports">ports</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">realm</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">realm execution context</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-05">5 January 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-09">9 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1689,7 +1689,6 @@ pre.idl.highlight { color: #708090; }
       <li><a href="#activation-algorithm"><span class="secno"></span> <span class="content"><span>Activate</span></span></a>
       <li><a href="#run-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Run Service Worker</span></span></a>
       <li><a href="#terminate-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Terminate Service Worker</span></span></a>
-      <li><a href="#extend-service-worker-lifetime-algorithm"><span class="secno"></span> <span class="content"><span>Extend Service Worker Lifetime</span></span></a>
       <li><a href="#handle-extend-lifetime-promise-algorithm"><span class="secno"></span> <span class="content"><span>Handle Extend Lifetime Promise</span></span></a>
       <li><a href="#on-fetch-request-algorithm"><span class="secno"></span> <span class="content"><span>Handle Fetch</span></span></a>
       <li><a href="#on-foreign-fetch-request-algorithm"><span class="secno"></span> <span class="content"><span>Handle Foreign Fetch</span></span></a>
@@ -3038,48 +3037,48 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 };
 </pre>
      <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-2">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-extend-lifetime-promises">extend lifetime promises</dfn> (an array of <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a>). It is initially an empty array.</p>
-     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-3">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extensions-allowed-flag">extensions allowed flag</dfn>. It is initially set.</p>
-     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-pending-promises-count">pending promises count</dfn> (the number of pending promises in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-1">extend lifetime promises</a>). It is initially set to zero.</p>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-59">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-60">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-5">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
-     <p><a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> also use or extend the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a></code> interface.</p>
-     <p class="note" role="note">Note: To extend the lifetime of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-61">service worker</a>, algorithms that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> events using the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-7">ExtendableEvent</a></code> interface run <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-1">Extend Service Worker Lifetime</a> algorithm after <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> the event. See <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-2">Handle Fetch</a>, <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-1">Handle Foreign Fetch</a>, and <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-1">Handle Functional Event</a>.</p>
+     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-3">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-pending-promises-count">pending promises count</dfn> (the number of pending promises in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-1">extend lifetime promises</a>). It is initially set to zero.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-59">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-60">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
+     <p><a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> also use or extend the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-5">ExtendableEvent</a></code> interface.</p>
      <section class="algorithm" data-algorithm="wait-until-method">
       <h4 class="heading settled" data-level="4.4.1" id="wait-until-method"><span class="secno">4.4.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-2">event.waitUntil(f)</a></code></span><a class="self-link" href="#wait-until-method"></a></h4>
       <p><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-3">waitUntil()</a></code> method extends the lifetime of the event.</p>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ExtendableEvent" data-dfn-type="method" data-export="" id="dom-extendableevent-waituntil"><code>waitUntil(<var>f</var>)</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
-        <p>If the <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-1">extensions allowed flag</a> is unset, then:</p>
+        <p>If the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-1">pending promises count</a> is zero and the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is unset, then:</p>
         <ol>
          <li data-md="">
           <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">Throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" exception.</p>
          <li data-md="">
           <p>Abort these steps.</p>
         </ol>
+        <p class="note" role="note">Note: If no lifetime extension promise has been added in the task that called the event handlers), calling <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-4">waitUntil()</a></code> in subsequent asynchronous tasks will throw.</p>
        <li data-md="">
         <p>Add <var>f</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-8">extend lifetime promises</a>.</p>
        <li data-md="">
-        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-1">pending promises count</a> by one.</p>
-        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-2">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-1">Handle Extend Lifetime Promise</a> algorithm.</p>
+        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-2">pending promises count</a> by one.</p>
+        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-3">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-1">Handle Extend Lifetime Promise</a> algorithm.</p>
        <li data-md="">
         <p>Run <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-2">Handle Extend Lifetime Promise</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> and <var>f</var>.</p>
        <li data-md="">
         <p>Return.</p>
       </ol>
+      <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-3">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> when <var>event</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is set or <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> is not zero. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
      </section>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-62">Service workers</a> and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> define their own behaviors, allowing the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-2">extend lifetime promises</a> to suggest operation length, and the rejected state of any of the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> in <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-3">extend lifetime promises</a> to suggest operation failure.</p>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-63">Service workers</a> define the following behaviors for <code><a data-link-type="dfn" href="#install" id="ref-for-install-2">install</a></code> event and <code><a data-link-type="dfn" href="#activate" id="ref-for-activate-4">activate</a></code> event, respectively:</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-61">Service workers</a> and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> define their own behaviors, allowing the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-2">extend lifetime promises</a> to suggest operation length, and the rejected state of any of the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> in <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-3">extend lifetime promises</a> to suggest operation failure.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-62">Service workers</a> define the following behaviors for <code><a data-link-type="dfn" href="#install" id="ref-for-install-2">install</a></code> event and <code><a data-link-type="dfn" href="#activate" id="ref-for-activate-4">activate</a></code> event, respectively:</p>
      <ul>
       <li data-md="">
-       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> <var>f</var> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-4">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-5">installing worker</a> as <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-4">waiting worker</a>) until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-5">extend lifetime promises</a> resolve successfully. (See step 11.3.1 of <a data-link-type="dfn" href="#install" id="ref-for-install-3">Install</a> algorithm.) If <var>f</var> rejects, the installation fails. This is primarily used to ensure that a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-64">service worker</a> is not considered <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-5">waiting worker</a>) until all of the core caches it depends on are populated.</p>
+       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> <var>f</var> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-4">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-5">installing worker</a> as <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-4">waiting worker</a>) until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-5">extend lifetime promises</a> resolve successfully. (See step 11.3.1 of <a data-link-type="dfn" href="#install" id="ref-for-install-3">Install</a> algorithm.) If <var>f</var> rejects, the installation fails. This is primarily used to ensure that a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-63">service worker</a> is not considered <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-5">waiting worker</a>) until all of the core caches it depends on are populated.</p>
       <li data-md="">
-       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-6">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-20">active worker</a> as <em>activated</em> until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-7">extend lifetime promises</a> settle. (See step 12.3 of <a data-link-type="dfn" href="#activate" id="ref-for-activate-5">Activate</a> algorithm.) This is primarily used to ensure that any <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-2">functional events</a> are not dispatched to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-12">ServiceWorkerGlobalScope</a></code> object that represents the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service worker</a> until it upgrades database schemas and deletes the outdated cache entries.</p>
+       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-6">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-20">active worker</a> as <em>activated</em> until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-7">extend lifetime promises</a> settle. (See step 12.3 of <a data-link-type="dfn" href="#activate" id="ref-for-activate-5">Activate</a> algorithm.) This is primarily used to ensure that any <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-2">functional events</a> are not dispatched to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-12">ServiceWorkerGlobalScope</a></code> object that represents the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-64">service worker</a> until it upgrades database schemas and deletes the outdated cache entries.</p>
      </ul>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.5" id="installevent-interface"><span class="secno">4.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#installevent" id="ref-for-installevent-1">InstallEvent</a></code></span><a class="self-link" href="#installevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="InstallEvent" data-dfn-type="constructor" data-export="" data-lt="InstallEvent(type, eventInitDict)|InstallEvent(type)" id="dom-installevent-installevent">Constructor<a class="self-link" href="#dom-installevent-installevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="InstallEvent/InstallEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-installevent-installevent-type-eventinitdict-type">type<a class="self-link" href="#dom-installevent-installevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-extendableeventinit" id="ref-for-dictdef-extendableeventinit-2">ExtendableEventInit</a> <dfn class="nv idl-code" data-dfn-for="InstallEvent/InstallEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-installevent-installevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-installevent-installevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="installevent">InstallEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-8">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="installevent">InstallEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a> {
   <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-installevent-registerforeignfetch" id="ref-for-dom-installevent-registerforeignfetch-1">registerForeignFetch</a>(<a class="n" data-link-type="idl-name" href="#dictdef-foreignfetchoptions" id="ref-for-dictdef-foreignfetchoptions-1">ForeignFetchOptions</a> <dfn class="nv idl-code" data-dfn-for="InstallEvent/registerForeignFetch(options)" data-dfn-type="argument" data-export="" id="dom-installevent-registerforeignfetch-options-options">options<a class="self-link" href="#dom-installevent-registerforeignfetch-options-options"></a></dfn>);
 };
 
@@ -3147,7 +3146,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.6" id="fetchevent-interface"><span class="secno">4.6. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-1">FetchEvent</a></code></span><a class="self-link" href="#fetchevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="FetchEvent" data-dfn-type="constructor" data-export="" data-lt="FetchEvent(type, eventInitDict)" id="dom-fetchevent-fetchevent">Constructor<a class="self-link" href="#dom-fetchevent-fetchevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="FetchEvent/FetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-fetchevent-fetchevent-type-eventinitdict-type">type<a class="self-link" href="#dom-fetchevent-fetchevent-type-eventinitdict-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-fetcheventinit" id="ref-for-dictdef-fetcheventinit-1">FetchEventInit</a> <dfn class="nv idl-code" data-dfn-for="FetchEvent/FetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-fetchevent-fetchevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-fetchevent-fetchevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="fetchevent">FetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-9">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="fetchevent">FetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-7">ExtendableEvent</a> {
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#request">Request</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Request" href="#dom-fetchevent-request" id="ref-for-dom-fetchevent-request-1">request</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">Promise</span>&lt;<span class="kt">any</span>> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Promise<any>" href="#dom-fetchevent-preloadresponse" id="ref-for-dom-fetchevent-preloadresponse-1">preloadResponse</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-fetchevent-clientid" id="ref-for-dom-fetchevent-clientid-1">clientId</a>;
@@ -3167,7 +3166,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="FetchEventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-fetcheventinit-isreload">isReload<a class="self-link" href="#dom-fetcheventinit-isreload"></a></dfn> = <span class="kt">false</span>;
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-68">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-69">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-10">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-68">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-69">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-8">ExtendableEvent</a></code> interface.</p>
      <p>Each event using <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-3">FetchEvent</a></code> interface has an associated <dfn class="dfn-paneled" data-dfn-for="FetchEvent" data-dfn-type="dfn" data-noexport="" id="fetchevent-potential-response">potential response</dfn> (a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>), initially set to null, and the following associated flags that are initially unset:</p>
      <ul>
       <li data-md="">
@@ -3226,11 +3225,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-9">extend lifetime promises</a>.</p>
        <li data-md="">
-        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-3">pending promises count</a> by one.</p>
-        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-3">Handle Extend Lifetime Promise</a> algorithm.</p>
+        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-5">pending promises count</a> by one.</p>
+        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-6">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-3">Handle Extend Lifetime Promise</a> algorithm.</p>
        <li data-md="">
         <p>Run <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-4">Handle Extend Lifetime Promise</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> and <var>r</var>.</p>
-        <p class="note" role="note">Note: <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-3">event.respondWith(r)</a></code> extends the lifetime of the event by default as if <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-4">event.waitUntil(r)</a></code> is called.</p>
+        <p class="note" role="note">Note: <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-3">event.respondWith(r)</a></code> extends the lifetime of the event by default as if <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">event.waitUntil(r)</a></code> is called.</p>
        <li data-md="">
         <p>Set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-propagation-flag">stop propagation flag</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">stop immediate propagation flag</a>.</p>
        <li data-md="">
@@ -3330,7 +3329,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
              <li data-md="">
               <p>Set the <a data-link-type="dfn" href="#fetchevent-respond-with-error-flag" id="ref-for-fetchevent-respond-with-error-flag-3">respond-with error flag</a>.</p>
             </ol>
-            <p class="note" role="note">Note: If the <a data-link-type="dfn" href="#fetchevent-respond-with-error-flag" id="ref-for-fetchevent-respond-with-error-flag-4">respond-with error flag</a> is set, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> is returned to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> through <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-3">Handle Fetch</a> algorithm. (See the step 21.1.) Otherwise, the value <var>response</var> is returned to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> through <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-4">Handle Fetch</a> algorithm. (See the step 22.1.)</p>
+            <p class="note" role="note">Note: If the <a data-link-type="dfn" href="#fetchevent-respond-with-error-flag" id="ref-for-fetchevent-respond-with-error-flag-4">respond-with error flag</a> is set, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> is returned to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> through <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-2">Handle Fetch</a> algorithm. (See the step 21.1.) Otherwise, the value <var>response</var> is returned to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> through <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-3">Handle Fetch</a> algorithm. (See the step 22.1.)</p>
           </ol>
          <li data-md="">
           <p>Unset the <a data-link-type="dfn" href="#fetchevent-wait-to-respond-flag" id="ref-for-fetchevent-wait-to-respond-flag-2">wait to respond flag</a>.</p>
@@ -3341,7 +3340,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.7" id="foreignfetchevent-interface"><span class="secno">4.7. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#foreignfetchevent" id="ref-for-foreignfetchevent-1">ForeignFetchEvent</a></code></span><a class="self-link" href="#foreignfetchevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="ForeignFetchEvent" data-dfn-type="constructor" data-export="" data-lt="ForeignFetchEvent(type, eventInitDict)" id="dom-foreignfetchevent-foreignfetchevent">Constructor<a class="self-link" href="#dom-foreignfetchevent-foreignfetchevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="ForeignFetchEvent/ForeignFetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-foreignfetchevent-foreignfetchevent-type-eventinitdict-type">type<a class="self-link" href="#dom-foreignfetchevent-foreignfetchevent-type-eventinitdict-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-foreignfetcheventinit" id="ref-for-dictdef-foreignfetcheventinit-1">ForeignFetchEventInit</a> <dfn class="nv idl-code" data-dfn-for="ForeignFetchEvent/ForeignFetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-foreignfetchevent-foreignfetchevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-foreignfetchevent-foreignfetchevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="foreignfetchevent">ForeignFetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="foreignfetchevent">ForeignFetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-9">ExtendableEvent</a> {
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#request">Request</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Request" href="#dom-foreignfetchevent-request" id="ref-for-dom-foreignfetchevent-request-1">request</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-foreignfetchevent-origin" id="ref-for-dom-foreignfetchevent-origin-1">origin</a>;
 
@@ -3359,7 +3358,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">sequence</span>&lt;<span class="kt">ByteString</span>> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ForeignFetchResponse" data-dfn-type="dict-member" data-export="" data-type="sequence<ByteString> " id="dom-foreignfetchresponse-headers">headers</dfn>;
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-70">Service workers</a> have a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-4">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-2">foreignfetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-3">foreignfetch</a></code> events, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-71">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#foreignfetchevent" id="ref-for-foreignfetchevent-2">ForeignFetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-12">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-70">Service workers</a> have a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-4">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-2">foreignfetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-3">foreignfetch</a></code> events, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-71">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#foreignfetchevent" id="ref-for-foreignfetchevent-2">ForeignFetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-10">ExtendableEvent</a></code> interface.</p>
      <p>Each event using <code class="idl"><a data-link-type="idl" href="#foreignfetchevent" id="ref-for-foreignfetchevent-3">ForeignFetchEvent</a></code> interface has an associated <dfn class="dfn-paneled" data-dfn-for="ForeignFetchEvent" data-dfn-type="dfn" data-noexport="" id="foreignfetchevent-potential-response">potential response</dfn> (a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>), initially set to null, an associated <dfn class="dfn-paneled" data-dfn-for="ForeignFetchEvent" data-dfn-type="dfn" data-noexport="" id="foreignfetchevent-origin">origin</dfn> (a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-USVString">USVString</a></code> or null), initially set to null, an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="list-of-exposed-headers">list of exposed headers</dfn> (whose element type is a byte string), initially set to an empty list, and the following associated flags that are initially unset:</p>
      <ul>
       <li data-md="">
@@ -3402,8 +3401,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-10">extend lifetime promises</a>.</p>
         <li data-md="">
-         <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-5">pending promises count</a> by one.</p>
-         <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-6">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-5">Handle Extend Lifetime Promise</a> algorithm.</p>
+         <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-7">pending promises count</a> by one.</p>
+         <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-5">Handle Extend Lifetime Promise</a> algorithm.</p>
         <li data-md="">
          <p>Run <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-6">Handle Extend Lifetime Promise</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> and <var>r</var>.</p>
         <li data-md="">
@@ -3508,7 +3507,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
               <li data-md="">
                <p>Set the <a data-link-type="dfn" href="#foreignfetchevent-respond-with-error-flag" id="ref-for-foreignfetchevent-respond-with-error-flag-3">respond-with error flag</a>.</p>
              </ol>
-             <p class="note" role="note">Note: If the <a data-link-type="dfn" href="#foreignfetchevent-respond-with-error-flag" id="ref-for-foreignfetchevent-respond-with-error-flag-4">respond-with error flag</a> is set, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> is returned to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> through <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-2">Handle Foreign Fetch</a> algorithm. (See the step 19.1.) Otherwise, a filtered version of <var>response</var> is returned to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> through <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-3">Handle Foreign Fetch</a> algorithm. (See the step 20.1.)</p>
+             <p class="note" role="note">Note: If the <a data-link-type="dfn" href="#foreignfetchevent-respond-with-error-flag" id="ref-for-foreignfetchevent-respond-with-error-flag-4">respond-with error flag</a> is set, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> is returned to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> through <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-1">Handle Foreign Fetch</a> algorithm. (See the step 19.1.) Otherwise, a filtered version of <var>response</var> is returned to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> through <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-2">Handle Foreign Fetch</a> algorithm. (See the step 20.1.)</p>
            </ol>
           <li data-md="">
            <p>Unset the <a data-link-type="dfn" href="#foreignfetchevent-wait-to-respond-flag" id="ref-for-foreignfetchevent-wait-to-respond-flag-2">wait to respond flag</a>.</p>
@@ -3520,7 +3519,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.8" id="extendablemessageevent-interface"><span class="secno">4.8. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-2">ExtendableMessageEvent</a></code></span><a class="self-link" href="#extendablemessageevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent" data-dfn-type="constructor" data-export="" data-lt="ExtendableMessageEvent(type, eventInitDict)|ExtendableMessageEvent(type)" id="dom-extendablemessageevent-extendablemessageevent">Constructor<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent/ExtendableMessageEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-type">type<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-extendablemessageeventinit" id="ref-for-dictdef-extendablemessageeventinit-1">ExtendableMessageEventInit</a> <dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent/ExtendableMessageEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="extendablemessageevent">ExtendableMessageEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-13">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="extendablemessageevent">ExtendableMessageEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">any</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="any" href="#dom-extendablemessageevent-data" id="ref-for-dom-extendablemessageevent-data-2">data</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-extendablemessageevent-origin" id="ref-for-dom-extendablemessageevent-origin-2">origin</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-extendablemessageevent-lasteventid" id="ref-for-dom-extendablemessageevent-lasteventid-1">lastEventId</a>;
@@ -3536,7 +3535,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/comms.html#messageport">MessagePort</a>> <dfn class="nv idl-code" data-default="None" data-dfn-for="ExtendableMessageEventInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MessagePort> " id="dom-extendablemessageeventinit-ports">ports<a class="self-link" href="#dom-extendablemessageeventinit-ports"></a></dfn> = [];
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-72">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-73">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-14">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-72">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-73">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-12">ExtendableEvent</a></code> interface.</p>
      <section>
       <h4 class="heading settled" data-level="4.8.1" id="extendablemessage-event-data"><span class="secno">4.8.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendablemessageevent-data" id="ref-for-dom-extendablemessageevent-data-3">event.data</a></code></span><a class="self-link" href="#extendablemessage-event-data"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ExtendableMessageEvent" data-dfn-type="attribute" data-export="" id="dom-extendablemessageevent-data">data</dfn> attribute <em>must</em> return the value it was initialized to. When the object is created, this attribute <em>must</em> be initialized to null. It represents the message being sent.</p>
@@ -3574,16 +3573,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-2">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-17">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-6">installing worker</a> changes. (See step 11.2 of the <a data-link-type="dfn" href="#install" id="ref-for-install-4">Install</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-activate-event"><code>activate</code></dfn>
-        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-15">ExtendableEvent</a></code>
+        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-13">ExtendableEvent</a></code>
         <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-3">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-18">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-10">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-21">active worker</a> changes. (See step 12.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-6">Activate</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-fetch-event"><code>fetch</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-4">FetchEvent</a></code>
-        <td>[<a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-5">Functional event</a>] The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a> invokes <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-5">Handle Fetch</a> with <var>request</var>. As a result of performing <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-6">Handle Fetch</a>, the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-19">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-1">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
+        <td>[<a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-5">Functional event</a>] The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a> invokes <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-4">Handle Fetch</a> with <var>request</var>. As a result of performing <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-5">Handle Fetch</a>, the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-19">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-1">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-foreignfetch-event"><code>foreignfetch</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-5">FetchEvent</a></code>
-        <td>[<a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-6">Functional event</a>] The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a> invokes <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-4">Handle Foreign Fetch</a> with <var>request</var>. As a result of performing <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-5">Handle Foreign Fetch</a>, the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-20">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-2">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
+        <td>[<a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-6">Functional event</a>] The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a> invokes <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-3">Handle Foreign Fetch</a> with <var>request</var>. As a result of performing <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-4">Handle Foreign Fetch</a>, the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-20">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-2">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="eventdef-serviceworkerglobalscope-message"><code>message</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-4">ExtendableMessageEvent</a></code>
@@ -4469,7 +4468,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <p>The implementers are encouraged to note:</p>
      <ul>
       <li data-md="">
-       <p>Plug-ins should not load via <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-86">service workers</a>. As plug-ins may get their security origins from their own urls, the embedding <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-87">service worker</a> cannot handle it. For this reason, the <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-7">Handle Fetch</a> algorithm makes the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">potential-navigation-or-subresource request</a> (whose context is either <code>&lt;embed></code> or <code>&lt;object></code>) immediately fallback to the network without dispatching <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-6">fetch</a></code> event.</p>
+       <p>Plug-ins should not load via <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-86">service workers</a>. As plug-ins may get their security origins from their own urls, the embedding <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-87">service worker</a> cannot handle it. For this reason, the <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-6">Handle Fetch</a> algorithm makes the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">potential-navigation-or-subresource request</a> (whose context is either <code>&lt;embed></code> or <code>&lt;object></code>) immediately fallback to the network without dispatching <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-6">fetch</a></code> event.</p>
       <li data-md="">
        <p>Some of the legacy networking stack code may need to be carefully audited to understand the ramifications of interactions with <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-88">service workers</a>.</p>
      </ul>
@@ -4495,7 +4494,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="8.2" id="extension-to-extendable-event"><span class="secno">8.2. </span><span class="content">Define Functional Event</span><a class="self-link" href="#extension-to-extendable-event"></a></h3>
-     <p>Specifications <em>may</em> define a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-7">functional event</a> by extending <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code> interface:</p>
+     <p>Specifications <em>may</em> define a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-7">functional event</a> by extending <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-14">ExtendableEvent</a></code> interface:</p>
 <pre class="example idl highlight def" data-no-idl="" id="example-3de376f0"><a class="self-link" href="#example-3de376f0"></a>// e.g. define FunctionalEvent interface
 <span class="kt">interface</span> <span class="nv">FunctionalEvent</span> : <span class="n">ExtendableEvent</span> {
   // add a functional event’s own attributes and methods
@@ -4512,8 +4511,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="8.4" id="request-functional-event-dispatch"><span class="secno">8.4. </span><span class="content">Request Functional Event Dispatch</span><a class="self-link" href="#request-functional-event-dispatch"></a></h3>
-     <p>To request a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-9">functional event</a> dispatch to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-92">service worker</a>, specifications <em>may</em> invoke <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-2">Handle Functional Event</a> algorithm with its <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-55">service worker registration</a> <var>registration</var> and the algorithm <var>callbackSteps</var> as the arguments.</p>
-     <p>Specifications <em>may</em> define an algorithm <var>callbackSteps</var> where the corresponding <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional event</a> can be created and fired with specification specific objects. The algorithm is passed <var>globalObject</var> (a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-17">ServiceWorkerGlobalScope</a></code> object) at which it <em>may</em> fire its <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>. This algorithm is called on a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-3">Handle Functional Event</a> algorithm.</p>
+     <p>To request a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-9">functional event</a> dispatch to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-92">service worker</a>, specifications <em>may</em> invoke <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-1">Handle Functional Event</a> algorithm with its <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-55">service worker registration</a> <var>registration</var> and the algorithm <var>callbackSteps</var> as the arguments.</p>
+     <p>Specifications <em>may</em> define an algorithm <var>callbackSteps</var> where the corresponding <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional event</a> can be created and fired with specification specific objects. The algorithm is passed <var>globalObject</var> (a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-17">ServiceWorkerGlobalScope</a></code> object) at which it <em>may</em> fire its <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>. This algorithm is called on a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-2">Handle Functional Event</a> algorithm.</p>
      <p class="note" role="note">Note: See an <a href="https://notifications.spec.whatwg.org/#activating-a-notification">example</a> hook defined in <a data-link-type="biblio" href="#biblio-notifications">Notifications API</a>.</p>
     </section>
    </section>
@@ -5087,17 +5086,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>installingWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-1">global object</a>.</p>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-2">Extend Service Worker Lifetime</a> with <var>e</var>.</p>
-        <li data-md="">
          <p><em>WaitForAsynchronousExtensions</em>: Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
          <ol>
           <li data-md="">
-           <p>Wait until <var>e</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-2">extensions allowed flag</a> is unset.</p>
+           <p>Wait until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-9">pending promises count</a> is zero.</p>
           <li data-md="">
            <p>If the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#waiting-for-all">waiting for all</a> of <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-11">extend lifetime promises</a> rejected, set <var>installFailed</var> to true.</p>
          </ol>
        </ol>
-       <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-3">termination</a> of <var>installingWorker</var>, set <var>installFailed</var> to true.</p>
+       <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-4">termination</a> of <var>installingWorker</var>, set <var>installFailed</var> to true.</p>
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded.</p>
       <li data-md="">
@@ -5124,7 +5121,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-7">waiting worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-4">Terminate</a> <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-5">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
          <p>The user agent <em>may</em> abort in-flight requests triggered by <var>redundantWorker</var>.</p>
        </ol>
@@ -5171,7 +5168,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Wait for <var>redundantWorker</var> to finish handling any in-progress requests.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-5">Terminate</a> <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-6">Terminate</a> <var>redundantWorker</var>.</p>
        </ol>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-5">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a> as the arguments.</p>
@@ -5207,18 +5204,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-17">ExtendableEvent</a></code>.</p>
+         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-15">ExtendableEvent</a></code>.</p>
         <li data-md="">
          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> attribute to <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-5">activate</a></code>.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-2">global object</a>.</p>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-3">Extend Service Worker Lifetime</a> with <var>e</var>.</p>
-        <li data-md="">
-         <p><em>WaitForAsynchronousExtensions</em>: Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>e</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-3">extensions allowed flag</a> is unset.</p>
+         <p><em>WaitForAsynchronousExtensions</em>: Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-10">pending promises count</a> is zero.</p>
        </ol>
       <li data-md="">
-       <p>Wait for <var>task</var> to have executed or been discarded, or the script to have been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-6">termination</a> of <var>activeWorker</var>.</p>
+       <p>Wait for <var>task</var> to have executed or been discarded, or the script to have been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">termination</a> of <var>activeWorker</var>.</p>
       <li data-md="">
        <p>Wait for the step labeled <em>WaitForAsynchronousExtensions</em> to complete.</p>
       <li data-md="">
@@ -5358,32 +5353,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Abort the script currently running in <var>serviceWorker</var>.</p>
      </ol>
     </section>
-    <section class="algorithm" data-algorithm="Extend Service Worker Lifetime">
-     <h3 class="heading settled" id="extend-service-worker-lifetime-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="extend-service-worker-lifetime">Extend Service Worker Lifetime</dfn></span><a class="self-link" href="#extend-service-worker-lifetime-algorithm"></a></h3>
-     <dl>
-      <dt data-md="">
-       <p>Input</p>
-      <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-18">ExtendableEvent</a></code> object</p>
-      <dt data-md="">
-       <p>Output</p>
-      <dd data-md="">
-       <p>None</p>
-     </dl>
-     <ol>
-      <li data-md="">
-       <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-7">pending promises count</a> is zero, unset <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-4">extensions allowed flag</a> and abort these steps.</p>
-       <p class="note" role="note">Note: If no lifetime extension promise has been added up to this point (i.e., at the end of the task that called the event handlers), the <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-5">extensions allowed flag</a> is immediately unset. Calling <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">waitUntil()</a></code> in subsequent asynchronous tasks will throw.</p>
-     </ol>
-     <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> until <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-6">extensions allowed flag</a> is unset. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
-    </section>
     <section class="algorithm" data-algorithm="Handle Extend Lifetime Promise">
      <h3 class="heading settled" id="handle-extend-lifetime-promise-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="handle-extend-lifetime-promise">Handle Extend Lifetime Promise</dfn></span><a class="self-link" href="#handle-extend-lifetime-promise-algorithm"></a></h3>
      <dl>
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-19">ExtendableEvent</a></code> object</p>
+       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code> object</p>
       <dd data-md="">
        <p><var>promise</var>, a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a></p>
       <dt data-md="">
@@ -5393,30 +5369,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>Wait until <var>promise</var> is settled <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
+       <p>Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>promise</var> is settled and <var>promise</var>’s <code>then</code> methods, if any, in the task where <var>promise</var> has been settled have executed.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">Queue a microtask</a> to run the following substeps:</p>
-       <ol>
-        <li data-md="">
-         <p>Decrease <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> by one.</p>
-        <li data-md="">
-         <p>For each <var>reaction</var> in <var>promise</var>.[[PromiseFulfillReactions]]:</p>
-         <ol>
-          <li data-md="">
-           <p>Append <var>reaction</var>.[[Capability]].[[Promise]] to <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-12">extend lifetime promises</a>.</p>
-          <li data-md="">
-           <p>Increase <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-9">pending promises count</a> by one.</p>
-          <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-7">Handle Extend Lifetime Promise</a> with <var>event</var> and <var>reaction</var>.[[Capability]].[[Promise]].</p>
-         </ol>
-        <li data-md="">
-         <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-10">pending promises count</a> is zero, unset <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-7">extensions allowed flag</a>.</p>
-       </ol>
+       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">Queue a microtask</a>, on <var>promise</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a>, to decrease <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-11">pending promises count</a> by one.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle Fetch">
      <h3 class="heading settled" id="on-fetch-request-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="handle-fetch">Handle Fetch</dfn></span><a class="self-link" href="#on-fetch-request-algorithm"></a></h3>
-     <p>The <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-8">Handle Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-99">service worker</a> context.</p>
+     <p>The <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-7">Handle Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a> context.</p>
      <dl>
       <dt data-md="">
        <p>Input</p>
@@ -5564,8 +5524,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-5">global object</a>.</p>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-4">Extend Service Worker Lifetime</a> with <var>e</var>.</p>
-        <li data-md="">
          <p>If <var>e</var>’s <a data-link-type="dfn" href="#fetchevent-respond-with-entered-flag" id="ref-for-fetchevent-respond-with-entered-flag-3">respond-with entered flag</a> is set, set <var>respondWithEntered</var> to true.</p>
         <li data-md="">
          <p>If <var>e</var>’s <a data-link-type="dfn" href="#fetchevent-wait-to-respond-flag" id="ref-for-fetchevent-wait-to-respond-flag-3">wait to respond flag</a> is set, then:</p>
@@ -5616,7 +5574,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section class="algorithm" data-algorithm="Handle Foreign Fetch">
      <h3 class="heading settled" id="on-foreign-fetch-request-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="handle-foreign-fetch">Handle Foreign Fetch</dfn></span><a class="self-link" href="#on-foreign-fetch-request-algorithm"></a></h3>
-     <p>The <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-6">Handle Foreign Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> context to handle foreign fetch requests.</p>
+     <p>The <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-5">Handle Foreign Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-99">service worker</a> context to handle foreign fetch requests.</p>
      <dl>
       <dt data-md="">
        <p>Input</p>
@@ -5683,8 +5641,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-foreignfetchevent-origin" id="ref-for-dom-foreignfetchevent-origin-3">origin</a></code> attribute to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin">Unicode serialization</a> of <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a>.</p>
          <li data-md="">
           <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-6">global object</a>.</p>
-         <li data-md="">
-          <p>Invoke <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-5">Extend Service Worker Lifetime</a> with <var>e</var>.</p>
          <li data-md="">
           <p>If <var>e</var>’s <a data-link-type="dfn" href="#foreignfetchevent-respond-with-entered-flag" id="ref-for-foreignfetchevent-respond-with-entered-flag-3">respond-with entered flag</a> is set, set <var>respondWithEntered</var> to true.</p>
          <li data-md="">
@@ -5767,7 +5723,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-20">ExtendableEvent</a></code> object</p>
+       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-17">ExtendableEvent</a></code> object</p>
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-62">service worker registration</a></p>
       <dd data-md="">
@@ -5804,8 +5760,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <ol>
         <li data-md="">
          <p>Invoke <var>callbackSteps</var> with <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-7">global object</a> as its argument.</p>
-        <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-6">Extend Service Worker Lifetime</a> with <var>event</var>.</p>
        </ol>
        <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-4">handle functional event task source</a>.</p>
       <li data-md="">
@@ -6019,7 +5973,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dd data-md="">
        <p><var>target</var>, a string (one of "<code>installing</code>", "<code>waiting</code>", and "<code>active</code>")</p>
       <dd data-md="">
-       <p><var>source</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a> or null</p>
+       <p><var>source</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> or null</p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -6073,9 +6027,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-102">service worker</a></p>
+       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a></p>
       <dd data-md="">
-       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-12">state</a></p>
+       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-102">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-12">state</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -6099,27 +6053,27 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
              <p><em>installing</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installing" id="ref-for-dom-serviceworkerstate-installing-1">"installing"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a> is not active until all of the core caches are populated.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> is not active until all of the core caches are populated.</p>
             <dt data-md="">
              <p><em>installed</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installed" id="ref-for-dom-serviceworkerstate-installed-1">"installed"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a>.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a>.</p>
             <dt data-md="">
              <p><em>activating</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activating" id="ref-for-dom-serviceworkerstate-activating-1">"activating"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-12">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-12">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
             <dt data-md="">
              <p><em>activated</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activated" id="ref-for-dom-serviceworkerstate-activated-1">"activated"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-42">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-13">functional events</a>.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-42">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-13">functional events</a>.</p>
             <dt data-md="">
              <p><em>redundant</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-redundant" id="ref-for-dom-serviceworkerstate-redundant-2">"redundant"</a></code></p>
-             <p class="note" role="note">Note: A new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-109">service worker</a> is replacing the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-110">service worker</a>, or the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-111">service worker</a> is being discarded due to an install failure.</p>
+             <p class="note" role="note">Note: A new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a> is replacing the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-109">service worker</a>, or the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-110">service worker</a> is being discarded due to an install failure.</p>
            </dl>
           <li data-md="">
            <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <code>statechange</code> at <var>workerObject</var>.</p>
@@ -6194,7 +6148,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-112">service worker</a></p>
+       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-111">service worker</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -6262,7 +6216,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>newestWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-113">service worker</a></p>
+       <p><var>newestWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-112">service worker</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -6557,18 +6511,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <h2 class="heading settled" id="extended-http-headers"><span class="content">Appendix B: Extended HTTP headers</span><a class="self-link" href="#extended-http-headers"></a></h2>
     <section>
      <h3 class="heading settled" id="service-worker-script-request"><span class="content">Service Worker Script Request</span><a class="self-link" href="#service-worker-script-request"></a></h3>
-     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-114">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-113">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker"><code>Service-Worker</code><a class="self-link" href="#service-worker"></a></dfn>`</p>
       <dd data-md="">
-       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-115">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request.</p>
+       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-114">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request.</p>
        <p class="note" role="note">Note: This header helps administrators log the requests and detect threats.</p>
      </dl>
     </section>
     <section>
      <h3 class="heading settled" id="service-worker-script-response"><span class="content">Service Worker Script Response</span><a class="self-link" href="#service-worker-script-response"></a></h3>
-     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-116">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-115">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker-allowed"><code>Service-Worker-Allowed</code><a class="self-link" href="#service-worker-allowed"></a></dfn>`</p>
@@ -6615,7 +6569,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" id="syntax"><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
-     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-117">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-17">script resource</a> requests and responses:</p>
+     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-116">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-17">script resource</a> requests and responses:</p>
 <pre>Service-Worker = %x73.63.72.69.70.74 ; "script", case-sensitive
 </pre>
      <p class="note" role="note">Note: The validation of the Service-Worker-Allowed header’s values is done by URL parsing algorithm (in Update algorithm) instead of using ABNF.</p>
@@ -6734,8 +6688,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dom-extendablemessageevent-extendablemessageevent">ExtendableMessageEvent(type)</a><span>, in §4.8</span>
    <li><a href="#dom-extendablemessageevent-extendablemessageevent">ExtendableMessageEvent(type, eventInitDict)</a><span>, in §4.8</span>
    <li><a href="#extendableevent-extend-lifetime-promises">extend lifetime promises</a><span>, in §4.4</span>
-   <li><a href="#extend-service-worker-lifetime">Extend Service Worker Lifetime</a><span>, in §Unnumbered section</span>
-   <li><a href="#extensions-allowed-flag">extensions allowed flag</a><span>, in §4.4</span>
    <li><a href="#service-worker-global-scope-fetch-event">fetch</a><span>, in §4.9</span>
    <li><a href="#fetchevent">FetchEvent</a><span>, in §4.6</span>
    <li><a href="#dictdef-fetcheventinit">FetchEventInit</a><span>, in §4.6</span>
@@ -7137,8 +7089,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dom-clienttype-worker">worker</a><span>, in §4.3</span>
    <li><a href="#dom-clienttype-worker">"worker"</a><span>, in §4.3</span>
    <li><a href="#dfn-worker-client">worker client</a><span>, in §2.3</span>
-   <li><a href="#link-workertype-attribute">workerType</a><span>, in §5.2</span>
    <li><a href="#element-attrdef-link-workertype">workertype</a><span>, in §5.2</span>
+   <li><a href="#link-workertype-attribute">workerType</a><span>, in §5.2</span>
    <li><a href="#dfn-job-worker-type">worker type</a><span>, in §Unnumbered section</span>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -7804,7 +7756,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-51">3.5. Events</a> <a href="#ref-for-dfn-service-worker-52">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-53">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-dfn-service-worker-54">(2)</a> <a href="#ref-for-dfn-service-worker-55">(3)</a> <a href="#ref-for-dfn-service-worker-56">(4)</a>
     <li><a href="#ref-for-dfn-service-worker-57">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-service-worker-58">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-59">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-service-worker-60">(2)</a> <a href="#ref-for-dfn-service-worker-61">(3)</a> <a href="#ref-for-dfn-service-worker-62">(4)</a> <a href="#ref-for-dfn-service-worker-63">(5)</a> <a href="#ref-for-dfn-service-worker-64">(6)</a> <a href="#ref-for-dfn-service-worker-65">(7)</a>
+    <li><a href="#ref-for-dfn-service-worker-59">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-service-worker-60">(2)</a> <a href="#ref-for-dfn-service-worker-61">(3)</a> <a href="#ref-for-dfn-service-worker-62">(4)</a> <a href="#ref-for-dfn-service-worker-63">(5)</a> <a href="#ref-for-dfn-service-worker-64">(6)</a>
+    <li><a href="#ref-for-dfn-service-worker-65">4.4.1. event.waitUntil(f)</a>
     <li><a href="#ref-for-dfn-service-worker-66">4.5.1. event.registerForeignFetch(options)</a> <a href="#ref-for-dfn-service-worker-67">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-68">4.6. FetchEvent</a> <a href="#ref-for-dfn-service-worker-69">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-70">4.7. ForeignFetchEvent</a> <a href="#ref-for-dfn-service-worker-71">(2)</a>
@@ -7822,16 +7775,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-94">Install</a> <a href="#ref-for-dfn-service-worker-95">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-96">Run Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-97">Terminate Service Worker</a>
-    <li><a href="#ref-for-dfn-service-worker-98">Extend Service Worker Lifetime</a>
-    <li><a href="#ref-for-dfn-service-worker-99">Handle Fetch</a>
-    <li><a href="#ref-for-dfn-service-worker-100">Handle Foreign Fetch</a>
-    <li><a href="#ref-for-dfn-service-worker-101">Update Registration State</a>
-    <li><a href="#ref-for-dfn-service-worker-102">Update Worker State</a> <a href="#ref-for-dfn-service-worker-103">(2)</a> <a href="#ref-for-dfn-service-worker-104">(3)</a> <a href="#ref-for-dfn-service-worker-105">(4)</a> <a href="#ref-for-dfn-service-worker-106">(5)</a> <a href="#ref-for-dfn-service-worker-107">(6)</a> <a href="#ref-for-dfn-service-worker-108">(7)</a> <a href="#ref-for-dfn-service-worker-109">(8)</a> <a href="#ref-for-dfn-service-worker-110">(9)</a> <a href="#ref-for-dfn-service-worker-111">(10)</a>
-    <li><a href="#ref-for-dfn-service-worker-112">Match Service Worker for Foreign Fetch</a>
-    <li><a href="#ref-for-dfn-service-worker-113">Get Newest Worker</a>
-    <li><a href="#ref-for-dfn-service-worker-114">Service Worker Script Request</a> <a href="#ref-for-dfn-service-worker-115">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-116">Service Worker Script Response</a>
-    <li><a href="#ref-for-dfn-service-worker-117">Syntax</a>
+    <li><a href="#ref-for-dfn-service-worker-98">Handle Fetch</a>
+    <li><a href="#ref-for-dfn-service-worker-99">Handle Foreign Fetch</a>
+    <li><a href="#ref-for-dfn-service-worker-100">Update Registration State</a>
+    <li><a href="#ref-for-dfn-service-worker-101">Update Worker State</a> <a href="#ref-for-dfn-service-worker-102">(2)</a> <a href="#ref-for-dfn-service-worker-103">(3)</a> <a href="#ref-for-dfn-service-worker-104">(4)</a> <a href="#ref-for-dfn-service-worker-105">(5)</a> <a href="#ref-for-dfn-service-worker-106">(6)</a> <a href="#ref-for-dfn-service-worker-107">(7)</a> <a href="#ref-for-dfn-service-worker-108">(8)</a> <a href="#ref-for-dfn-service-worker-109">(9)</a> <a href="#ref-for-dfn-service-worker-110">(10)</a>
+    <li><a href="#ref-for-dfn-service-worker-111">Match Service Worker for Foreign Fetch</a>
+    <li><a href="#ref-for-dfn-service-worker-112">Get Newest Worker</a>
+    <li><a href="#ref-for-dfn-service-worker-113">Service Worker Script Request</a> <a href="#ref-for-dfn-service-worker-114">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-115">Service Worker Script Response</a>
+    <li><a href="#ref-for-dfn-service-worker-116">Syntax</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-state">
@@ -9007,17 +8959,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="extendableevent">
    <b><a href="#extendableevent">#extendableevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendableevent-1">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-2">(2)</a> <a href="#ref-for-extendableevent-3">(3)</a> <a href="#ref-for-extendableevent-4">(4)</a> <a href="#ref-for-extendableevent-5">(5)</a> <a href="#ref-for-extendableevent-6">(6)</a> <a href="#ref-for-extendableevent-7">(7)</a>
-    <li><a href="#ref-for-extendableevent-8">4.5. InstallEvent</a>
-    <li><a href="#ref-for-extendableevent-9">4.6. FetchEvent</a> <a href="#ref-for-extendableevent-10">(2)</a>
-    <li><a href="#ref-for-extendableevent-11">4.7. ForeignFetchEvent</a> <a href="#ref-for-extendableevent-12">(2)</a>
-    <li><a href="#ref-for-extendableevent-13">4.8. ExtendableMessageEvent</a> <a href="#ref-for-extendableevent-14">(2)</a>
-    <li><a href="#ref-for-extendableevent-15">4.9. Events</a>
-    <li><a href="#ref-for-extendableevent-16">8.2. Define Functional Event</a>
-    <li><a href="#ref-for-extendableevent-17">Activate</a>
-    <li><a href="#ref-for-extendableevent-18">Extend Service Worker Lifetime</a>
-    <li><a href="#ref-for-extendableevent-19">Handle Extend Lifetime Promise</a>
-    <li><a href="#ref-for-extendableevent-20">Handle Functional Event</a>
+    <li><a href="#ref-for-extendableevent-1">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-2">(2)</a> <a href="#ref-for-extendableevent-3">(3)</a> <a href="#ref-for-extendableevent-4">(4)</a> <a href="#ref-for-extendableevent-5">(5)</a>
+    <li><a href="#ref-for-extendableevent-6">4.5. InstallEvent</a>
+    <li><a href="#ref-for-extendableevent-7">4.6. FetchEvent</a> <a href="#ref-for-extendableevent-8">(2)</a>
+    <li><a href="#ref-for-extendableevent-9">4.7. ForeignFetchEvent</a> <a href="#ref-for-extendableevent-10">(2)</a>
+    <li><a href="#ref-for-extendableevent-11">4.8. ExtendableMessageEvent</a> <a href="#ref-for-extendableevent-12">(2)</a>
+    <li><a href="#ref-for-extendableevent-13">4.9. Events</a>
+    <li><a href="#ref-for-extendableevent-14">8.2. Define Functional Event</a>
+    <li><a href="#ref-for-extendableevent-15">Activate</a>
+    <li><a href="#ref-for-extendableevent-16">Handle Extend Lifetime Promise</a>
+    <li><a href="#ref-for-extendableevent-17">Handle Functional Event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-extendableeventinit">
@@ -9038,37 +8989,26 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-9">4.6.7. event.respondWith(r)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-10">4.7.3. event.respondWith(r)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-11">Install</a>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-12">Handle Extend Lifetime Promise</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="extensions-allowed-flag">
-   <b><a href="#extensions-allowed-flag">#extensions-allowed-flag</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-extensions-allowed-flag-1">4.4.1. event.waitUntil(f)</a>
-    <li><a href="#ref-for-extensions-allowed-flag-2">Install</a>
-    <li><a href="#ref-for-extensions-allowed-flag-3">Activate</a>
-    <li><a href="#ref-for-extensions-allowed-flag-4">Extend Service Worker Lifetime</a> <a href="#ref-for-extensions-allowed-flag-5">(2)</a> <a href="#ref-for-extensions-allowed-flag-6">(3)</a>
-    <li><a href="#ref-for-extensions-allowed-flag-7">Handle Extend Lifetime Promise</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="extendableevent-pending-promises-count">
    <b><a href="#extendableevent-pending-promises-count">#extendableevent-pending-promises-count</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-extendableevent-pending-promises-count-2">(2)</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-3">4.6.7. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-4">(2)</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-5">4.7.3. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-6">(2)</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-7">Extend Service Worker Lifetime</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-8">Handle Extend Lifetime Promise</a> <a href="#ref-for-extendableevent-pending-promises-count-9">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count-10">(3)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-extendableevent-pending-promises-count-2">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count-3">(3)</a> <a href="#ref-for-extendableevent-pending-promises-count-4">(4)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-5">4.6.7. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-6">(2)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-7">4.7.3. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-8">(2)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-9">Install</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-10">Activate</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-11">Handle Extend Lifetime Promise</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-extendableevent-waituntil">
    <b><a href="#dom-extendableevent-waituntil">#dom-extendableevent-waituntil</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendableevent-waituntil-1">4.4. ExtendableEvent</a>
-    <li><a href="#ref-for-dom-extendableevent-waituntil-2">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-dom-extendableevent-waituntil-3">(2)</a>
-    <li><a href="#ref-for-dom-extendableevent-waituntil-4">4.6.7. event.respondWith(r)</a>
-    <li><a href="#ref-for-dom-extendableevent-waituntil-5">4.8. ExtendableMessageEvent</a>
-    <li><a href="#ref-for-dom-extendableevent-waituntil-6">Extend Service Worker Lifetime</a>
+    <li><a href="#ref-for-dom-extendableevent-waituntil-2">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-dom-extendableevent-waituntil-3">(2)</a> <a href="#ref-for-dom-extendableevent-waituntil-4">(3)</a>
+    <li><a href="#ref-for-dom-extendableevent-waituntil-5">4.6.7. event.respondWith(r)</a>
+    <li><a href="#ref-for-dom-extendableevent-waituntil-6">4.8. ExtendableMessageEvent</a>
     <li><a href="#ref-for-dom-extendableevent-waituntil-7">Update Worker State</a> <a href="#ref-for-dom-extendableevent-waituntil-8">(2)</a>
    </ul>
   </aside>
@@ -9949,24 +9889,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-terminate-service-worker-1">2.1.1. Lifetime</a>
     <li><a href="#ref-for-terminate-service-worker-2">2.2. Service Worker Registration</a>
-    <li><a href="#ref-for-terminate-service-worker-3">Install</a> <a href="#ref-for-terminate-service-worker-4">(2)</a>
-    <li><a href="#ref-for-terminate-service-worker-5">Activate</a> <a href="#ref-for-terminate-service-worker-6">(2)</a>
-    <li><a href="#ref-for-terminate-service-worker-7">Extend Service Worker Lifetime</a>
+    <li><a href="#ref-for-terminate-service-worker-3">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-terminate-service-worker-4">Install</a> <a href="#ref-for-terminate-service-worker-5">(2)</a>
+    <li><a href="#ref-for-terminate-service-worker-6">Activate</a> <a href="#ref-for-terminate-service-worker-7">(2)</a>
     <li><a href="#ref-for-terminate-service-worker-8">Handle Fetch</a>
     <li><a href="#ref-for-terminate-service-worker-9">Handle Foreign Fetch</a>
     <li><a href="#ref-for-terminate-service-worker-10">Handle Service Worker Client Unload</a>
     <li><a href="#ref-for-terminate-service-worker-11">Clear Registration</a> <a href="#ref-for-terminate-service-worker-12">(2)</a> <a href="#ref-for-terminate-service-worker-13">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="extend-service-worker-lifetime">
-   <b><a href="#extend-service-worker-lifetime">#extend-service-worker-lifetime</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-extend-service-worker-lifetime-1">4.4. ExtendableEvent</a>
-    <li><a href="#ref-for-extend-service-worker-lifetime-2">Install</a>
-    <li><a href="#ref-for-extend-service-worker-lifetime-3">Activate</a>
-    <li><a href="#ref-for-extend-service-worker-lifetime-4">Handle Fetch</a>
-    <li><a href="#ref-for-extend-service-worker-lifetime-5">Handle Foreign Fetch</a>
-    <li><a href="#ref-for-extend-service-worker-lifetime-6">Handle Functional Event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-extend-lifetime-promise">
@@ -9975,34 +9904,30 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-handle-extend-lifetime-promise-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-handle-extend-lifetime-promise-2">(2)</a>
     <li><a href="#ref-for-handle-extend-lifetime-promise-3">4.6.7. event.respondWith(r)</a> <a href="#ref-for-handle-extend-lifetime-promise-4">(2)</a>
     <li><a href="#ref-for-handle-extend-lifetime-promise-5">4.7.3. event.respondWith(r)</a> <a href="#ref-for-handle-extend-lifetime-promise-6">(2)</a>
-    <li><a href="#ref-for-handle-extend-lifetime-promise-7">Handle Extend Lifetime Promise</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-fetch">
    <b><a href="#handle-fetch">#handle-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-fetch-1">3.4.3. register(scriptURL, options)</a>
-    <li><a href="#ref-for-handle-fetch-2">4.4. ExtendableEvent</a>
-    <li><a href="#ref-for-handle-fetch-3">4.6.7. event.respondWith(r)</a> <a href="#ref-for-handle-fetch-4">(2)</a>
-    <li><a href="#ref-for-handle-fetch-5">4.9. Events</a> <a href="#ref-for-handle-fetch-6">(2)</a>
-    <li><a href="#ref-for-handle-fetch-7">7.5. Implementer Concerns</a>
-    <li><a href="#ref-for-handle-fetch-8">Handle Fetch</a>
+    <li><a href="#ref-for-handle-fetch-2">4.6.7. event.respondWith(r)</a> <a href="#ref-for-handle-fetch-3">(2)</a>
+    <li><a href="#ref-for-handle-fetch-4">4.9. Events</a> <a href="#ref-for-handle-fetch-5">(2)</a>
+    <li><a href="#ref-for-handle-fetch-6">7.5. Implementer Concerns</a>
+    <li><a href="#ref-for-handle-fetch-7">Handle Fetch</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-foreign-fetch">
    <b><a href="#handle-foreign-fetch">#handle-foreign-fetch</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-handle-foreign-fetch-1">4.4. ExtendableEvent</a>
-    <li><a href="#ref-for-handle-foreign-fetch-2">4.7.3. event.respondWith(r)</a> <a href="#ref-for-handle-foreign-fetch-3">(2)</a>
-    <li><a href="#ref-for-handle-foreign-fetch-4">4.9. Events</a> <a href="#ref-for-handle-foreign-fetch-5">(2)</a>
-    <li><a href="#ref-for-handle-foreign-fetch-6">Handle Foreign Fetch</a>
+    <li><a href="#ref-for-handle-foreign-fetch-1">4.7.3. event.respondWith(r)</a> <a href="#ref-for-handle-foreign-fetch-2">(2)</a>
+    <li><a href="#ref-for-handle-foreign-fetch-3">4.9. Events</a> <a href="#ref-for-handle-foreign-fetch-4">(2)</a>
+    <li><a href="#ref-for-handle-foreign-fetch-5">Handle Foreign Fetch</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-functional-event">
    <b><a href="#handle-functional-event">#handle-functional-event</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-handle-functional-event-1">4.4. ExtendableEvent</a>
-    <li><a href="#ref-for-handle-functional-event-2">8.4. Request Functional Event Dispatch</a> <a href="#ref-for-handle-functional-event-3">(2)</a>
+    <li><a href="#ref-for-handle-functional-event-1">8.4. Request Functional Event Dispatch</a> <a href="#ref-for-handle-functional-event-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-service-worker-client-unload">

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -1208,15 +1208,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     An {{ExtendableEvent}} object has an associated <dfn for="ExtendableEvent">extend lifetime promises</dfn> (an array of <a>promises</a>). It is initially an empty array.
 
-    An {{ExtendableEvent}} object has an associated <dfn for="ExtendableEvent" id="extensions-allowed-flag">extensions allowed flag</dfn>. It is initially set.
-
     An {{ExtendableEvent}} object has an associated <dfn for="ExtendableEvent">pending promises count</dfn> (the number of pending promises in the [=ExtendableEvent/extend lifetime promises=]). It is initially set to zero.
 
     [=/Service workers=] have two <a>lifecycle events</a>, {{install!!event}} and {{activate!!event}}. [=/Service workers=] use the {{ExtendableEvent}} interface for {{activate!!event}} event and {{install!!event}} event.
 
     <a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> *may* also use or extend the {{ExtendableEvent}} interface.
-
-    Note: To extend the lifetime of a [=/service worker=], algorithms that <a>dispatch</a> events using the {{ExtendableEvent}} interface run [=Extend Service Worker Lifetime=] algorithm after <a>dispatching</a> the event. See <a>Handle Fetch</a> and <a>Handle Functional Event</a>.
 
     <section algorithm="wait-until-method">
       <h4 id="wait-until-method">{{ExtendableEvent/waitUntil()|event.waitUntil(f)}}</h4>
@@ -1225,9 +1221,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       <dfn method for="ExtendableEvent"><code>waitUntil(|f|)</code></dfn> method *must* run these steps:
 
-        1. If the <a>extensions allowed flag</a> is unset, then:
+        1. If the [=ExtendableEvent/pending promises count=] is zero and the [=dispatch flag=] is unset, then:
             1. <a>Throw</a> an "{{InvalidStateError}}" exception.
             1. Abort these steps.
+
+            Note: If no lifetime extension promise has been added in the task that called the event handlers), calling {{ExtendableEvent/waitUntil()}} in subsequent asynchronous tasks will throw.
+
         1. Add |f| to the [=ExtendableEvent/extend lifetime promises=].
         1. Increase the [=ExtendableEvent/pending promises count=] by one.
 
@@ -1235,6 +1234,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
         1. Run [=Handle Extend Lifetime Promise=] with the [=context object=] and |f|.
         1. Return.
+
+        The user agent *should not* <a lt="terminate service worker">terminate</a> the [=/service worker=] associated with |event|'s <a>relevant settings object</a>'s [=environment settings object/global object=] when |event|'s [=dispatch flag=] is set or |event|'s [=ExtendableEvent/pending promises count=] is not zero. However, the user agent *may* impose a time limit to this lifetime extension.
     </section>
 
     [=/Service workers=] and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> *may* define their own behaviors, allowing the [=ExtendableEvent/extend lifetime promises=] to suggest operation length, and the rejected state of any of the <a>promise</a> in [=ExtendableEvent/extend lifetime promises=] to suggest operation failure.
@@ -2325,9 +2326,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Let |e| be the result of <a>creating an event</a> with {{ExtendableEvent}}.
           1. Initialize |e|’s {{Event/type}} attribute to {{install!!event}}.
           1. <a>Dispatch</a> |e| at |installingWorker|'s [=service worker/global object=].
-          1. Invoke [=Extend Service Worker Lifetime=] with |e|.
           1. *WaitForAsynchronousExtensions*: Run the following substeps <a>in parallel</a>:
-              1. Wait until |e|'s <a>extensions allowed flag</a> is unset.
+              1. Wait until |e|'s [=ExtendableEvent/pending promises count=] is zero.
               1. If the result of <a>waiting for all</a> of |e|'s <a>extend lifetime promises</a> rejected, set |installFailed| to true.
 
           If |task| is discarded or the script has been aborted by the <a lt="Terminate Service Worker">termination</a> of |installingWorker|, set |installFailed| to true.
@@ -2391,8 +2391,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Let |e| be the result of <a>creating an event</a> with {{ExtendableEvent}}.
           1. Initialize |e|’s {{Event/type}} attribute to {{activate!!event}}.
           1. <a>Dispatch</a> |e| at |activeWorker|'s [=service worker/global object=].
-          1. Invoke [=Extend Service Worker Lifetime=] with |e|.
-          1. *WaitForAsynchronousExtensions*: Wait, <a>in parallel</a>, until |e|'s <a>extensions allowed flag</a> is unset.
+          1. *WaitForAsynchronousExtensions*: Wait, <a>in parallel</a>, until |e|'s [=ExtendableEvent/pending promises count=] is zero.
       1. Wait for |task| to have executed or been discarded, or the script to have been aborted by the <a lt="terminate service worker">termination</a> of |activeWorker|.
       1. Wait for the step labeled *WaitForAsynchronousExtensions* to complete.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>active worker</a> and *activated* as the arguments.
@@ -2477,21 +2476,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   </section>
 
   <section algorithm>
-    <h3 id="extend-service-worker-lifetime-algorithm"><dfn>Extend Service Worker Lifetime</dfn></h3>
-
-      : Input
-      :: |event|, an {{ExtendableEvent}} object
-      : Output
-      :: None
-
-      1. If |event|'s [=ExtendableEvent/pending promises count=] is zero, unset |event|'s [=ExtendableEvent/extensions allowed flag=] and abort these steps.
-
-          Note: If no lifetime extension promise has been added up to this point (i.e., at the end of the task that called the event handlers), the [=ExtendableEvent/extensions allowed flag=] is immediately unset. Calling {{ExtendableEvent/waitUntil()}} in subsequent asynchronous tasks will throw.
-      
-      The user agent *should not* <a lt="terminate service worker">terminate</a> the [=/service worker=] associated with |event|'s <a>relevant settings object</a>'s [=environment settings object/global object=] until |event|'s <a>extensions allowed flag</a> is unset. However, the user agent *may* impose a time limit to this lifetime extension.
-  </section>
-
-  <section algorithm>
     <h3 id="handle-extend-lifetime-promise-algorithm"><dfn>Handle Extend Lifetime Promise</dfn></h3>
 
       : Input
@@ -2500,14 +2484,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: None
 
-      1. Wait until |promise| is settled [=in parallel=].
-      2. [=Queue a microtask=] to run the following substeps:
-          1. Decrease |event|'s [=ExtendableEvent/pending promises count=] by one.
-          1. For each |reaction| in |promise|.\[[PromiseFulfillReactions]]:
-              1. Append |reaction|.\[[Capability]].\[[Promise]] to |event|'s [=ExtendableEvent/extend lifetime promises=].
-              1. Increase |event|'s [=ExtendableEvent/pending promises count=] by one.
-              1. Invoke [=Handle Extend Lifetime Promise=] with |event| and |reaction|.\[[Capability]].\[[Promise]].
-          1. If |event|'s [=ExtendableEvent/pending promises count=] is zero, unset |event|'s [=ExtendableEvent/extensions allowed flag=].
+      1. Wait, [=in parallel=], until |promise| is settled and |promise|'s <code>then</code> methods, if any, in the task where |promise| has been settled have executed.
+      2. [=Queue a microtask=], on |promise|'s [=relevant settings object=]'s [=responsible event loop=], to decrease |event|'s [=ExtendableEvent/pending promises count=] by one.
   </section>
 
   <section algorithm>
@@ -2571,7 +2549,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. If |request| is a <a>navigation request</a>, initialize |e|'s {{FetchEvent/targetClientId}} attribute to |request|'s [=request/target client id=], and to the empty string otherwise.
           1. Let the {{FetchEvent/isReload}} attribute of |e| be initialized to <code>true</code> if |request|'s [=request/client=] is a <a>window client</a> and the event was dispatched with the user's intention for the page reload, and <code>false</code> otherwise.
           1. <a>Dispatch</a> |e| at |activeWorker|'s [=service worker/global object=].
-          1. Invoke [=Extend Service Worker Lifetime=] with |e|.
           1. If |e|'s [=FetchEvent/respond-with entered flag=] is set, set |respondWithEntered| to true.
           1. If |e|'s [=FetchEvent/wait to respond flag=] is set, then:
               1. Wait until |e|'s [=FetchEvent/wait to respond flag=] is unset.
@@ -2621,7 +2598,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Invoke <a>Run Service Worker</a> algorithm with |activeWorker| as the argument.
       1. <a>Queue a task</a> |task| to run these substeps:
           1. Invoke |callbackSteps| with |activeWorker|'s [=service worker/global object=] as its argument.
-          1. Invoke [=Extend Service Worker Lifetime=] with |event|.
 
           The |task| *must* use |activeWorker|'s <a>event loop</a> and the <a>handle functional event task source</a>.
 

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -1230,10 +1230,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Add |f| to the [=ExtendableEvent/extend lifetime promises=].
         1. Increase the [=ExtendableEvent/pending promises count=] by one.
 
-            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done within [=Handle Extend Lifetime Promise=] algorithm.
+            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done in the task queued by the reaction to the promise.
 
-        1. Run [=Handle Extend Lifetime Promise=] with the [=context object=] and |f|.
-        1. Return.
+        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |f|, [=queue a task=], on |f|’s [=relevant settings object=]'s [=responsible event loop=] using the [=handle functional event task source=], to decrease the [=ExtendableEvent/pending promises count=] by one.
 
         The user agent *should not* <a lt="terminate service worker">terminate</a> the [=/service worker=] associated with |event|'s <a>relevant settings object</a>'s [=environment settings object/global object=] when |event|'s [=dispatch flag=] is set or |event|'s [=ExtendableEvent/pending promises count=] is not zero. However, the user agent *may* impose a time limit to this lifetime extension.
     </section>
@@ -1327,9 +1326,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Add |r| to the <a>extend lifetime promises</a>.
         1. Increase the [=ExtendableEvent/pending promises count=] by one.
 
-            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done within [=Handle Extend Lifetime Promise=] algorithm.
+            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done in the task queued by the reaction to the promise.
 
-        1. Run [=Handle Extend Lifetime Promise=] with the [=context object=] and |r|.
+        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |r|, [=queue a task=], on |r|’s [=relevant settings object=]'s [=responsible event loop=] using the [=handle fetch task source=], to decrease the [=ExtendableEvent/pending promises count=] by one.
 
             Note: {{FetchEvent/respondWith(r)|event.respondWith(r)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(r)}} is called.
 
@@ -2473,19 +2472,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           Note: This effectively means that the fetch events and the other functional events such as push events are backed up by the registration's task queues while the other tasks including message events are discarded.
 
       1. Abort the script currently running in |serviceWorker|.
-  </section>
-
-  <section algorithm>
-    <h3 id="handle-extend-lifetime-promise-algorithm"><dfn>Handle Extend Lifetime Promise</dfn></h3>
-
-      : Input
-      :: |event|, an {{ExtendableEvent}} object
-      :: |promise|, a [=promise=]
-      : Output
-      :: None
-
-      1. Wait until |promise| is settled [=in parallel=].
-      2. [=Queue a task=], on |promise|'s [=relevant settings object=]'s [=responsible event loop=], to decrease |event|'s [=ExtendableEvent/pending promises count=] by one.
   </section>
 
   <section algorithm>

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -1208,7 +1208,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     An {{ExtendableEvent}} object has an associated <dfn for="ExtendableEvent">extend lifetime promises</dfn> (an array of <a>promises</a>). It is initially an empty array.
 
-    An {{ExtendableEvent}} object has an associated <dfn id="extensions-allowed-flag">extensions allowed flag</dfn>. It is initially set.
+    An {{ExtendableEvent}} object has an associated <dfn for="ExtendableEvent" id="extensions-allowed-flag">extensions allowed flag</dfn>. It is initially set.
+
+    An {{ExtendableEvent}} object has an associated <dfn for="ExtendableEvent">pending promises count</dfn> (the number of pending promises in the [=ExtendableEvent/extend lifetime promises=]). It is initially set to zero.
 
     [=/Service workers=] have two <a>lifecycle events</a>, {{install!!event}} and {{activate!!event}}. [=/Service workers=] use the {{ExtendableEvent}} interface for {{activate!!event}} event and {{install!!event}} event.
 
@@ -1227,6 +1229,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             1. <a>Throw</a> an "{{InvalidStateError}}" exception.
             1. Abort these steps.
         1. Add |f| to the [=ExtendableEvent/extend lifetime promises=].
+        1. Increase the [=ExtendableEvent/pending promises count=] by one.
+
+            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done within [=Handle Extend Lifetime Promise=] algorithm.
+
+        1. Run [=Handle Extend Lifetime Promise=] with the [=context object=] and |f|.
+        1. Return.
     </section>
 
     [=/Service workers=] and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> *may* define their own behaviors, allowing the [=ExtendableEvent/extend lifetime promises=] to suggest operation length, and the rejected state of any of the <a>promise</a> in [=ExtendableEvent/extend lifetime promises=] to suggest operation failure.
@@ -1316,6 +1324,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             1. <a>Throw</a> an "{{InvalidStateError}}" exception.
             1. Abort these steps.
         1. Add |r| to the <a>extend lifetime promises</a>.
+        1. Increase the [=ExtendableEvent/pending promises count=] by one.
+
+            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done within [=Handle Extend Lifetime Promise=] algorithm.
+
+        1. Run [=Handle Extend Lifetime Promise=] with the [=context object=] and |r|.
 
             Note: {{FetchEvent/respondWith(r)|event.respondWith(r)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(r)}} is called.
 
@@ -2471,15 +2484,30 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: None
 
-      1. If |event|'s <a>extend lifetime promises</a> is empty, unset |event|'s <a>extensions allowed flag</a> and abort these steps.
-      1. Let |extendLifetimePromises| be an empty array.
-      1. Run the following substeps <a>in parallel</a>:
-          1. *SetupPromiseArray*: Set |extendLifetimePromises| to a copy of |event|'s <a>extend lifetime promises</a>.
-          1. Wait until all the <a>promises</a> in |extendLifetimePromises| settle.
-          1. If the length of |extendLifetimePromises| does not equal the length of |event|'s <a>extend lifetime promises</a>, jump to the step labeled *SetupPromiseArray*.
-          1. Unset |event|'s <a>extensions allowed flag</a>.
+      1. If |event|'s [=ExtendableEvent/pending promises count=] is zero, unset |event|'s [=ExtendableEvent/extensions allowed flag=] and abort these steps.
 
+          Note: If no lifetime extension promise has been added up to this point (i.e., at the end of the task that called the event handlers), the [=ExtendableEvent/extensions allowed flag=] is immediately unset. Calling {{ExtendableEvent/waitUntil()}} in subsequent asynchronous tasks will throw.
+      
       The user agent *should not* <a lt="terminate service worker">terminate</a> the [=/service worker=] associated with |event|'s <a>relevant settings object</a>'s [=environment settings object/global object=] until |event|'s <a>extensions allowed flag</a> is unset. However, the user agent *may* impose a time limit to this lifetime extension.
+  </section>
+
+  <section algorithm>
+    <h3 id="handle-extend-lifetime-promise-algorithm"><dfn>Handle Extend Lifetime Promise</dfn></h3>
+
+      : Input
+      :: |event|, an {{ExtendableEvent}} object
+      :: |promise|, a [=promise=]
+      : Output
+      :: None
+
+      1. Wait until |promise| is settled [=in parallel=].
+      2. [=Queue a microtask=] to run the following substeps:
+          1. Decrease |event|'s [=ExtendableEvent/pending promises count=] by one.
+          1. For each |reaction| in |promise|.\[[PromiseFulfillReactions]]:
+              1. Append |reaction|.\[[Capability]].\[[Promise]] to |event|'s [=ExtendableEvent/extend lifetime promises=].
+              1. Increase |event|'s [=ExtendableEvent/pending promises count=] by one.
+              1. Invoke [=Handle Extend Lifetime Promise=] with |event| and |reaction|.\[[Capability]].\[[Promise]].
+          1. If |event|'s [=ExtendableEvent/pending promises count=] is zero, unset |event|'s [=ExtendableEvent/extensions allowed flag=].
   </section>
 
   <section algorithm>

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -2484,8 +2484,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: None
 
-      1. Wait, [=in parallel=], until |promise| is settled and |promise|'s <code>then</code> methods, if any, in the task where |promise| has been settled have executed.
-      2. [=Queue a microtask=], on |promise|'s [=relevant settings object=]'s [=responsible event loop=], to decrease |event|'s [=ExtendableEvent/pending promises count=] by one.
+      1. Wait until |promise| is settled [=in parallel=].
+      2. [=Queue a task=], on |promise|'s [=relevant settings object=]'s [=responsible event loop=], to decrease |event|'s [=ExtendableEvent/pending promises count=] by one.
   </section>
 
   <section algorithm>

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -4861,9 +4861,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>promise</var> is settled and <var>promise</var>’s <code>then</code> methods, if any, in the task where <var>promise</var> has been settled have executed.</p>
+       <p>Wait until <var>promise</var> is settled <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">Queue a microtask</a>, on <var>promise</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a>, to decrease <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-9">pending promises count</a> by one.</p>
+       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>promise</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a>, to decrease <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-9">pending promises count</a> by one.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle Fetch">
@@ -6458,7 +6458,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context">parent browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a>
      <li><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports">ports</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">realm</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">realm execution context</a>

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 190a4fcba8ed9462253188b3415e5074949e11bd" name="generator">
+  <meta content="Bikeshed version 176d39d5a285c04f57d2f0e078fa69273028eb45" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-12-15">15 December 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-05">5 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1444,7 +1444,7 @@ pre.idl.highlight { color: #708090; }
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" rel="license">permissive document license</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" rel="license">permissive document license</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
@@ -1660,6 +1660,7 @@ pre.idl.highlight { color: #708090; }
       <li><a href="#run-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Run Service Worker</span></span></a>
       <li><a href="#terminate-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Terminate Service Worker</span></span></a>
       <li><a href="#extend-service-worker-lifetime-algorithm"><span class="secno"></span> <span class="content"><span>Extend Service Worker Lifetime</span></span></a>
+      <li><a href="#handle-extend-lifetime-promise-algorithm"><span class="secno"></span> <span class="content"><span>Handle Extend Lifetime Promise</span></span></a>
       <li><a href="#on-fetch-request-algorithm"><span class="secno"></span> <span class="content"><span>Handle Fetch</span></span></a>
       <li><a href="#handle-functional-event-algorithm"><span class="secno"></span> <span class="content"><span>Handle Functional Event</span></span></a>
       <li><a href="#on-client-unload-algorithm"><span class="secno"></span> <span class="content"><span>Handle Service Worker Client Unload</span></span></a>
@@ -2938,10 +2939,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 };
 </pre>
      <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-2">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-extend-lifetime-promises">extend lifetime promises</dfn> (an array of <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a>). It is initially an empty array.</p>
-     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-3">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="extensions-allowed-flag">extensions allowed flag</dfn>. It is initially set.</p>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-57">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-58">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
-     <p><a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> also use or extend the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-5">ExtendableEvent</a></code> interface.</p>
-     <p class="note" role="note">Note: To extend the lifetime of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-59">service worker</a>, algorithms that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> events using the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a></code> interface run <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-1">Extend Service Worker Lifetime</a> algorithm after <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> the event. See <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-2">Handle Fetch</a> and <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-1">Handle Functional Event</a>.</p>
+     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-3">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extensions-allowed-flag">extensions allowed flag</dfn>. It is initially set.</p>
+     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-pending-promises-count">pending promises count</dfn> (the number of pending promises in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-1">extend lifetime promises</a>). It is initially set to zero.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-57">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-58">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-5">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
+     <p><a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> also use or extend the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a></code> interface.</p>
+     <p class="note" role="note">Note: To extend the lifetime of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-59">service worker</a>, algorithms that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> events using the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-7">ExtendableEvent</a></code> interface run <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-1">Extend Service Worker Lifetime</a> algorithm after <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> the event. See <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-2">Handle Fetch</a> and <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-1">Handle Functional Event</a>.</p>
      <section class="algorithm" data-algorithm="wait-until-method">
       <h4 class="heading settled" data-level="4.4.1" id="wait-until-method"><span class="secno">4.4.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-2">event.waitUntil(f)</a></code></span><a class="self-link" href="#wait-until-method"></a></h4>
       <p><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-3">waitUntil()</a></code> method extends the lifetime of the event.</p>
@@ -2956,7 +2958,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <p>Abort these steps.</p>
         </ol>
        <li data-md="">
-        <p>Add <var>f</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-1">extend lifetime promises</a>.</p>
+        <p>Add <var>f</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-8">extend lifetime promises</a>.</p>
+       <li data-md="">
+        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-1">pending promises count</a> by one.</p>
+        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-2">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-1">Handle Extend Lifetime Promise</a> algorithm.</p>
+       <li data-md="">
+        <p>Run <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-2">Handle Extend Lifetime Promise</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> and <var>f</var>.</p>
+       <li data-md="">
+        <p>Return.</p>
       </ol>
      </section>
      <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-60">Service workers</a> and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> define their own behaviors, allowing the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-2">extend lifetime promises</a> to suggest operation length, and the rejected state of any of the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> in <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-3">extend lifetime promises</a> to suggest operation failure.</p>
@@ -2971,7 +2980,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.5" id="fetchevent-interface"><span class="secno">4.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-1">FetchEvent</a></code></span><a class="self-link" href="#fetchevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="FetchEvent" data-dfn-type="constructor" data-export="" data-lt="FetchEvent(type, eventInitDict)" id="dom-fetchevent-fetchevent">Constructor<a class="self-link" href="#dom-fetchevent-fetchevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="FetchEvent/FetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-fetchevent-fetchevent-type-eventinitdict-type">type<a class="self-link" href="#dom-fetchevent-fetchevent-type-eventinitdict-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-fetcheventinit" id="ref-for-dictdef-fetcheventinit-1">FetchEventInit</a> <dfn class="nv idl-code" data-dfn-for="FetchEvent/FetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-fetchevent-fetchevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-fetchevent-fetchevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="fetchevent">FetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-7">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="fetchevent">FetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-8">ExtendableEvent</a> {
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#request">Request</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Request" href="#dom-fetchevent-request" id="ref-for-dom-fetchevent-request-1">request</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-fetchevent-clientid" id="ref-for-dom-fetchevent-clientid-1">clientId</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-fetchevent-reservedclientid" id="ref-for-dom-fetchevent-reservedclientid-1">reservedClientId</a>;
@@ -2989,7 +2998,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="FetchEventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-fetcheventinit-isreload">isReload<a class="self-link" href="#dom-fetcheventinit-isreload"></a></dfn> = <span class="kt">false</span>;
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-64">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-8">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-64">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-9">ExtendableEvent</a></code> interface.</p>
      <p>Each event using <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-3">FetchEvent</a></code> interface has an associated <dfn class="dfn-paneled" data-dfn-for="FetchEvent" data-dfn-type="dfn" data-noexport="" id="fetchevent-potential-response">potential response</dfn> (a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>), initially set to null, and the following associated flags that are initially unset:</p>
      <ul>
       <li data-md="">
@@ -3042,7 +3051,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <p>Abort these steps.</p>
         </ol>
        <li data-md="">
-        <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-8">extend lifetime promises</a>.</p>
+        <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-9">extend lifetime promises</a>.</p>
+       <li data-md="">
+        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-3">pending promises count</a> by one.</p>
+        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-3">Handle Extend Lifetime Promise</a> algorithm.</p>
+       <li data-md="">
+        <p>Run <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-4">Handle Extend Lifetime Promise</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> and <var>r</var>.</p>
         <p class="note" role="note">Note: <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-3">event.respondWith(r)</a></code> extends the lifetime of the event by default as if <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-4">event.waitUntil(r)</a></code> is called.</p>
        <li data-md="">
         <p>Set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-propagation-flag">stop propagation flag</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">stop immediate propagation flag</a>.</p>
@@ -3154,7 +3168,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.6" id="extendablemessageevent-interface"><span class="secno">4.6. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-2">ExtendableMessageEvent</a></code></span><a class="self-link" href="#extendablemessageevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent" data-dfn-type="constructor" data-export="" data-lt="ExtendableMessageEvent(type, eventInitDict)|ExtendableMessageEvent(type)" id="dom-extendablemessageevent-extendablemessageevent">Constructor<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent/ExtendableMessageEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-type">type<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-extendablemessageeventinit" id="ref-for-dictdef-extendablemessageeventinit-1">ExtendableMessageEventInit</a> <dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent/ExtendableMessageEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="extendablemessageevent">ExtendableMessageEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-9">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="extendablemessageevent">ExtendableMessageEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-10">ExtendableEvent</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">any</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="any" href="#dom-extendablemessageevent-data" id="ref-for-dom-extendablemessageevent-data-2">data</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-extendablemessageevent-origin" id="ref-for-dom-extendablemessageevent-origin-2">origin</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-extendablemessageevent-lasteventid" id="ref-for-dom-extendablemessageevent-lasteventid-1">lastEventId</a>;
@@ -3170,7 +3184,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/comms.html#messageport">MessagePort</a>> <dfn class="nv idl-code" data-default="None" data-dfn-for="ExtendableMessageEventInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MessagePort> " id="dom-extendablemessageeventinit-ports">ports<a class="self-link" href="#dom-extendablemessageeventinit-ports"></a></dfn> = [];
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-66">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-67">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-10">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-66">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-67">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a></code> interface.</p>
      <section>
       <h4 class="heading settled" data-level="4.6.1" id="extendablemessage-event-data"><span class="secno">4.6.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendablemessageevent-data" id="ref-for-dom-extendablemessageevent-data-3">event.data</a></code></span><a class="self-link" href="#extendablemessage-event-data"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ExtendableMessageEvent" data-dfn-type="attribute" data-export="" id="dom-extendablemessageevent-data">data</dfn> attribute <em>must</em> return the value it was initialized to. When the object is created, this attribute <em>must</em> be initialized to null. It represents the message being sent.</p>
@@ -3204,11 +3218,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <tbody>
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-install-event"><code>install</code></dfn>
-        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a></code>
+        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-12">ExtendableEvent</a></code>
         <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-2">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-16">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-8">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-6">installing worker</a> changes. (See step 11.2 of the <a data-link-type="dfn" href="#install" id="ref-for-install-4">Install</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-activate-event"><code>activate</code></dfn>
-        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-12">ExtendableEvent</a></code>
+        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-13">ExtendableEvent</a></code>
         <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-3">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-17">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-18">active worker</a> changes. (See step 12.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-6">Activate</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-fetch-event"><code>fetch</code></dfn>
@@ -4028,7 +4042,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="7.2" id="extension-to-extendable-event"><span class="secno">7.2. </span><span class="content">Define Functional Event</span><a class="self-link" href="#extension-to-extendable-event"></a></h3>
-     <p>Specifications <em>may</em> define a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-5">functional event</a> by extending <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-13">ExtendableEvent</a></code> interface:</p>
+     <p>Specifications <em>may</em> define a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-5">functional event</a> by extending <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-14">ExtendableEvent</a></code> interface:</p>
 <pre class="example idl highlight def" data-no-idl="" id="example-3de376f0"><a class="self-link" href="#example-3de376f0"></a>// e.g. define FunctionalEvent interface
 <span class="kt">interface</span> <span class="nv">FunctionalEvent</span> : <span class="n">ExtendableEvent</span> {
   // add a functional event’s own attributes and methods
@@ -4559,7 +4573,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-14">ExtendableEvent</a></code>.</p>
+         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-15">ExtendableEvent</a></code>.</p>
         <li data-md="">
          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> attribute to <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-5">install</a></code>.</p>
         <li data-md="">
@@ -4572,7 +4586,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <li data-md="">
            <p>Wait until <var>e</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-2">extensions allowed flag</a> is unset.</p>
           <li data-md="">
-           <p>If the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#waiting-for-all">waiting for all</a> of <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-9">extend lifetime promises</a> rejected, set <var>installFailed</var> to true.</p>
+           <p>If the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#waiting-for-all">waiting for all</a> of <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-10">extend lifetime promises</a> rejected, set <var>installFailed</var> to true.</p>
          </ol>
        </ol>
        <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-3">termination</a> of <var>installingWorker</var>, set <var>installFailed</var> to true.</p>
@@ -4685,7 +4699,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-15">ExtendableEvent</a></code>.</p>
+         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code>.</p>
         <li data-md="">
          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> attribute to <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-5">activate</a></code>.</p>
         <li data-md="">
@@ -4842,7 +4856,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code> object</p>
+       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-17">ExtendableEvent</a></code> object</p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -4850,23 +4864,47 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-10">extend lifetime promises</a> is empty, unset <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-4">extensions allowed flag</a> and abort these steps.</p>
-      <li data-md="">
-       <p>Let <var>extendLifetimePromises</var> be an empty array.</p>
-      <li data-md="">
-       <p>Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
-       <ol>
-        <li data-md="">
-         <p><em>SetupPromiseArray</em>: Set <var>extendLifetimePromises</var> to a copy of <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-11">extend lifetime promises</a>.</p>
-        <li data-md="">
-         <p>Wait until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in <var>extendLifetimePromises</var> settle.</p>
-        <li data-md="">
-         <p>If the length of <var>extendLifetimePromises</var> does not equal the length of <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-12">extend lifetime promises</a>, jump to the step labeled <em>SetupPromiseArray</em>.</p>
-        <li data-md="">
-         <p>Unset <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-5">extensions allowed flag</a>.</p>
-       </ol>
+       <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-5">pending promises count</a> is zero, unset <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-4">extensions allowed flag</a> and abort these steps.</p>
+       <p class="note" role="note">Note: If no lifetime extension promise has been added up to this point (i.e., at the end of the task that called the event handlers), the <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-5">extensions allowed flag</a> is immediately unset. Calling <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">waitUntil()</a></code> in subsequent asynchronous tasks will throw.</p>
      </ol>
      <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-92">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> until <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-6">extensions allowed flag</a> is unset. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
+    </section>
+    <section class="algorithm" data-algorithm="Handle Extend Lifetime Promise">
+     <h3 class="heading settled" id="handle-extend-lifetime-promise-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="handle-extend-lifetime-promise">Handle Extend Lifetime Promise</dfn></span><a class="self-link" href="#handle-extend-lifetime-promise-algorithm"></a></h3>
+     <dl>
+      <dt data-md="">
+       <p>Input</p>
+      <dd data-md="">
+       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-18">ExtendableEvent</a></code> object</p>
+      <dd data-md="">
+       <p><var>promise</var>, a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a></p>
+      <dt data-md="">
+       <p>Output</p>
+      <dd data-md="">
+       <p>None</p>
+     </dl>
+     <ol>
+      <li data-md="">
+       <p>Wait until <var>promise</var> is settled <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
+      <li data-md="">
+       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">Queue a microtask</a> to run the following substeps:</p>
+       <ol>
+        <li data-md="">
+         <p>Decrease <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-6">pending promises count</a> by one.</p>
+        <li data-md="">
+         <p>For each <var>reaction</var> in <var>promise</var>.[[PromiseFulfillReactions]]:</p>
+         <ol>
+          <li data-md="">
+           <p>Append <var>reaction</var>.[[Capability]].[[Promise]] to <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-11">extend lifetime promises</a>.</p>
+          <li data-md="">
+           <p>Increase <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-7">pending promises count</a> by one.</p>
+          <li data-md="">
+           <p>Invoke <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-5">Handle Extend Lifetime Promise</a> with <var>event</var> and <var>reaction</var>.[[Capability]].[[Promise]].</p>
+         </ol>
+        <li data-md="">
+         <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> is zero, unset <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-7">extensions allowed flag</a>.</p>
+       </ol>
+     </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle Fetch">
      <h3 class="heading settled" id="on-fetch-request-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="handle-fetch">Handle Fetch</dfn></span><a class="self-link" href="#on-fetch-request-algorithm"></a></h3>
@@ -5039,7 +5077,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-17">ExtendableEvent</a></code> object</p>
+       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-19">ExtendableEvent</a></code> object</p>
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-54">service worker registration</a></p>
       <dd data-md="">
@@ -5371,7 +5409,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
              <p><em>installing</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installing" id="ref-for-dom-serviceworkerstate-installing-1">"installing"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-97">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a> is not active until all of the core caches are populated.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-97">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a> is not active until all of the core caches are populated.</p>
             <dt data-md="">
              <p><em>installed</em></p>
             <dd data-md="">
@@ -5381,7 +5419,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
              <p><em>activating</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activating" id="ref-for-dom-serviceworkerstate-activating-1">"activating"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
             <dt data-md="">
              <p><em>activated</em></p>
             <dd data-md="">
@@ -5992,6 +6030,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="#dfn-service-worker-global-object">dfn for service worker</a><span>, in §2.1</span>
      <li><a href="#cachestorage-global-object">dfn for CacheStorage</a><span>, in §5.5</span>
     </ul>
+   <li><a href="#handle-extend-lifetime-promise">Handle Extend Lifetime Promise</a><span>, in §Unnumbered section</span>
    <li><a href="#handle-fetch">Handle Fetch</a><span>, in §Unnumbered section</span>
    <li><a href="#dfn-handle-fetch-task-source">handle fetch task source</a><span>, in §2.5</span>
    <li><a href="#handle-functional-event">Handle Functional Event</a><span>, in §Unnumbered section</span>
@@ -6102,6 +6141,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="#dom-extendablemessageeventinit-origin">dict-member for ExtendableMessageEventInit</a><span>, in §4.6</span>
      <li><a href="#dom-extendablemessageevent-origin">attribute for ExtendableMessageEvent</a><span>, in §4.6.2</span>
     </ul>
+   <li><a href="#extendableevent-pending-promises-count">pending promises count</a><span>, in §4.4</span>
    <li>
     ports
     <ul>
@@ -6464,6 +6504,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context">parent browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a>
      <li><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports">ports</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">realm</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">realm execution context</a>
@@ -6605,7 +6646,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <dt id="biblio-promises-guide">[PROMISES-GUIDE]
    <dd>Domenic Denicola. <a href="https://www.w3.org/2001/tag/doc/promises-guide">Writing Promise-Using Specifications</a>. 16 February 2016. Finding of the W3C TAG. URL: <a href="https://www.w3.org/2001/tag/doc/promises-guide">https://www.w3.org/2001/tag/doc/promises-guide</a>
    <dt id="biblio-referrer-policy">[REFERRER-POLICY]
-   <dd>Jochen Eisinger; Mike West. <a href="https://w3c.github.io/webappsec-referrer-policy/">Referrer Policy</a>. URL: <a href="https://w3c.github.io/webappsec-referrer-policy/">https://w3c.github.io/webappsec-referrer-policy/</a>
+   <dd>Jochen Eisinger; Emily Stark. <a href="https://w3c.github.io/webappsec-referrer-policy/">Referrer Policy</a>. URL: <a href="https://w3c.github.io/webappsec-referrer-policy/">https://w3c.github.io/webappsec-referrer-policy/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-rfc5234">[RFC5234]
@@ -7942,15 +7983,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="extendableevent">
    <b><a href="#extendableevent">#extendableevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendableevent-1">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-2">(2)</a> <a href="#ref-for-extendableevent-3">(3)</a> <a href="#ref-for-extendableevent-4">(4)</a> <a href="#ref-for-extendableevent-5">(5)</a> <a href="#ref-for-extendableevent-6">(6)</a>
-    <li><a href="#ref-for-extendableevent-7">4.5. FetchEvent</a> <a href="#ref-for-extendableevent-8">(2)</a>
-    <li><a href="#ref-for-extendableevent-9">4.6. ExtendableMessageEvent</a> <a href="#ref-for-extendableevent-10">(2)</a>
-    <li><a href="#ref-for-extendableevent-11">4.7. Events</a> <a href="#ref-for-extendableevent-12">(2)</a>
-    <li><a href="#ref-for-extendableevent-13">7.2. Define Functional Event</a>
-    <li><a href="#ref-for-extendableevent-14">Install</a>
-    <li><a href="#ref-for-extendableevent-15">Activate</a>
-    <li><a href="#ref-for-extendableevent-16">Extend Service Worker Lifetime</a>
-    <li><a href="#ref-for-extendableevent-17">Handle Functional Event</a>
+    <li><a href="#ref-for-extendableevent-1">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-2">(2)</a> <a href="#ref-for-extendableevent-3">(3)</a> <a href="#ref-for-extendableevent-4">(4)</a> <a href="#ref-for-extendableevent-5">(5)</a> <a href="#ref-for-extendableevent-6">(6)</a> <a href="#ref-for-extendableevent-7">(7)</a>
+    <li><a href="#ref-for-extendableevent-8">4.5. FetchEvent</a> <a href="#ref-for-extendableevent-9">(2)</a>
+    <li><a href="#ref-for-extendableevent-10">4.6. ExtendableMessageEvent</a> <a href="#ref-for-extendableevent-11">(2)</a>
+    <li><a href="#ref-for-extendableevent-12">4.7. Events</a> <a href="#ref-for-extendableevent-13">(2)</a>
+    <li><a href="#ref-for-extendableevent-14">7.2. Define Functional Event</a>
+    <li><a href="#ref-for-extendableevent-15">Install</a>
+    <li><a href="#ref-for-extendableevent-16">Activate</a>
+    <li><a href="#ref-for-extendableevent-17">Extend Service Worker Lifetime</a>
+    <li><a href="#ref-for-extendableevent-18">Handle Extend Lifetime Promise</a>
+    <li><a href="#ref-for-extendableevent-19">Handle Functional Event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-extendableeventinit">
@@ -7964,11 +8006,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="extendableevent-extend-lifetime-promises">
    <b><a href="#extendableevent-extend-lifetime-promises">#extendableevent-extend-lifetime-promises</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-1">4.4.1. event.waitUntil(f)</a>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-2">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-3">(2)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-4">(3)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-5">(4)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-6">(5)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-7">(6)</a>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-8">4.5.6. event.respondWith(r)</a>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-9">Install</a>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-10">Extend Service Worker Lifetime</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-11">(2)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-12">(3)</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-1">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-2">(2)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-3">(3)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-4">(4)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-5">(5)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-6">(6)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-7">(7)</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-8">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-9">4.5.6. event.respondWith(r)</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-10">Install</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-11">Handle Extend Lifetime Promise</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="extensions-allowed-flag">
@@ -7978,6 +8020,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-extensions-allowed-flag-2">Install</a>
     <li><a href="#ref-for-extensions-allowed-flag-3">Activate</a>
     <li><a href="#ref-for-extensions-allowed-flag-4">Extend Service Worker Lifetime</a> <a href="#ref-for-extensions-allowed-flag-5">(2)</a> <a href="#ref-for-extensions-allowed-flag-6">(3)</a>
+    <li><a href="#ref-for-extensions-allowed-flag-7">Handle Extend Lifetime Promise</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="extendableevent-pending-promises-count">
+   <b><a href="#extendableevent-pending-promises-count">#extendableevent-pending-promises-count</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-extendableevent-pending-promises-count-2">(2)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-3">4.5.6. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-4">(2)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-5">Extend Service Worker Lifetime</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-6">Handle Extend Lifetime Promise</a> <a href="#ref-for-extendableevent-pending-promises-count-7">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count-8">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-extendableevent-waituntil">
@@ -7987,7 +8039,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dom-extendableevent-waituntil-2">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-dom-extendableevent-waituntil-3">(2)</a>
     <li><a href="#ref-for-dom-extendableevent-waituntil-4">4.5.6. event.respondWith(r)</a>
     <li><a href="#ref-for-dom-extendableevent-waituntil-5">4.6. ExtendableMessageEvent</a>
-    <li><a href="#ref-for-dom-extendableevent-waituntil-6">Update Worker State</a> <a href="#ref-for-dom-extendableevent-waituntil-7">(2)</a>
+    <li><a href="#ref-for-dom-extendableevent-waituntil-6">Extend Service Worker Lifetime</a>
+    <li><a href="#ref-for-dom-extendableevent-waituntil-7">Update Worker State</a> <a href="#ref-for-dom-extendableevent-waituntil-8">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fetchevent">
@@ -8674,6 +8727,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-extend-service-worker-lifetime-3">Activate</a>
     <li><a href="#ref-for-extend-service-worker-lifetime-4">Handle Fetch</a>
     <li><a href="#ref-for-extend-service-worker-lifetime-5">Handle Functional Event</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="handle-extend-lifetime-promise">
+   <b><a href="#handle-extend-lifetime-promise">#handle-extend-lifetime-promise</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-handle-extend-lifetime-promise-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-handle-extend-lifetime-promise-2">(2)</a>
+    <li><a href="#ref-for-handle-extend-lifetime-promise-3">4.5.6. event.respondWith(r)</a> <a href="#ref-for-handle-extend-lifetime-promise-4">(2)</a>
+    <li><a href="#ref-for-handle-extend-lifetime-promise-5">Handle Extend Lifetime Promise</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-fetch">

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-09">9 January 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-11">11 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1659,7 +1659,6 @@ pre.idl.highlight { color: #708090; }
       <li><a href="#activation-algorithm"><span class="secno"></span> <span class="content"><span>Activate</span></span></a>
       <li><a href="#run-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Run Service Worker</span></span></a>
       <li><a href="#terminate-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Terminate Service Worker</span></span></a>
-      <li><a href="#handle-extend-lifetime-promise-algorithm"><span class="secno"></span> <span class="content"><span>Handle Extend Lifetime Promise</span></span></a>
       <li><a href="#on-fetch-request-algorithm"><span class="secno"></span> <span class="content"><span>Handle Fetch</span></span></a>
       <li><a href="#handle-functional-event-algorithm"><span class="secno"></span> <span class="content"><span>Handle Functional Event</span></span></a>
       <li><a href="#on-client-unload-algorithm"><span class="secno"></span> <span class="content"><span>Handle Service Worker Client Unload</span></span></a>
@@ -2959,13 +2958,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>Add <var>f</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-8">extend lifetime promises</a>.</p>
        <li data-md="">
         <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-2">pending promises count</a> by one.</p>
-        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-3">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-1">Handle Extend Lifetime Promise</a> algorithm.</p>
+        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-3">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done in the task queued by the reaction to the promise.</p>
        <li data-md="">
-        <p>Run <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-2">Handle Extend Lifetime Promise</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> and <var>f</var>.</p>
-       <li data-md="">
-        <p>Return.</p>
+        <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>f</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>f</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, to decrease the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> by one.</p>
       </ol>
-      <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-3">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-63">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> when <var>event</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is set or <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> is not zero. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
+      <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-3">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-63">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> when <var>event</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is set or <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-5">pending promises count</a> is not zero. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
      </section>
      <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-59">Service workers</a> and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> define their own behaviors, allowing the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-2">extend lifetime promises</a> to suggest operation length, and the rejected state of any of the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> in <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-3">extend lifetime promises</a> to suggest operation failure.</p>
      <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-60">Service workers</a> define the following behaviors for <code><a data-link-type="dfn" href="#install" id="ref-for-install-2">install</a></code> event and <code><a data-link-type="dfn" href="#activate" id="ref-for-activate-4">activate</a></code> event, respectively:</p>
@@ -3052,10 +3049,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-9">extend lifetime promises</a>.</p>
        <li data-md="">
-        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-5">pending promises count</a> by one.</p>
-        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-6">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-3">Handle Extend Lifetime Promise</a> algorithm.</p>
+        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-6">pending promises count</a> by one.</p>
+        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-7">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done in the task queued by the reaction to the promise.</p>
        <li data-md="">
-        <p>Run <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-4">Handle Extend Lifetime Promise</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> and <var>r</var>.</p>
+        <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>r</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>r</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a>, to decrease the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> by one.</p>
         <p class="note" role="note">Note: <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-3">event.respondWith(r)</a></code> extends the lifetime of the event by default as if <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">event.waitUntil(r)</a></code> is called.</p>
        <li data-md="">
         <p>Set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-propagation-flag">stop propagation flag</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">stop immediate propagation flag</a>.</p>
@@ -4581,7 +4578,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><em>WaitForAsynchronousExtensions</em>: Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
          <ol>
           <li data-md="">
-           <p>Wait until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-7">pending promises count</a> is zero.</p>
+           <p>Wait until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-9">pending promises count</a> is zero.</p>
           <li data-md="">
            <p>If the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#waiting-for-all">waiting for all</a> of <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-10">extend lifetime promises</a> rejected, set <var>installFailed</var> to true.</p>
          </ol>
@@ -4702,7 +4699,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-2">global object</a>.</p>
         <li data-md="">
-         <p><em>WaitForAsynchronousExtensions</em>: Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> is zero.</p>
+         <p><em>WaitForAsynchronousExtensions</em>: Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-10">pending promises count</a> is zero.</p>
        </ol>
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded, or the script to have been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">termination</a> of <var>activeWorker</var>.</p>
@@ -4839,31 +4836,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>serviceWorkerGlobalScope</var>’s closing flag to true.</p>
       <li data-md="">
-       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-13">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
+       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-13">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-4">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-4">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
        <p class="note" role="note">Note: This effectively means that the fetch events and the other functional events such as push events are backed up by the registration’s task queues while the other tasks including message events are discarded.</p>
       <li data-md="">
        <p>Abort the script currently running in <var>serviceWorker</var>.</p>
-     </ol>
-    </section>
-    <section class="algorithm" data-algorithm="Handle Extend Lifetime Promise">
-     <h3 class="heading settled" id="handle-extend-lifetime-promise-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="handle-extend-lifetime-promise">Handle Extend Lifetime Promise</dfn></span><a class="self-link" href="#handle-extend-lifetime-promise-algorithm"></a></h3>
-     <dl>
-      <dt data-md="">
-       <p>Input</p>
-      <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-15">ExtendableEvent</a></code> object</p>
-      <dd data-md="">
-       <p><var>promise</var>, a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a></p>
-      <dt data-md="">
-       <p>Output</p>
-      <dd data-md="">
-       <p>None</p>
-     </dl>
-     <ol>
-      <li data-md="">
-       <p>Wait until <var>promise</var> is settled <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
-      <li data-md="">
-       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>promise</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a>, to decrease <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-9">pending promises count</a> by one.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle Fetch">
@@ -4996,7 +4972,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>If <var>e</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#canceled-flag">canceled flag</a> is set, set <var>eventCanceled</var> to true.</p>
        </ol>
        <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-8">termination</a> of <var>activeWorker</var>, set <var>handleFetchFailed</var> to true.</p>
-       <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-4">handle fetch task source</a>.</p>
+       <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-5">handle fetch task source</a>.</p>
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded.</p>
       <li data-md="">
@@ -5035,7 +5011,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code> object</p>
+       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-15">ExtendableEvent</a></code> object</p>
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-54">service worker registration</a></p>
       <dd data-md="">
@@ -5073,7 +5049,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Invoke <var>callbackSteps</var> with <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-6">global object</a> as its argument.</p>
        </ol>
-       <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-4">handle functional event task source</a>.</p>
+       <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-5">handle functional event task source</a>.</p>
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded.</p>
       <li data-md="">
@@ -5984,7 +5960,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="#dfn-service-worker-global-object">dfn for service worker</a><span>, in §2.1</span>
      <li><a href="#cachestorage-global-object">dfn for CacheStorage</a><span>, in §5.5</span>
     </ul>
-   <li><a href="#handle-extend-lifetime-promise">Handle Extend Lifetime Promise</a><span>, in §Unnumbered section</span>
    <li><a href="#handle-fetch">Handle Fetch</a><span>, in §Unnumbered section</span>
    <li><a href="#dfn-handle-fetch-task-source">handle fetch task source</a><span>, in §2.5</span>
    <li><a href="#handle-functional-event">Handle Functional Event</a><span>, in §Unnumbered section</span>
@@ -6515,6 +6490,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <a data-link-type="biblio">[promises-guide]</a> defines the following terms:
     <ul>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#transforming-by">transforming</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">upon fulfillment</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">upon rejection</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#waiting-for-all">waiting for all</a>
     </ul>
    <li>
@@ -7282,16 +7259,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dfn-handle-fetch-task-source">#dfn-handle-fetch-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-handle-fetch-task-source-1">2.2. Service Worker Registration</a>
-    <li><a href="#ref-for-dfn-handle-fetch-task-source-2">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-fetch-task-source-3">(2)</a>
-    <li><a href="#ref-for-dfn-handle-fetch-task-source-4">Handle Fetch</a>
+    <li><a href="#ref-for-dfn-handle-fetch-task-source-2">4.5.6. event.respondWith(r)</a>
+    <li><a href="#ref-for-dfn-handle-fetch-task-source-3">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-fetch-task-source-4">(2)</a>
+    <li><a href="#ref-for-dfn-handle-fetch-task-source-5">Handle Fetch</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-handle-functional-event-task-source">
    <b><a href="#dfn-handle-functional-event-task-source">#dfn-handle-functional-event-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-handle-functional-event-task-source-1">2.2. Service Worker Registration</a>
-    <li><a href="#ref-for-dfn-handle-functional-event-task-source-2">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-functional-event-task-source-3">(2)</a>
-    <li><a href="#ref-for-dfn-handle-functional-event-task-source-4">Handle Functional Event</a>
+    <li><a href="#ref-for-dfn-handle-functional-event-task-source-2">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-dfn-handle-functional-event-task-source-3">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-functional-event-task-source-4">(2)</a>
+    <li><a href="#ref-for-dfn-handle-functional-event-task-source-5">Handle Functional Event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serviceworker">
@@ -7943,8 +7922,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-extendableevent-12">7.2. Define Functional Event</a>
     <li><a href="#ref-for-extendableevent-13">Install</a>
     <li><a href="#ref-for-extendableevent-14">Activate</a>
-    <li><a href="#ref-for-extendableevent-15">Handle Extend Lifetime Promise</a>
-    <li><a href="#ref-for-extendableevent-16">Handle Functional Event</a>
+    <li><a href="#ref-for-extendableevent-15">Handle Functional Event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-extendableeventinit">
@@ -7967,11 +7945,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="extendableevent-pending-promises-count">
    <b><a href="#extendableevent-pending-promises-count">#extendableevent-pending-promises-count</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-extendableevent-pending-promises-count-2">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count-3">(3)</a> <a href="#ref-for-extendableevent-pending-promises-count-4">(4)</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-5">4.5.6. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-6">(2)</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-7">Install</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-8">Activate</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-9">Handle Extend Lifetime Promise</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-extendableevent-pending-promises-count-2">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count-3">(3)</a> <a href="#ref-for-extendableevent-pending-promises-count-4">(4)</a> <a href="#ref-for-extendableevent-pending-promises-count-5">(5)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-6">4.5.6. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-7">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count-8">(3)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-9">Install</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-10">Activate</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-extendableevent-waituntil">
@@ -8658,13 +8635,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-terminate-service-worker-8">Handle Fetch</a>
     <li><a href="#ref-for-terminate-service-worker-9">Handle Service Worker Client Unload</a>
     <li><a href="#ref-for-terminate-service-worker-10">Clear Registration</a> <a href="#ref-for-terminate-service-worker-11">(2)</a> <a href="#ref-for-terminate-service-worker-12">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="handle-extend-lifetime-promise">
-   <b><a href="#handle-extend-lifetime-promise">#handle-extend-lifetime-promise</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-handle-extend-lifetime-promise-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-handle-extend-lifetime-promise-2">(2)</a>
-    <li><a href="#ref-for-handle-extend-lifetime-promise-3">4.5.6. event.respondWith(r)</a> <a href="#ref-for-handle-extend-lifetime-promise-4">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-fetch">

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-05">5 January 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-09">9 January 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1659,7 +1659,6 @@ pre.idl.highlight { color: #708090; }
       <li><a href="#activation-algorithm"><span class="secno"></span> <span class="content"><span>Activate</span></span></a>
       <li><a href="#run-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Run Service Worker</span></span></a>
       <li><a href="#terminate-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Terminate Service Worker</span></span></a>
-      <li><a href="#extend-service-worker-lifetime-algorithm"><span class="secno"></span> <span class="content"><span>Extend Service Worker Lifetime</span></span></a>
       <li><a href="#handle-extend-lifetime-promise-algorithm"><span class="secno"></span> <span class="content"><span>Handle Extend Lifetime Promise</span></span></a>
       <li><a href="#on-fetch-request-algorithm"><span class="secno"></span> <span class="content"><span>Handle Fetch</span></span></a>
       <li><a href="#handle-functional-event-algorithm"><span class="secno"></span> <span class="content"><span>Handle Functional Event</span></span></a>
@@ -2939,48 +2938,48 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 };
 </pre>
      <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-2">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-extend-lifetime-promises">extend lifetime promises</dfn> (an array of <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a>). It is initially an empty array.</p>
-     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-3">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extensions-allowed-flag">extensions allowed flag</dfn>. It is initially set.</p>
-     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-pending-promises-count">pending promises count</dfn> (the number of pending promises in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-1">extend lifetime promises</a>). It is initially set to zero.</p>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-57">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-58">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-5">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
-     <p><a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> also use or extend the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a></code> interface.</p>
-     <p class="note" role="note">Note: To extend the lifetime of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-59">service worker</a>, algorithms that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> events using the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-7">ExtendableEvent</a></code> interface run <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-1">Extend Service Worker Lifetime</a> algorithm after <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> the event. See <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-2">Handle Fetch</a> and <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-1">Handle Functional Event</a>.</p>
+     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-3">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-pending-promises-count">pending promises count</dfn> (the number of pending promises in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-1">extend lifetime promises</a>). It is initially set to zero.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-57">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-58">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
+     <p><a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> also use or extend the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-5">ExtendableEvent</a></code> interface.</p>
      <section class="algorithm" data-algorithm="wait-until-method">
       <h4 class="heading settled" data-level="4.4.1" id="wait-until-method"><span class="secno">4.4.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-2">event.waitUntil(f)</a></code></span><a class="self-link" href="#wait-until-method"></a></h4>
       <p><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-3">waitUntil()</a></code> method extends the lifetime of the event.</p>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ExtendableEvent" data-dfn-type="method" data-export="" id="dom-extendableevent-waituntil"><code>waitUntil(<var>f</var>)</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
-        <p>If the <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-1">extensions allowed flag</a> is unset, then:</p>
+        <p>If the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-1">pending promises count</a> is zero and the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is unset, then:</p>
         <ol>
          <li data-md="">
           <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">Throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" exception.</p>
          <li data-md="">
           <p>Abort these steps.</p>
         </ol>
+        <p class="note" role="note">Note: If no lifetime extension promise has been added in the task that called the event handlers), calling <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-4">waitUntil()</a></code> in subsequent asynchronous tasks will throw.</p>
        <li data-md="">
         <p>Add <var>f</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-8">extend lifetime promises</a>.</p>
        <li data-md="">
-        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-1">pending promises count</a> by one.</p>
-        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-2">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-1">Handle Extend Lifetime Promise</a> algorithm.</p>
+        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-2">pending promises count</a> by one.</p>
+        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-3">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-1">Handle Extend Lifetime Promise</a> algorithm.</p>
        <li data-md="">
         <p>Run <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-2">Handle Extend Lifetime Promise</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> and <var>f</var>.</p>
        <li data-md="">
         <p>Return.</p>
       </ol>
+      <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-3">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-63">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> when <var>event</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is set or <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> is not zero. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
      </section>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-60">Service workers</a> and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> define their own behaviors, allowing the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-2">extend lifetime promises</a> to suggest operation length, and the rejected state of any of the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> in <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-3">extend lifetime promises</a> to suggest operation failure.</p>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-61">Service workers</a> define the following behaviors for <code><a data-link-type="dfn" href="#install" id="ref-for-install-2">install</a></code> event and <code><a data-link-type="dfn" href="#activate" id="ref-for-activate-4">activate</a></code> event, respectively:</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-59">Service workers</a> and <a href="#extensibility">extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> define their own behaviors, allowing the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-2">extend lifetime promises</a> to suggest operation length, and the rejected state of any of the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> in <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-3">extend lifetime promises</a> to suggest operation failure.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-60">Service workers</a> define the following behaviors for <code><a data-link-type="dfn" href="#install" id="ref-for-install-2">install</a></code> event and <code><a data-link-type="dfn" href="#activate" id="ref-for-activate-4">activate</a></code> event, respectively:</p>
      <ul>
       <li data-md="">
-       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> <var>f</var> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-4">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-5">installing worker</a> as <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-4">waiting worker</a>) until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-5">extend lifetime promises</a> resolve successfully. (See step 11.3.1 of <a data-link-type="dfn" href="#install" id="ref-for-install-3">Install</a> algorithm.) If <var>f</var> rejects, the installation fails. This is primarily used to ensure that a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-62">service worker</a> is not considered <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-5">waiting worker</a>) until all of the core caches it depends on are populated.</p>
+       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> <var>f</var> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-4">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-5">installing worker</a> as <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-4">waiting worker</a>) until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-5">extend lifetime promises</a> resolve successfully. (See step 11.3.1 of <a data-link-type="dfn" href="#install" id="ref-for-install-3">Install</a> algorithm.) If <var>f</var> rejects, the installation fails. This is primarily used to ensure that a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-61">service worker</a> is not considered <em>installed</em> (i.e. a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-5">waiting worker</a>) until all of the core caches it depends on are populated.</p>
       <li data-md="">
-       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-6">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-17">active worker</a> as <em>activated</em> until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-7">extend lifetime promises</a> settle. (See step 12.3 of <a data-link-type="dfn" href="#activate" id="ref-for-activate-5">Activate</a> algorithm.) This is primarily used to ensure that any <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-2">functional events</a> are not dispatched to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-12">ServiceWorkerGlobalScope</a></code> object that represents the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-63">service worker</a> until it upgrades database schemas and deletes the outdated cache entries.</p>
+       <p>Adding a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> to the event’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-6">extend lifetime promises</a> delays treating the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-17">active worker</a> as <em>activated</em> until all the <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a> in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-7">extend lifetime promises</a> settle. (See step 12.3 of <a data-link-type="dfn" href="#activate" id="ref-for-activate-5">Activate</a> algorithm.) This is primarily used to ensure that any <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-2">functional events</a> are not dispatched to the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-12">ServiceWorkerGlobalScope</a></code> object that represents the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-62">service worker</a> until it upgrades database schemas and deletes the outdated cache entries.</p>
      </ul>
     </section>
     <section>
      <h3 class="heading settled" data-level="4.5" id="fetchevent-interface"><span class="secno">4.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-1">FetchEvent</a></code></span><a class="self-link" href="#fetchevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="FetchEvent" data-dfn-type="constructor" data-export="" data-lt="FetchEvent(type, eventInitDict)" id="dom-fetchevent-fetchevent">Constructor<a class="self-link" href="#dom-fetchevent-fetchevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="FetchEvent/FetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-fetchevent-fetchevent-type-eventinitdict-type">type<a class="self-link" href="#dom-fetchevent-fetchevent-type-eventinitdict-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-fetcheventinit" id="ref-for-dictdef-fetcheventinit-1">FetchEventInit</a> <dfn class="nv idl-code" data-dfn-for="FetchEvent/FetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-fetchevent-fetchevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-fetchevent-fetchevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="fetchevent">FetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-8">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="fetchevent">FetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a> {
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#request">Request</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Request" href="#dom-fetchevent-request" id="ref-for-dom-fetchevent-request-1">request</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-fetchevent-clientid" id="ref-for-dom-fetchevent-clientid-1">clientId</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-fetchevent-reservedclientid" id="ref-for-dom-fetchevent-reservedclientid-1">reservedClientId</a>;
@@ -2998,7 +2997,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="FetchEventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-fetcheventinit-isreload">isReload<a class="self-link" href="#dom-fetcheventinit-isreload"></a></dfn> = <span class="kt">false</span>;
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-64">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-9">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-64">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-7">ExtendableEvent</a></code> interface.</p>
      <p>Each event using <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-3">FetchEvent</a></code> interface has an associated <dfn class="dfn-paneled" data-dfn-for="FetchEvent" data-dfn-type="dfn" data-noexport="" id="fetchevent-potential-response">potential response</dfn> (a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>), initially set to null, and the following associated flags that are initially unset:</p>
      <ul>
       <li data-md="">
@@ -3053,11 +3052,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-9">extend lifetime promises</a>.</p>
        <li data-md="">
-        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-3">pending promises count</a> by one.</p>
-        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-3">Handle Extend Lifetime Promise</a> algorithm.</p>
+        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-5">pending promises count</a> by one.</p>
+        <p class="note" role="note">Note: The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-6">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done within <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-3">Handle Extend Lifetime Promise</a> algorithm.</p>
        <li data-md="">
         <p>Run <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-4">Handle Extend Lifetime Promise</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> and <var>r</var>.</p>
-        <p class="note" role="note">Note: <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-3">event.respondWith(r)</a></code> extends the lifetime of the event by default as if <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-4">event.waitUntil(r)</a></code> is called.</p>
+        <p class="note" role="note">Note: <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-3">event.respondWith(r)</a></code> extends the lifetime of the event by default as if <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">event.waitUntil(r)</a></code> is called.</p>
        <li data-md="">
         <p>Set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-propagation-flag">stop propagation flag</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">stop immediate propagation flag</a>.</p>
        <li data-md="">
@@ -3157,7 +3156,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
              <li data-md="">
               <p>Set the <a data-link-type="dfn" href="#fetchevent-respond-with-error-flag" id="ref-for-fetchevent-respond-with-error-flag-3">respond-with error flag</a>.</p>
             </ol>
-            <p class="note" role="note">Note: If the <a data-link-type="dfn" href="#fetchevent-respond-with-error-flag" id="ref-for-fetchevent-respond-with-error-flag-4">respond-with error flag</a> is set, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> is returned to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> through <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-3">Handle Fetch</a> algorithm. (See the step 21.1.) Otherwise, the value <var>response</var> is returned to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> through <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-4">Handle Fetch</a> algorithm. (See the step 22.1.)</p>
+            <p class="note" role="note">Note: If the <a data-link-type="dfn" href="#fetchevent-respond-with-error-flag" id="ref-for-fetchevent-respond-with-error-flag-4">respond-with error flag</a> is set, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a> is returned to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> through <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-2">Handle Fetch</a> algorithm. (See the step 21.1.) Otherwise, the value <var>response</var> is returned to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> through <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-3">Handle Fetch</a> algorithm. (See the step 22.1.)</p>
           </ol>
          <li data-md="">
           <p>Unset the <a data-link-type="dfn" href="#fetchevent-wait-to-respond-flag" id="ref-for-fetchevent-wait-to-respond-flag-2">wait to respond flag</a>.</p>
@@ -3168,7 +3167,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.6" id="extendablemessageevent-interface"><span class="secno">4.6. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-2">ExtendableMessageEvent</a></code></span><a class="self-link" href="#extendablemessageevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent" data-dfn-type="constructor" data-export="" data-lt="ExtendableMessageEvent(type, eventInitDict)|ExtendableMessageEvent(type)" id="dom-extendablemessageevent-extendablemessageevent">Constructor<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent/ExtendableMessageEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-type">type<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-extendablemessageeventinit" id="ref-for-dictdef-extendablemessageeventinit-1">ExtendableMessageEventInit</a> <dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent/ExtendableMessageEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="extendablemessageevent">ExtendableMessageEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-10">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="extendablemessageevent">ExtendableMessageEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-8">ExtendableEvent</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">any</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="any" href="#dom-extendablemessageevent-data" id="ref-for-dom-extendablemessageevent-data-2">data</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-extendablemessageevent-origin" id="ref-for-dom-extendablemessageevent-origin-2">origin</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-extendablemessageevent-lasteventid" id="ref-for-dom-extendablemessageevent-lasteventid-1">lastEventId</a>;
@@ -3184,7 +3183,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/comms.html#messageport">MessagePort</a>> <dfn class="nv idl-code" data-default="None" data-dfn-for="ExtendableMessageEventInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MessagePort> " id="dom-extendablemessageeventinit-ports">ports<a class="self-link" href="#dom-extendablemessageeventinit-ports"></a></dfn> = [];
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-66">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-67">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-66">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-67">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-9">ExtendableEvent</a></code> interface.</p>
      <section>
       <h4 class="heading settled" data-level="4.6.1" id="extendablemessage-event-data"><span class="secno">4.6.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendablemessageevent-data" id="ref-for-dom-extendablemessageevent-data-3">event.data</a></code></span><a class="self-link" href="#extendablemessage-event-data"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ExtendableMessageEvent" data-dfn-type="attribute" data-export="" id="dom-extendablemessageevent-data">data</dfn> attribute <em>must</em> return the value it was initialized to. When the object is created, this attribute <em>must</em> be initialized to null. It represents the message being sent.</p>
@@ -3218,16 +3217,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <tbody>
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-install-event"><code>install</code></dfn>
-        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-12">ExtendableEvent</a></code>
+        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-10">ExtendableEvent</a></code>
         <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-2">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-16">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-8">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-6">installing worker</a> changes. (See step 11.2 of the <a data-link-type="dfn" href="#install" id="ref-for-install-4">Install</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-activate-event"><code>activate</code></dfn>
-        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-13">ExtendableEvent</a></code>
+        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a></code>
         <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-3">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-17">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-18">active worker</a> changes. (See step 12.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-6">Activate</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-fetch-event"><code>fetch</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-4">FetchEvent</a></code>
-        <td>[<a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-4">Functional event</a>] The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a> invokes <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-5">Handle Fetch</a> with <var>request</var>. As a result of performing <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-6">Handle Fetch</a>, the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-18">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-1">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
+        <td>[<a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-4">Functional event</a>] The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a> invokes <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-4">Handle Fetch</a> with <var>request</var>. As a result of performing <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-5">Handle Fetch</a>, the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-18">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-1">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="eventdef-serviceworkerglobalscope-message"><code>message</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-4">ExtendableMessageEvent</a></code>
@@ -4016,7 +4015,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <p>The implementers are encouraged to note:</p>
      <ul>
       <li data-md="">
-       <p>Plug-ins should not load via <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-80">service workers</a>. As plug-ins may get their security origins from their own urls, the embedding <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-81">service worker</a> cannot handle it. For this reason, the <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-7">Handle Fetch</a> algorithm makes the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">potential-navigation-or-subresource request</a> (whose context is either <code>&lt;embed></code> or <code>&lt;object></code>) immediately fallback to the network without dispatching <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-6">fetch</a></code> event.</p>
+       <p>Plug-ins should not load via <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-80">service workers</a>. As plug-ins may get their security origins from their own urls, the embedding <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-81">service worker</a> cannot handle it. For this reason, the <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-6">Handle Fetch</a> algorithm makes the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">potential-navigation-or-subresource request</a> (whose context is either <code>&lt;embed></code> or <code>&lt;object></code>) immediately fallback to the network without dispatching <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-6">fetch</a></code> event.</p>
       <li data-md="">
        <p>Some of the legacy networking stack code may need to be carefully audited to understand the ramifications of interactions with <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-82">service workers</a>.</p>
      </ul>
@@ -4042,7 +4041,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="7.2" id="extension-to-extendable-event"><span class="secno">7.2. </span><span class="content">Define Functional Event</span><a class="self-link" href="#extension-to-extendable-event"></a></h3>
-     <p>Specifications <em>may</em> define a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-5">functional event</a> by extending <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-14">ExtendableEvent</a></code> interface:</p>
+     <p>Specifications <em>may</em> define a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-5">functional event</a> by extending <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-12">ExtendableEvent</a></code> interface:</p>
 <pre class="example idl highlight def" data-no-idl="" id="example-3de376f0"><a class="self-link" href="#example-3de376f0"></a>// e.g. define FunctionalEvent interface
 <span class="kt">interface</span> <span class="nv">FunctionalEvent</span> : <span class="n">ExtendableEvent</span> {
   // add a functional event’s own attributes and methods
@@ -4059,8 +4058,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="7.4" id="request-functional-event-dispatch"><span class="secno">7.4. </span><span class="content">Request Functional Event Dispatch</span><a class="self-link" href="#request-functional-event-dispatch"></a></h3>
-     <p>To request a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-7">functional event</a> dispatch to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-86">service worker</a>, specifications <em>may</em> invoke <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-2">Handle Functional Event</a> algorithm with its <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-47">service worker registration</a> <var>registration</var> and the algorithm <var>callbackSteps</var> as the arguments.</p>
-     <p>Specifications <em>may</em> define an algorithm <var>callbackSteps</var> where the corresponding <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-8">functional event</a> can be created and fired with specification specific objects. The algorithm is passed <var>globalObject</var> (a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-17">ServiceWorkerGlobalScope</a></code> object) at which it <em>may</em> fire its <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-9">functional events</a>. This algorithm is called on a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-3">Handle Functional Event</a> algorithm.</p>
+     <p>To request a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-7">functional event</a> dispatch to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-86">service worker</a>, specifications <em>may</em> invoke <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-1">Handle Functional Event</a> algorithm with its <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-47">service worker registration</a> <var>registration</var> and the algorithm <var>callbackSteps</var> as the arguments.</p>
+     <p>Specifications <em>may</em> define an algorithm <var>callbackSteps</var> where the corresponding <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-8">functional event</a> can be created and fired with specification specific objects. The algorithm is passed <var>globalObject</var> (a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-17">ServiceWorkerGlobalScope</a></code> object) at which it <em>may</em> fire its <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-9">functional events</a>. This algorithm is called on a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#handle-functional-event" id="ref-for-handle-functional-event-2">Handle Functional Event</a> algorithm.</p>
      <p class="note" role="note">Note: See an <a href="https://notifications.spec.whatwg.org/#activating-a-notification">example</a> hook defined in <a data-link-type="biblio" href="#biblio-notifications">Notifications API</a>.</p>
     </section>
    </section>
@@ -4573,23 +4572,21 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-15">ExtendableEvent</a></code>.</p>
+         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-13">ExtendableEvent</a></code>.</p>
         <li data-md="">
          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> attribute to <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-5">install</a></code>.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>installingWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-1">global object</a>.</p>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-2">Extend Service Worker Lifetime</a> with <var>e</var>.</p>
-        <li data-md="">
          <p><em>WaitForAsynchronousExtensions</em>: Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
          <ol>
           <li data-md="">
-           <p>Wait until <var>e</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-2">extensions allowed flag</a> is unset.</p>
+           <p>Wait until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-7">pending promises count</a> is zero.</p>
           <li data-md="">
            <p>If the result of <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#waiting-for-all">waiting for all</a> of <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-10">extend lifetime promises</a> rejected, set <var>installFailed</var> to true.</p>
          </ol>
        </ol>
-       <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-3">termination</a> of <var>installingWorker</var>, set <var>installFailed</var> to true.</p>
+       <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-4">termination</a> of <var>installingWorker</var>, set <var>installFailed</var> to true.</p>
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded.</p>
       <li data-md="">
@@ -4616,7 +4613,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-7">waiting worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-4">Terminate</a> <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-5">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
          <p>The user agent <em>may</em> abort in-flight requests triggered by <var>redundantWorker</var>.</p>
        </ol>
@@ -4663,7 +4660,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Wait for <var>redundantWorker</var> to finish handling any in-progress requests.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-5">Terminate</a> <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-6">Terminate</a> <var>redundantWorker</var>.</p>
        </ol>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-5">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a> as the arguments.</p>
@@ -4699,18 +4696,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code>.</p>
+         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-14">ExtendableEvent</a></code>.</p>
         <li data-md="">
          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> attribute to <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-5">activate</a></code>.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-2">global object</a>.</p>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-3">Extend Service Worker Lifetime</a> with <var>e</var>.</p>
-        <li data-md="">
-         <p><em>WaitForAsynchronousExtensions</em>: Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>e</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-3">extensions allowed flag</a> is unset.</p>
+         <p><em>WaitForAsynchronousExtensions</em>: Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> is zero.</p>
        </ol>
       <li data-md="">
-       <p>Wait for <var>task</var> to have executed or been discarded, or the script to have been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-6">termination</a> of <var>activeWorker</var>.</p>
+       <p>Wait for <var>task</var> to have executed or been discarded, or the script to have been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">termination</a> of <var>activeWorker</var>.</p>
       <li data-md="">
        <p>Wait for the step labeled <em>WaitForAsynchronousExtensions</em> to complete.</p>
       <li data-md="">
@@ -4850,32 +4845,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Abort the script currently running in <var>serviceWorker</var>.</p>
      </ol>
     </section>
-    <section class="algorithm" data-algorithm="Extend Service Worker Lifetime">
-     <h3 class="heading settled" id="extend-service-worker-lifetime-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="extend-service-worker-lifetime">Extend Service Worker Lifetime</dfn></span><a class="self-link" href="#extend-service-worker-lifetime-algorithm"></a></h3>
-     <dl>
-      <dt data-md="">
-       <p>Input</p>
-      <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-17">ExtendableEvent</a></code> object</p>
-      <dt data-md="">
-       <p>Output</p>
-      <dd data-md="">
-       <p>None</p>
-     </dl>
-     <ol>
-      <li data-md="">
-       <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-5">pending promises count</a> is zero, unset <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-4">extensions allowed flag</a> and abort these steps.</p>
-       <p class="note" role="note">Note: If no lifetime extension promise has been added up to this point (i.e., at the end of the task that called the event handlers), the <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-5">extensions allowed flag</a> is immediately unset. Calling <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">waitUntil()</a></code> in subsequent asynchronous tasks will throw.</p>
-     </ol>
-     <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-92">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> until <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-6">extensions allowed flag</a> is unset. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
-    </section>
     <section class="algorithm" data-algorithm="Handle Extend Lifetime Promise">
      <h3 class="heading settled" id="handle-extend-lifetime-promise-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="handle-extend-lifetime-promise">Handle Extend Lifetime Promise</dfn></span><a class="self-link" href="#handle-extend-lifetime-promise-algorithm"></a></h3>
      <dl>
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-18">ExtendableEvent</a></code> object</p>
+       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-15">ExtendableEvent</a></code> object</p>
       <dd data-md="">
        <p><var>promise</var>, a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a></p>
       <dt data-md="">
@@ -4885,30 +4861,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>Wait until <var>promise</var> is settled <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>.</p>
+       <p>Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>promise</var> is settled and <var>promise</var>’s <code>then</code> methods, if any, in the task where <var>promise</var> has been settled have executed.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">Queue a microtask</a> to run the following substeps:</p>
-       <ol>
-        <li data-md="">
-         <p>Decrease <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-6">pending promises count</a> by one.</p>
-        <li data-md="">
-         <p>For each <var>reaction</var> in <var>promise</var>.[[PromiseFulfillReactions]]:</p>
-         <ol>
-          <li data-md="">
-           <p>Append <var>reaction</var>.[[Capability]].[[Promise]] to <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-11">extend lifetime promises</a>.</p>
-          <li data-md="">
-           <p>Increase <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-7">pending promises count</a> by one.</p>
-          <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#handle-extend-lifetime-promise" id="ref-for-handle-extend-lifetime-promise-5">Handle Extend Lifetime Promise</a> with <var>event</var> and <var>reaction</var>.[[Capability]].[[Promise]].</p>
-         </ol>
-        <li data-md="">
-         <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> is zero, unset <var>event</var>’s <a data-link-type="dfn" href="#extensions-allowed-flag" id="ref-for-extensions-allowed-flag-7">extensions allowed flag</a>.</p>
-       </ol>
+       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">Queue a microtask</a>, on <var>promise</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a>, to decrease <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-9">pending promises count</a> by one.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle Fetch">
      <h3 class="heading settled" id="on-fetch-request-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="handle-fetch">Handle Fetch</dfn></span><a class="self-link" href="#on-fetch-request-algorithm"></a></h3>
-     <p>The <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-8">Handle Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-93">service worker</a> context.</p>
+     <p>The <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-7">Handle Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-92">service worker</a> context.</p>
      <dl>
       <dt data-md="">
        <p>Input</p>
@@ -5021,8 +4981,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-5">global object</a>.</p>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-4">Extend Service Worker Lifetime</a> with <var>e</var>.</p>
-        <li data-md="">
          <p>If <var>e</var>’s <a data-link-type="dfn" href="#fetchevent-respond-with-entered-flag" id="ref-for-fetchevent-respond-with-entered-flag-3">respond-with entered flag</a> is set, set <var>respondWithEntered</var> to true.</p>
         <li data-md="">
          <p>If <var>e</var>’s <a data-link-type="dfn" href="#fetchevent-wait-to-respond-flag" id="ref-for-fetchevent-wait-to-respond-flag-3">wait to respond flag</a> is set, then:</p>
@@ -5077,7 +5035,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-19">ExtendableEvent</a></code> object</p>
+       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code> object</p>
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-54">service worker registration</a></p>
       <dd data-md="">
@@ -5114,8 +5072,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <ol>
         <li data-md="">
          <p>Invoke <var>callbackSteps</var> with <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-6">global object</a> as its argument.</p>
-        <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#extend-service-worker-lifetime" id="ref-for-extend-service-worker-lifetime-5">Extend Service Worker Lifetime</a> with <var>event</var>.</p>
        </ol>
        <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-4">handle functional event task source</a>.</p>
       <li data-md="">
@@ -5329,7 +5285,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dd data-md="">
        <p><var>target</var>, a string (one of "<code>installing</code>", "<code>waiting</code>", and "<code>active</code>")</p>
       <dd data-md="">
-       <p><var>source</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-94">service worker</a> or null</p>
+       <p><var>source</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-93">service worker</a> or null</p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5383,9 +5339,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-95">service worker</a></p>
+       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-94">service worker</a></p>
       <dd data-md="">
-       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-96">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-10">state</a></p>
+       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-95">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-10">state</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5409,27 +5365,27 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
              <p><em>installing</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installing" id="ref-for-dom-serviceworkerstate-installing-1">"installing"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-97">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a> is not active until all of the core caches are populated.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-96">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-97">service worker</a> is not active until all of the core caches are populated.</p>
             <dt data-md="">
              <p><em>installed</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installed" id="ref-for-dom-serviceworkerstate-installed-1">"installed"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-99">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a>.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a>.</p>
             <dt data-md="">
              <p><em>activating</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activating" id="ref-for-dom-serviceworkerstate-activating-1">"activating"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-99">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
             <dt data-md="">
              <p><em>activated</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activated" id="ref-for-dom-serviceworkerstate-activated-1">"activated"</a></code></p>
-             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>.</p>
+             <p class="note" role="note">Note: The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>.</p>
             <dt data-md="">
              <p><em>redundant</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-redundant" id="ref-for-dom-serviceworkerstate-redundant-2">"redundant"</a></code></p>
-             <p class="note" role="note">Note: A new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-102">service worker</a> is replacing the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a>, or the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> is being discarded due to an install failure.</p>
+             <p class="note" role="note">Note: A new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a> is replacing the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-102">service worker</a>, or the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a> is being discarded due to an install failure.</p>
            </dl>
           <li data-md="">
            <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <code>statechange</code> at <var>workerObject</var>.</p>
@@ -5535,7 +5491,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>newestWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a></p>
+       <p><var>newestWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -5830,18 +5786,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <h2 class="heading settled" id="extended-http-headers"><span class="content">Appendix B: Extended HTTP headers</span><a class="self-link" href="#extended-http-headers"></a></h2>
     <section>
      <h3 class="heading settled" id="service-worker-script-request"><span class="content">Service Worker Script Request</span><a class="self-link" href="#service-worker-script-request"></a></h3>
-     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker"><code>Service-Worker</code><a class="self-link" href="#service-worker"></a></dfn>`</p>
       <dd data-md="">
-       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request.</p>
+       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request.</p>
        <p class="note" role="note">Note: This header helps administrators log the requests and detect threats.</p>
      </dl>
     </section>
     <section>
      <h3 class="heading settled" id="service-worker-script-response"><span class="content">Service Worker Script Response</span><a class="self-link" href="#service-worker-script-response"></a></h3>
-     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker-allowed"><code>Service-Worker-Allowed</code><a class="self-link" href="#service-worker-allowed"></a></dfn>`</p>
@@ -5888,7 +5844,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" id="syntax"><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
-     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-109">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-17">script resource</a> requests and responses:</p>
+     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-17">script resource</a> requests and responses:</p>
 <pre>Service-Worker = %x73.63.72.69.70.74 ; "script", case-sensitive
 </pre>
      <p class="note" role="note">Note: The validation of the Service-Worker-Allowed header’s values is done by URL parsing algorithm (in Update algorithm) instead of using ABNF.</p>
@@ -6004,8 +5960,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dom-extendablemessageevent-extendablemessageevent">ExtendableMessageEvent(type)</a><span>, in §4.6</span>
    <li><a href="#dom-extendablemessageevent-extendablemessageevent">ExtendableMessageEvent(type, eventInitDict)</a><span>, in §4.6</span>
    <li><a href="#extendableevent-extend-lifetime-promises">extend lifetime promises</a><span>, in §4.4</span>
-   <li><a href="#extend-service-worker-lifetime">Extend Service Worker Lifetime</a><span>, in §Unnumbered section</span>
-   <li><a href="#extensions-allowed-flag">extensions allowed flag</a><span>, in §4.4</span>
    <li><a href="#service-worker-global-scope-fetch-event">fetch</a><span>, in §4.7</span>
    <li><a href="#fetchevent">FetchEvent</a><span>, in §4.5</span>
    <li><a href="#dictdef-fetcheventinit">FetchEventInit</a><span>, in §4.5</span>
@@ -6904,7 +6858,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-49">3.5. Events</a> <a href="#ref-for-dfn-service-worker-50">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-51">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-dfn-service-worker-52">(2)</a> <a href="#ref-for-dfn-service-worker-53">(3)</a> <a href="#ref-for-dfn-service-worker-54">(4)</a>
     <li><a href="#ref-for-dfn-service-worker-55">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-service-worker-56">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-57">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-service-worker-58">(2)</a> <a href="#ref-for-dfn-service-worker-59">(3)</a> <a href="#ref-for-dfn-service-worker-60">(4)</a> <a href="#ref-for-dfn-service-worker-61">(5)</a> <a href="#ref-for-dfn-service-worker-62">(6)</a> <a href="#ref-for-dfn-service-worker-63">(7)</a>
+    <li><a href="#ref-for-dfn-service-worker-57">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-service-worker-58">(2)</a> <a href="#ref-for-dfn-service-worker-59">(3)</a> <a href="#ref-for-dfn-service-worker-60">(4)</a> <a href="#ref-for-dfn-service-worker-61">(5)</a> <a href="#ref-for-dfn-service-worker-62">(6)</a>
+    <li><a href="#ref-for-dfn-service-worker-63">4.4.1. event.waitUntil(f)</a>
     <li><a href="#ref-for-dfn-service-worker-64">4.5. FetchEvent</a> <a href="#ref-for-dfn-service-worker-65">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-66">4.6. ExtendableMessageEvent</a> <a href="#ref-for-dfn-service-worker-67">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-68">5.2. Understanding Cache Lifetimes</a> <a href="#ref-for-dfn-service-worker-69">(2)</a>
@@ -6920,14 +6875,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-88">Install</a> <a href="#ref-for-dfn-service-worker-89">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-90">Run Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-91">Terminate Service Worker</a>
-    <li><a href="#ref-for-dfn-service-worker-92">Extend Service Worker Lifetime</a>
-    <li><a href="#ref-for-dfn-service-worker-93">Handle Fetch</a>
-    <li><a href="#ref-for-dfn-service-worker-94">Update Registration State</a>
-    <li><a href="#ref-for-dfn-service-worker-95">Update Worker State</a> <a href="#ref-for-dfn-service-worker-96">(2)</a> <a href="#ref-for-dfn-service-worker-97">(3)</a> <a href="#ref-for-dfn-service-worker-98">(4)</a> <a href="#ref-for-dfn-service-worker-99">(5)</a> <a href="#ref-for-dfn-service-worker-100">(6)</a> <a href="#ref-for-dfn-service-worker-101">(7)</a> <a href="#ref-for-dfn-service-worker-102">(8)</a> <a href="#ref-for-dfn-service-worker-103">(9)</a> <a href="#ref-for-dfn-service-worker-104">(10)</a>
-    <li><a href="#ref-for-dfn-service-worker-105">Get Newest Worker</a>
-    <li><a href="#ref-for-dfn-service-worker-106">Service Worker Script Request</a> <a href="#ref-for-dfn-service-worker-107">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-108">Service Worker Script Response</a>
-    <li><a href="#ref-for-dfn-service-worker-109">Syntax</a>
+    <li><a href="#ref-for-dfn-service-worker-92">Handle Fetch</a>
+    <li><a href="#ref-for-dfn-service-worker-93">Update Registration State</a>
+    <li><a href="#ref-for-dfn-service-worker-94">Update Worker State</a> <a href="#ref-for-dfn-service-worker-95">(2)</a> <a href="#ref-for-dfn-service-worker-96">(3)</a> <a href="#ref-for-dfn-service-worker-97">(4)</a> <a href="#ref-for-dfn-service-worker-98">(5)</a> <a href="#ref-for-dfn-service-worker-99">(6)</a> <a href="#ref-for-dfn-service-worker-100">(7)</a> <a href="#ref-for-dfn-service-worker-101">(8)</a> <a href="#ref-for-dfn-service-worker-102">(9)</a> <a href="#ref-for-dfn-service-worker-103">(10)</a>
+    <li><a href="#ref-for-dfn-service-worker-104">Get Newest Worker</a>
+    <li><a href="#ref-for-dfn-service-worker-105">Service Worker Script Request</a> <a href="#ref-for-dfn-service-worker-106">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-107">Service Worker Script Response</a>
+    <li><a href="#ref-for-dfn-service-worker-108">Syntax</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-state">
@@ -7983,16 +7937,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="extendableevent">
    <b><a href="#extendableevent">#extendableevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendableevent-1">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-2">(2)</a> <a href="#ref-for-extendableevent-3">(3)</a> <a href="#ref-for-extendableevent-4">(4)</a> <a href="#ref-for-extendableevent-5">(5)</a> <a href="#ref-for-extendableevent-6">(6)</a> <a href="#ref-for-extendableevent-7">(7)</a>
-    <li><a href="#ref-for-extendableevent-8">4.5. FetchEvent</a> <a href="#ref-for-extendableevent-9">(2)</a>
-    <li><a href="#ref-for-extendableevent-10">4.6. ExtendableMessageEvent</a> <a href="#ref-for-extendableevent-11">(2)</a>
-    <li><a href="#ref-for-extendableevent-12">4.7. Events</a> <a href="#ref-for-extendableevent-13">(2)</a>
-    <li><a href="#ref-for-extendableevent-14">7.2. Define Functional Event</a>
-    <li><a href="#ref-for-extendableevent-15">Install</a>
-    <li><a href="#ref-for-extendableevent-16">Activate</a>
-    <li><a href="#ref-for-extendableevent-17">Extend Service Worker Lifetime</a>
-    <li><a href="#ref-for-extendableevent-18">Handle Extend Lifetime Promise</a>
-    <li><a href="#ref-for-extendableevent-19">Handle Functional Event</a>
+    <li><a href="#ref-for-extendableevent-1">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-2">(2)</a> <a href="#ref-for-extendableevent-3">(3)</a> <a href="#ref-for-extendableevent-4">(4)</a> <a href="#ref-for-extendableevent-5">(5)</a>
+    <li><a href="#ref-for-extendableevent-6">4.5. FetchEvent</a> <a href="#ref-for-extendableevent-7">(2)</a>
+    <li><a href="#ref-for-extendableevent-8">4.6. ExtendableMessageEvent</a> <a href="#ref-for-extendableevent-9">(2)</a>
+    <li><a href="#ref-for-extendableevent-10">4.7. Events</a> <a href="#ref-for-extendableevent-11">(2)</a>
+    <li><a href="#ref-for-extendableevent-12">7.2. Define Functional Event</a>
+    <li><a href="#ref-for-extendableevent-13">Install</a>
+    <li><a href="#ref-for-extendableevent-14">Activate</a>
+    <li><a href="#ref-for-extendableevent-15">Handle Extend Lifetime Promise</a>
+    <li><a href="#ref-for-extendableevent-16">Handle Functional Event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-extendableeventinit">
@@ -8010,36 +7963,25 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-8">4.4.1. event.waitUntil(f)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-9">4.5.6. event.respondWith(r)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-10">Install</a>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-11">Handle Extend Lifetime Promise</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="extensions-allowed-flag">
-   <b><a href="#extensions-allowed-flag">#extensions-allowed-flag</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-extensions-allowed-flag-1">4.4.1. event.waitUntil(f)</a>
-    <li><a href="#ref-for-extensions-allowed-flag-2">Install</a>
-    <li><a href="#ref-for-extensions-allowed-flag-3">Activate</a>
-    <li><a href="#ref-for-extensions-allowed-flag-4">Extend Service Worker Lifetime</a> <a href="#ref-for-extensions-allowed-flag-5">(2)</a> <a href="#ref-for-extensions-allowed-flag-6">(3)</a>
-    <li><a href="#ref-for-extensions-allowed-flag-7">Handle Extend Lifetime Promise</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="extendableevent-pending-promises-count">
    <b><a href="#extendableevent-pending-promises-count">#extendableevent-pending-promises-count</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-extendableevent-pending-promises-count-2">(2)</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-3">4.5.6. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-4">(2)</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-5">Extend Service Worker Lifetime</a>
-    <li><a href="#ref-for-extendableevent-pending-promises-count-6">Handle Extend Lifetime Promise</a> <a href="#ref-for-extendableevent-pending-promises-count-7">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count-8">(3)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-extendableevent-pending-promises-count-2">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count-3">(3)</a> <a href="#ref-for-extendableevent-pending-promises-count-4">(4)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-5">4.5.6. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-6">(2)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-7">Install</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-8">Activate</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-9">Handle Extend Lifetime Promise</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-extendableevent-waituntil">
    <b><a href="#dom-extendableevent-waituntil">#dom-extendableevent-waituntil</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendableevent-waituntil-1">4.4. ExtendableEvent</a>
-    <li><a href="#ref-for-dom-extendableevent-waituntil-2">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-dom-extendableevent-waituntil-3">(2)</a>
-    <li><a href="#ref-for-dom-extendableevent-waituntil-4">4.5.6. event.respondWith(r)</a>
-    <li><a href="#ref-for-dom-extendableevent-waituntil-5">4.6. ExtendableMessageEvent</a>
-    <li><a href="#ref-for-dom-extendableevent-waituntil-6">Extend Service Worker Lifetime</a>
+    <li><a href="#ref-for-dom-extendableevent-waituntil-2">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-dom-extendableevent-waituntil-3">(2)</a> <a href="#ref-for-dom-extendableevent-waituntil-4">(3)</a>
+    <li><a href="#ref-for-dom-extendableevent-waituntil-5">4.5.6. event.respondWith(r)</a>
+    <li><a href="#ref-for-dom-extendableevent-waituntil-6">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-dom-extendableevent-waituntil-7">Update Worker State</a> <a href="#ref-for-dom-extendableevent-waituntil-8">(2)</a>
    </ul>
   </aside>
@@ -8711,22 +8653,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-terminate-service-worker-1">2.1.1. Lifetime</a>
     <li><a href="#ref-for-terminate-service-worker-2">2.2. Service Worker Registration</a>
-    <li><a href="#ref-for-terminate-service-worker-3">Install</a> <a href="#ref-for-terminate-service-worker-4">(2)</a>
-    <li><a href="#ref-for-terminate-service-worker-5">Activate</a> <a href="#ref-for-terminate-service-worker-6">(2)</a>
-    <li><a href="#ref-for-terminate-service-worker-7">Extend Service Worker Lifetime</a>
+    <li><a href="#ref-for-terminate-service-worker-3">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-terminate-service-worker-4">Install</a> <a href="#ref-for-terminate-service-worker-5">(2)</a>
+    <li><a href="#ref-for-terminate-service-worker-6">Activate</a> <a href="#ref-for-terminate-service-worker-7">(2)</a>
     <li><a href="#ref-for-terminate-service-worker-8">Handle Fetch</a>
     <li><a href="#ref-for-terminate-service-worker-9">Handle Service Worker Client Unload</a>
     <li><a href="#ref-for-terminate-service-worker-10">Clear Registration</a> <a href="#ref-for-terminate-service-worker-11">(2)</a> <a href="#ref-for-terminate-service-worker-12">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="extend-service-worker-lifetime">
-   <b><a href="#extend-service-worker-lifetime">#extend-service-worker-lifetime</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-extend-service-worker-lifetime-1">4.4. ExtendableEvent</a>
-    <li><a href="#ref-for-extend-service-worker-lifetime-2">Install</a>
-    <li><a href="#ref-for-extend-service-worker-lifetime-3">Activate</a>
-    <li><a href="#ref-for-extend-service-worker-lifetime-4">Handle Fetch</a>
-    <li><a href="#ref-for-extend-service-worker-lifetime-5">Handle Functional Event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-extend-lifetime-promise">
@@ -8734,25 +8666,22 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-handle-extend-lifetime-promise-1">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-handle-extend-lifetime-promise-2">(2)</a>
     <li><a href="#ref-for-handle-extend-lifetime-promise-3">4.5.6. event.respondWith(r)</a> <a href="#ref-for-handle-extend-lifetime-promise-4">(2)</a>
-    <li><a href="#ref-for-handle-extend-lifetime-promise-5">Handle Extend Lifetime Promise</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-fetch">
    <b><a href="#handle-fetch">#handle-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-fetch-1">3.4.3. register(scriptURL, options)</a>
-    <li><a href="#ref-for-handle-fetch-2">4.4. ExtendableEvent</a>
-    <li><a href="#ref-for-handle-fetch-3">4.5.6. event.respondWith(r)</a> <a href="#ref-for-handle-fetch-4">(2)</a>
-    <li><a href="#ref-for-handle-fetch-5">4.7. Events</a> <a href="#ref-for-handle-fetch-6">(2)</a>
-    <li><a href="#ref-for-handle-fetch-7">6.5. Implementer Concerns</a>
-    <li><a href="#ref-for-handle-fetch-8">Handle Fetch</a>
+    <li><a href="#ref-for-handle-fetch-2">4.5.6. event.respondWith(r)</a> <a href="#ref-for-handle-fetch-3">(2)</a>
+    <li><a href="#ref-for-handle-fetch-4">4.7. Events</a> <a href="#ref-for-handle-fetch-5">(2)</a>
+    <li><a href="#ref-for-handle-fetch-6">6.5. Implementer Concerns</a>
+    <li><a href="#ref-for-handle-fetch-7">Handle Fetch</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-functional-event">
    <b><a href="#handle-functional-event">#handle-functional-event</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-handle-functional-event-1">4.4. ExtendableEvent</a>
-    <li><a href="#ref-for-handle-functional-event-2">7.4. Request Functional Event Dispatch</a> <a href="#ref-for-handle-functional-event-3">(2)</a>
+    <li><a href="#ref-for-handle-functional-event-1">7.4. Request Functional Event Dispatch</a> <a href="#ref-for-handle-functional-event-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-service-worker-client-unload">


### PR DESCRIPTION
(1) This changes the approach to unsetting the extendable events'
extensions allowed flag. This change introduced a reference count based
approach instead of the promise-copying-and-checking approach.

(2) This also extends the opportunities of the lifetime extension by
allowing calling waitUntil() within microtasks queued by the given
promise's Promise.prototype.then callbacks.

Related issues:
 - https://github.com/w3c/ServiceWorker/issues/931 (1)
 - https://github.com/w3c/ServiceWorker/issues/935 (2)
 - https://github.com/w3c/ServiceWorker/issues/1039 (2)