### PR TITLE
Use right value for Resolve Job Promise

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2544,14 +2544,14 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       : Input
       :: |job|, a [=job=]
-      :: |reason|, an [=exception=]
+      :: |errorName|, a string
       : Output
       :: none
 
-      1. If |job|'s [=job/client=] is not null, [=queue a task=], on |job|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |job|'s [=job/job promise=] with an exception that is a copy of |reason|, in |job|'s [=job/client=]'s [=environment settings object/Realm=].
+      1. If |job|'s [=job/client=] is not null, [=queue a task=], on |job|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |job|'s [=job/job promise=] with a [=exception/create|new=] [=exception=] with |errorName| and a user agent-defined [=exception/message=].
       1. For each |equivalentJob| in |job|'s [=list of equivalent jobs=]:
-          1. If |equivalentJob|'s [=job/client=] is null, continue to the next iteration of the loop:
-          1. [=Queue a task=], on |equivalentJob|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |equivalentJob|'s [=job/job promise=] with an exception that is a copy of |reason|, in |equivalentJob|'s [=job/client=]'s [=environment settings object/Realm=].
+          1. If |equivalentJob|'s [=job/client=] is null, [=iteration/continue=].
+          1. [=Queue a task=], on |equivalentJob|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |equivalentJob|'s [=job/job promise=] with a [=exception/create|new=] [=exception=] with |errorName| and a user agent-defined [=exception/message=].
   </section>
 
   <section algorithm>
@@ -2594,13 +2594,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: none
 
       1. If the result of running <a>potentially trustworthy origin</a> with the [=environment settings object/origin=] of |job|'s [=job/script url=] as the argument is <code>Not Trusted</code>, then:
-          1. Invoke <a>Reject Job Promise</a> with |job| and a "{{SecurityError}}" exception.
+          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. If the [=environment settings object/origin=] of |job|'s [=job/script url=] is not |job|'s [=job/referrer=]'s [=environment settings object/origin=], then:
-          1. Invoke <a>Reject Job Promise</a> with |job| and a "{{SecurityError}}" exception.
+          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. If the [=environment settings object/origin=] of |job|'s [=job/scope url=] is not |job|'s [=job/referrer=]'s [=environment settings object/origin=], then:
-          1. Invoke <a>Reject Job Promise</a> with |job| and a "{{SecurityError}}" exception.
+          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |registration| be the result of running the <a>Get Registration</a> algorithm passing |job|'s [=job/scope url=] as the argument.
       1. If |registration| is not null, then:
@@ -2624,11 +2624,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       1. Let |registration| be the result of running the <a>Get Registration</a> algorithm passing |job|'s [=job/scope url=] as the argument.
       1. If |registration| is null or |registration|'s <a>uninstalling flag</a> is set, then:
-          1. Invoke <a>Reject Job Promise</a> with |job| and a <code>TypeError</code>.
+          1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |newestWorker| be the result of running <a>Get Newest Worker</a> algorithm passing |registration| as the argument.
       1. If |job|'s <a>job type</a> is *update*, and |newestWorker|'s [=service worker/script url=] does not [=url/equal=] |job|'s [=job/script url=] with the *exclude fragments flag* set, then:
-          1. Invoke <a>Reject Job Promise</a> with |job| and a <code>TypeError</code>.
+          1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |httpsState| be "<code>none</code>".
       1. Let |referrerPolicy| be the empty string.
@@ -2657,7 +2657,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Set |request|'s [=request/redirect mode=] to "<code>error</code>".
           1. [=/Fetch=] |request|, and asynchronously wait to run the remaining steps as part of fetch's <a>process response</a> for the [=/response=] |response|.
           1. [=Extract a MIME type=] from the |response|'s [=response/header list=]. If this MIME type (ignoring parameters) is not a [=JavaScript MIME type=], then:
-              1. Invoke [=Reject Job Promise=] with |job| and a "{{SecurityError}}" exception.
+              1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
               1. Asynchronously complete these steps with a [=network error=].
           1. Let |serviceWorkerAllowed| be the result of [=extracting header list values=] given \`<code>Service-Worker-Allowed</code>\` and |response|'s [=response/header list=].
 
@@ -2677,7 +2677,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Let |scopeString| be "<code>/</code>" concatenated with the strings in |scopeURL|'s [=url/path=] (including empty strings), separated from each other by "<code>/</code>".
           1. If |scopeString| starts with |maxScopeString|, do nothing.
           1. Else:
-              1. Invoke <a>Reject Job Promise</a> with |job| and a "{{SecurityError}}" exception.
+              1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
               1. Asynchronously complete these steps with a <a>network error</a>.
           1. If |response|'s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|'s <a>last update check time</a> to the current time.
 
@@ -2687,9 +2687,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
           If the algorithm asynchronously completes with null, then:
 
-              1. Invoke <a>Reject Job Promise</a> with |job| and a <code>TypeError</code>.
+              1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
 
-                  Note: This will do nothing if <a>Reject Job Promise</a> was previously invoked with a "{{SecurityError}}" exception.
+                  Note: This will do nothing if [=Reject Job Promise=] was previously invoked with "`SecurityError`".
 
               1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
@@ -2707,7 +2707,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
           1. Invoke <a>Run Service Worker</a> algorithm given |worker|, and with the *force bypass cache for importscripts flag* set if |job|'s [=job/force bypass cache flag=] is set.
           1. If an uncaught runtime script error occurs during the above step, then:
-              1. Invoke <a>Reject Job Promise</a> with |job| and a <code>TypeError</code>.
+              1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
               1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Invoke <a>Install</a> algorithm with |job|, |worker|, and |registration| as its arguments.
@@ -3194,7 +3194,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: none
 
       1. If the [=environment settings object/origin=] of |job|'s [=job/scope url=] is not |job|'s [=job/client=]'s [=environment settings object/origin=], then:
-          1. Invoke <a>Reject Job Promise</a> with |job| and a "{{SecurityError}}" exception.
+          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |registration| be the result of running <a>Get Registration</a> algorithm passing |job|'s [=job/scope url=] as the argument.
       1. If |registration| is null, then:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2521,28 +2521,37 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <h3 id="resolve-job-promise-algorithm"><dfn>Resolve Job Promise</dfn></h3>
 
       : Input
-      :: |job|, a <a>job</a>
+      :: |job|, a [=job=]
       :: |value|, any
       : Output
       :: none
 
-      1. If |job|'s [=job/client=] is not null, <a>queue a task</a> to resolve |job|'s [=job/job promise=] with |value| on |job|'s [=job/client=]'s <a>responsible event loop</a> using the <a>DOM manipulation task source</a> as the <a>task source</a>.
+      1. Let |convertedValue| be null.
+      1. If |job|'s [=job/client=] is not null, [=queue a task=], on |job|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to run the following substeps:
+          1. If |job|'s [=job/job type=] is either *register* or *update*, set |convertedValue| to the {{ServiceWorkerRegistration}} object that represents |value|, in |job|'s [=job/client=]'s [=environment settings object/Realm=].
+          1. Else, set |convertedValue| to |value|, in |job|'s [=job/client=]'s [=environment settings object/Realm=].
+          1. Resolve |job|'s [=job/job promise=] with |convertedValue|.
       1. For each |equivalentJob| in |job|'s <a>list of equivalent jobs</a>:
-          1. If |equivalentJob|'s [=job/client=] is not null, <a>queue a task</a> to resolve |equivalentJob|'s [=job/job promise=] with |value| on |equivalentJob|'s [=job/client=]'s <a>responsible event loop</a> using the <a>DOM manipulation task source</a> as the <a>task source</a>.
+          1. If |equivalentJob|'s [=job/client=] is null, continue to the next iteration of the loop.
+          1. [=Queue a task=], on |equivalentJob|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to run the following substeps:
+              1. If |equivalentJob|'s [=job/job type=] is either *register* or *update*, set |convertedValue| to the {{ServiceWorkerRegistration}} object that represents |value|, in |equivalentJob|'s [=job/client=]'s [=environment settings object/Realm=].
+              1. Else, set |convertedValue| to |value|, in |equivalentJob|'s [=job/client=]'s [=environment settings object/Realm=].
+              1. Resolve |equivalentJob|'s [=job/job promise=] with |convertedValue|.
   </section>
 
   <section algorithm>
     <h3 id="reject-job-promise-algorithm"><dfn>Reject Job Promise</dfn></h3>
 
       : Input
-      :: |job|, a <a>job</a>
-      :: |reason|, an <a>exception</a>
+      :: |job|, a [=job=]
+      :: |reason|, an [=exception=]
       : Output
       :: none
 
-      1. If |job|'s [=job/client=] is not null, <a>queue a task</a> to reject |job|'s [=job/job promise=] with |reason| on |job|'s [=job/client=]'s <a>responsible event loop</a> using the <a>DOM manipulation task source</a> as the <a>task source</a>.
-      1. For each |equivalentJob| in |job|'s <a>list of equivalent jobs</a>:
-          1. If |equivalentJob|'s [=job/client=] is not null, <a>queue a task</a> to reject |equivalentJob|'s [=job/job promise=] with |reason| on |equivalentJob|'s [=job/client=]'s <a>responsible event loop</a> using the <a>DOM manipulation task source</a> as the <a>task source</a>.
+      1. If |job|'s [=job/client=] is not null, [=queue a task=], on |job|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |job|'s [=job/job promise=] with an exception that is a copy of |reason|, in |job|'s [=job/client=]'s [=environment settings object/Realm=].
+      1. For each |equivalentJob| in |job|'s [=list of equivalent jobs=]:
+          1. If |equivalentJob|'s [=job/client=] is null, continue to the next iteration of the loop:
+          1. [=Queue a task=], on |equivalentJob|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |equivalentJob|'s [=job/job promise=] with an exception that is a copy of |reason|, in |equivalentJob|'s [=job/client=]'s [=environment settings object/Realm=].
   </section>
 
   <section algorithm>
@@ -2598,7 +2607,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. If |registration|'s <a>uninstalling flag</a> is set, unset it.
           1. Let |newestWorker| be the result of running the <a>Get Newest Worker</a> algorithm passing |registration| as the argument.
           1. If |newestWorker| is not null, |job|'s [=job/script url=] [=url/equals=] |newestWorker|'s [=service worker/script url=] with the *exclude fragments flag* set, and |job|'s [=job/update via cache mode=]'s value equals |registration|'s [=service worker registration/update via cache mode=], then:
-              1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
+              1. Invoke [=Resolve Job Promise=] with |job| and |registration|.
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Else:
           1. Invoke <a>Set Registration</a> algorithm with |job|'s [=job/scope url=] and |job|'s [=job/update via cache mode=].
@@ -2688,7 +2697,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           Else, continue the rest of these steps after the algorithm's asynchronous completion, with |script| being the asynchronous completion value.
 
       1. If |newestWorker| is not null, |newestWorker|'s [=service worker/script url=] [=url/equals=] |job|'s [=job/script url=] with the *exclude fragments flag* set, and |script|'s [=source text=] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=source text=], if |script| is a [=classic script=], and |script|'s [=module script/module record=]'s \[[ECMAScriptCode]] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=module script/module record=]'s \[[ECMAScriptCode]] otherwise, then:
-          1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
+          1. Invoke [=Resolve Job Promise=] with |job| and |registration|.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Else:
           1. Let |worker| be a new [=/service worker=].
@@ -2741,7 +2750,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and |worker| as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>installing worker</a> and *installing* as the arguments.
       1. Assert: |job|'s [=job/job promise=] is not null.
-      1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
+      1. Invoke [=Resolve Job Promise=] with |job| and |registration|.
       1. <a>Queue a task</a> to <a>fire an event</a> named <code>updatefound</code> at all the {{ServiceWorkerRegistration}} objects for all the [=/service worker clients=] whose <a>creation URL</a> <a lt="Match Service Worker Registration">matches</a> |registration|'s [=service worker registration/scope url=] and all the [=/service workers=] whose <a>containing service worker registration</a> is |registration|.
       1. Let |installingWorker| be |registration|'s <a>installing worker</a>.
       1. Invoke <a>Run Service Worker</a> algorithm given |installingWorker|, and with the *force bypass cache for importscripts flag* set if |job|'s [=job/force bypass cache flag=] is set.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2544,14 +2544,14 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       : Input
       :: |job|, a [=job=]
-      :: |errorName|, a string
+      :: |errorData|, the information necessary to [=exception/create|create an exception=]
       : Output
       :: none
 
-      1. If |job|'s [=job/client=] is not null, [=queue a task=], on |job|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |job|'s [=job/job promise=] with a [=exception/create|new=] [=exception=] with |errorName| and a user agent-defined [=exception/message=].
+      1. If |job|'s [=job/client=] is not null, [=queue a task=], on |job|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |job|'s [=job/job promise=] with a [=exception/create|new=] [=exception=] with |errorData| and a user agent-defined [=exception/message=], in |job|'s [=job/client=]'s [=environment settings object/Realm=].
       1. For each |equivalentJob| in |job|'s [=list of equivalent jobs=]:
           1. If |equivalentJob|'s [=job/client=] is null, [=iteration/continue=].
-          1. [=Queue a task=], on |equivalentJob|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |equivalentJob|'s [=job/job promise=] with a [=exception/create|new=] [=exception=] with |errorName| and a user agent-defined [=exception/message=].
+          1. [=Queue a task=], on |equivalentJob|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |equivalentJob|'s [=job/job promise=] with a [=exception/create|new=] [=exception=] with |errorData| and a user agent-defined [=exception/message=], in |equivalentJob|'s [=job/client=]'s [=environment settings object/Realm=].
   </section>
 
   <section algorithm>
@@ -2594,13 +2594,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: none
 
       1. If the result of running <a>potentially trustworthy origin</a> with the [=environment settings object/origin=] of |job|'s [=job/script url=] as the argument is <code>Not Trusted</code>, then:
-          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
+          1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" DOMException.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. If the [=environment settings object/origin=] of |job|'s [=job/script url=] is not |job|'s [=job/referrer=]'s [=environment settings object/origin=], then:
-          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
+          1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" DOMException.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. If the [=environment settings object/origin=] of |job|'s [=job/scope url=] is not |job|'s [=job/referrer=]'s [=environment settings object/origin=], then:
-          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
+          1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" DOMException.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |registration| be the result of running the <a>Get Registration</a> algorithm passing |job|'s [=job/scope url=] as the argument.
       1. If |registration| is not null, then:
@@ -2624,11 +2624,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       1. Let |registration| be the result of running the <a>Get Registration</a> algorithm passing |job|'s [=job/scope url=] as the argument.
       1. If |registration| is null or |registration|'s <a>uninstalling flag</a> is set, then:
-          1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
+          1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |newestWorker| be the result of running <a>Get Newest Worker</a> algorithm passing |registration| as the argument.
       1. If |job|'s <a>job type</a> is *update*, and |newestWorker|'s [=service worker/script url=] does not [=url/equal=] |job|'s [=job/script url=] with the *exclude fragments flag* set, then:
-          1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
+          1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |httpsState| be "<code>none</code>".
       1. Let |referrerPolicy| be the empty string.
@@ -2657,7 +2657,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Set |request|'s [=request/redirect mode=] to "<code>error</code>".
           1. [=/Fetch=] |request|, and asynchronously wait to run the remaining steps as part of fetch's <a>process response</a> for the [=/response=] |response|.
           1. [=Extract a MIME type=] from the |response|'s [=response/header list=]. If this MIME type (ignoring parameters) is not a [=JavaScript MIME type=], then:
-              1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
+              1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" DOMException.
               1. Asynchronously complete these steps with a [=network error=].
           1. Let |serviceWorkerAllowed| be the result of [=extracting header list values=] given \`<code>Service-Worker-Allowed</code>\` and |response|'s [=response/header list=].
 
@@ -2677,7 +2677,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Let |scopeString| be "<code>/</code>" concatenated with the strings in |scopeURL|'s [=url/path=] (including empty strings), separated from each other by "<code>/</code>".
           1. If |scopeString| starts with |maxScopeString|, do nothing.
           1. Else:
-              1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
+              1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" DOMException.
               1. Asynchronously complete these steps with a <a>network error</a>.
           1. If |response|'s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|'s <a>last update check time</a> to the current time.
 
@@ -2687,9 +2687,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
           If the algorithm asynchronously completes with null, then:
 
-              1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
+              1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
 
-                  Note: This will do nothing if [=Reject Job Promise=] was previously invoked with "`SecurityError`".
+                  Note: This will do nothing if [=Reject Job Promise=] was previously invoked with "{{SecurityError}}" DOMException.
 
               1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
@@ -2707,7 +2707,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
           1. Invoke <a>Run Service Worker</a> algorithm given |worker|, and with the *force bypass cache for importscripts flag* set if |job|'s [=job/force bypass cache flag=] is set.
           1. If an uncaught runtime script error occurs during the above step, then:
-              1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
+              1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
               1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Invoke <a>Install</a> algorithm with |job|, |worker|, and |registration| as its arguments.
@@ -3194,7 +3194,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: none
 
       1. If the [=environment settings object/origin=] of |job|'s [=job/scope url=] is not |job|'s [=job/client=]'s [=environment settings object/origin=], then:
-          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
+          1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" DOMException.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |registration| be the result of running <a>Get Registration</a> algorithm passing |job|'s [=job/scope url=] as the argument.
       1. If |registration| is null, then:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version bab6032cf8759f7d2fb1341d02aa48484a5a3187" name="generator">
+  <meta content="Bikeshed version 78add57678334db281af36bf567919103e7c1e66" name="generator">
   <link href="https://www.w3.org/TR/service-workers/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1425,7 +1425,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-26">26 June 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-29">29 June 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -4766,21 +4766,21 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-23">job</a></p>
       <dd data-md="">
-       <p><var>reason</var>, an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a></p>
+       <p><var>errorName</var>, a string</p>
       <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-5">job promise</a> with an exception that is a copy of <var>reason</var>, in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-12">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
+       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-5">job promise</a> with a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">new</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a> with <var>errorName</var> and a user agent-defined <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-message">message</a>.</p>
       <li data-md="">
        <p>For each <var>equivalentJob</var> in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-list-of-equivalent-jobs" id="ref-for-dfn-job-list-of-equivalent-jobs-3">list of equivalent jobs</a>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-13">client</a> is null, continue to the next iteration of the loop:</p>
+         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-12">client</a> is null, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-14">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-6">job promise</a> with an exception that is a copy of <var>reason</var>, in <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-15">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-13">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-6">job promise</a> with a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">new</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a> with <var>errorName</var> and a user agent-defined <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-message">message</a>.</p>
        </ol>
      </ol>
     </section>
@@ -4849,7 +4849,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If the result of running <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin">potentially trustworthy origin</a> with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-3">script url</a> as the argument is <code>Not Trusted</code>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-1">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-1">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-1">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4857,7 +4857,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-4">script url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#job-referrer" id="ref-for-job-referrer-3">referrer</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-2">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-2">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-2">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4865,7 +4865,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-5">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#job-referrer" id="ref-for-job-referrer-4">referrer</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-3">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-3">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-3">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4914,7 +4914,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-6">uninstalling flag</a> is set, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-4">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-4">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-5">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4924,7 +4924,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-9">job type</a> is <em>update</em>, and <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-5">script url</a> does not <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equal</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-6">script url</a> with the <em>exclude fragments flag</em> set, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-5">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-5">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-6">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4937,10 +4937,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <dl>
         <dt data-md="">"<code>classic</code>"
         <dd data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-16">client</a>, "<code>serviceworker</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-14">client</a>, "<code>serviceworker</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
         <dt data-md="">"<code>module</code>"
         <dd data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">Fetch a module worker script graph</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-17">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">Fetch a module worker script graph</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-15">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
        </dl>
        <p>To <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a> given <var>request</var>, run the following steps:</p>
        <ol>
@@ -4970,7 +4970,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">Extract a MIME type</a> from the <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#javascript-mime-type">JavaScript MIME type</a>, then:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-6">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
+           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-6">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
           <li data-md="">
            <p>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
          </ol>
@@ -5013,7 +5013,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Else:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-7">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
+           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-7">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
           <li data-md="">
            <p>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
          </ol>
@@ -5026,8 +5026,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If the algorithm asynchronously completes with null, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-8">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</p>
-         <p class="note" role="note"><span>Note:</span> This will do nothing if <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-9">Reject Job Promise</a> was previously invoked with a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-8">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
+         <p class="note" role="note"><span>Note:</span> This will do nothing if <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-9">Reject Job Promise</a> was previously invoked with "<code>SecurityError</code>".</p>
         <li data-md="">
          <p>If <var>newestWorker</var> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-1">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
         <li data-md="">
@@ -5061,7 +5061,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>If an uncaught runtime script error occurs during the above step, then:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-10">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</p>
+           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-10">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
           <li data-md="">
            <p>If <var>newestWorker</var> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-2">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
           <li data-md="">
@@ -5899,10 +5899,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-9">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-18">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-9">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-16">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-11">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-11">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-12">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -7416,6 +7416,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ascii case-insensitive</a>
      <li><a href="https://infra.spec.whatwg.org/#byte-sequence">byte sequence</a>
      <li><a href="https://infra.spec.whatwg.org/#list-contain">contain</a>
+     <li><a href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>
      <li><a href="https://infra.spec.whatwg.org/#map-exists">exist</a>
      <li><a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
      <li><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">get the keys</a>
@@ -7513,8 +7514,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://heycam.github.io/webidl/#securityerror">SecurityError</a>
      <li><a href="https://heycam.github.io/webidl/#idl-USVString">USVString</a>
      <li><a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>
+     <li><a href="https://heycam.github.io/webidl/#dfn-create-exception">created</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-exception">exception</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-frozen-array-type">frozen array type</a>
+     <li><a href="https://heycam.github.io/webidl/#dfn-exception-message">message</a>
      <li><a href="https://heycam.github.io/webidl/#idl-object">object</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-partial-interface">partial interface</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-present">present</a>
@@ -9839,9 +9842,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-job-client-1">Create Job</a>
     <li><a href="#ref-for-dfn-job-client-2">Resolve Job Promise</a> <a href="#ref-for-dfn-job-client-3">(2)</a> <a href="#ref-for-dfn-job-client-4">(3)</a> <a href="#ref-for-dfn-job-client-5">(4)</a> <a href="#ref-for-dfn-job-client-6">(5)</a> <a href="#ref-for-dfn-job-client-7">(6)</a> <a href="#ref-for-dfn-job-client-8">(7)</a> <a href="#ref-for-dfn-job-client-9">(8)</a>
-    <li><a href="#ref-for-dfn-job-client-10">Reject Job Promise</a> <a href="#ref-for-dfn-job-client-11">(2)</a> <a href="#ref-for-dfn-job-client-12">(3)</a> <a href="#ref-for-dfn-job-client-13">(4)</a> <a href="#ref-for-dfn-job-client-14">(5)</a> <a href="#ref-for-dfn-job-client-15">(6)</a>
-    <li><a href="#ref-for-dfn-job-client-16">Update</a> <a href="#ref-for-dfn-job-client-17">(2)</a>
-    <li><a href="#ref-for-dfn-job-client-18">Unregister</a>
+    <li><a href="#ref-for-dfn-job-client-10">Reject Job Promise</a> <a href="#ref-for-dfn-job-client-11">(2)</a> <a href="#ref-for-dfn-job-client-12">(3)</a> <a href="#ref-for-dfn-job-client-13">(4)</a>
+    <li><a href="#ref-for-dfn-job-client-14">Update</a> <a href="#ref-for-dfn-job-client-15">(2)</a>
+    <li><a href="#ref-for-dfn-job-client-16">Unregister</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="job-referrer">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 39e591568007a470c8705dd14db3d9d86db98356" name="generator">
+  <meta content="Bikeshed version bab6032cf8759f7d2fb1341d02aa48484a5a3187" name="generator">
   <link href="https://www.w3.org/TR/service-workers/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1365,67 +1365,67 @@ Possible extra rowspan handling
         </style>
 <style>/* style-syntax-highlighting */
 pre.idl.highlight { color: #708090; }
-        .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
-        code.highlight { padding: .1em; border-radius: .3em; }
-        pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-        .highlight .c { color: #708090 } /* Comment */
-        .highlight .k { color: #990055 } /* Keyword */
-        .highlight .l { color: #000000 } /* Literal */
-        .highlight .n { color: #0077aa } /* Name */
-        .highlight .o { color: #999999 } /* Operator */
-        .highlight .p { color: #999999 } /* Punctuation */
-        .highlight .cm { color: #708090 } /* Comment.Multiline */
-        .highlight .cp { color: #708090 } /* Comment.Preproc */
-        .highlight .c1 { color: #708090 } /* Comment.Single */
-        .highlight .cs { color: #708090 } /* Comment.Special */
-        .highlight .kc { color: #990055 } /* Keyword.Constant */
-        .highlight .kd { color: #990055 } /* Keyword.Declaration */
-        .highlight .kn { color: #990055 } /* Keyword.Namespace */
-        .highlight .kp { color: #990055 } /* Keyword.Pseudo */
-        .highlight .kr { color: #990055 } /* Keyword.Reserved */
-        .highlight .kt { color: #990055 } /* Keyword.Type */
-        .highlight .ld { color: #000000 } /* Literal.Date */
-        .highlight .m { color: #000000 } /* Literal.Number */
-        .highlight .s { color: #a67f59 } /* Literal.String */
-        .highlight .na { color: #0077aa } /* Name.Attribute */
-        .highlight .nc { color: #0077aa } /* Name.Class */
-        .highlight .no { color: #0077aa } /* Name.Constant */
-        .highlight .nd { color: #0077aa } /* Name.Decorator */
-        .highlight .ni { color: #0077aa } /* Name.Entity */
-        .highlight .ne { color: #0077aa } /* Name.Exception */
-        .highlight .nf { color: #0077aa } /* Name.Function */
-        .highlight .nl { color: #0077aa } /* Name.Label */
-        .highlight .nn { color: #0077aa } /* Name.Namespace */
-        .highlight .py { color: #0077aa } /* Name.Property */
-        .highlight .nt { color: #669900 } /* Name.Tag */
-        .highlight .nv { color: #222222 } /* Name.Variable */
-        .highlight .ow { color: #999999 } /* Operator.Word */
-        .highlight .mb { color: #000000 } /* Literal.Number.Bin */
-        .highlight .mf { color: #000000 } /* Literal.Number.Float */
-        .highlight .mh { color: #000000 } /* Literal.Number.Hex */
-        .highlight .mi { color: #000000 } /* Literal.Number.Integer */
-        .highlight .mo { color: #000000 } /* Literal.Number.Oct */
-        .highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
-        .highlight .sc { color: #a67f59 } /* Literal.String.Char */
-        .highlight .sd { color: #a67f59 } /* Literal.String.Doc */
-        .highlight .s2 { color: #a67f59 } /* Literal.String.Double */
-        .highlight .se { color: #a67f59 } /* Literal.String.Escape */
-        .highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
-        .highlight .si { color: #a67f59 } /* Literal.String.Interpol */
-        .highlight .sx { color: #a67f59 } /* Literal.String.Other */
-        .highlight .sr { color: #a67f59 } /* Literal.String.Regex */
-        .highlight .s1 { color: #a67f59 } /* Literal.String.Single */
-        .highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
-        .highlight .vc { color: #0077aa } /* Name.Variable.Class */
-        .highlight .vg { color: #0077aa } /* Name.Variable.Global */
-        .highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-        .highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
-        </style>
+.highlight:not(.idl) { background: hsl(24, 20%, 95%); }
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+.highlight .c { color: #708090 } /* Comment */
+.highlight .k { color: #990055 } /* Keyword */
+.highlight .l { color: #000000 } /* Literal */
+.highlight .n { color: #0077aa } /* Name */
+.highlight .o { color: #999999 } /* Operator */
+.highlight .p { color: #999999 } /* Punctuation */
+.highlight .cm { color: #708090 } /* Comment.Multiline */
+.highlight .cp { color: #708090 } /* Comment.Preproc */
+.highlight .c1 { color: #708090 } /* Comment.Single */
+.highlight .cs { color: #708090 } /* Comment.Special */
+.highlight .kc { color: #990055 } /* Keyword.Constant */
+.highlight .kd { color: #990055 } /* Keyword.Declaration */
+.highlight .kn { color: #990055 } /* Keyword.Namespace */
+.highlight .kp { color: #990055 } /* Keyword.Pseudo */
+.highlight .kr { color: #990055 } /* Keyword.Reserved */
+.highlight .kt { color: #990055 } /* Keyword.Type */
+.highlight .ld { color: #000000 } /* Literal.Date */
+.highlight .m { color: #000000 } /* Literal.Number */
+.highlight .s { color: #a67f59 } /* Literal.String */
+.highlight .na { color: #0077aa } /* Name.Attribute */
+.highlight .nc { color: #0077aa } /* Name.Class */
+.highlight .no { color: #0077aa } /* Name.Constant */
+.highlight .nd { color: #0077aa } /* Name.Decorator */
+.highlight .ni { color: #0077aa } /* Name.Entity */
+.highlight .ne { color: #0077aa } /* Name.Exception */
+.highlight .nf { color: #0077aa } /* Name.Function */
+.highlight .nl { color: #0077aa } /* Name.Label */
+.highlight .nn { color: #0077aa } /* Name.Namespace */
+.highlight .py { color: #0077aa } /* Name.Property */
+.highlight .nt { color: #669900 } /* Name.Tag */
+.highlight .nv { color: #222222 } /* Name.Variable */
+.highlight .ow { color: #999999 } /* Operator.Word */
+.highlight .mb { color: #000000 } /* Literal.Number.Bin */
+.highlight .mf { color: #000000 } /* Literal.Number.Float */
+.highlight .mh { color: #000000 } /* Literal.Number.Hex */
+.highlight .mi { color: #000000 } /* Literal.Number.Integer */
+.highlight .mo { color: #000000 } /* Literal.Number.Oct */
+.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
+.highlight .sc { color: #a67f59 } /* Literal.String.Char */
+.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
+.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
+.highlight .se { color: #a67f59 } /* Literal.String.Escape */
+.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
+.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
+.highlight .sx { color: #a67f59 } /* Literal.String.Other */
+.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
+.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
+.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
+.highlight .vc { color: #0077aa } /* Name.Variable.Class */
+.highlight .vg { color: #0077aa } /* Name.Variable.Global */
+.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
+.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+</style>
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-24">24 June 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-26">26 June 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1856,15 +1856,15 @@ pre.idl.highlight { color: #708090; }
     <div class="example" id="example-7e94092e">
      <a class="self-link" href="#example-7e94092e"></a> Bootstrapping with a service worker: 
 <pre class="highlight"><span class="c1">// scope defaults to the path the script sits in
-</span><span class="c1">// "/" in this example
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/serviceworker.js"</span><span class="p">)</span><span class="p">.</span>then<span class="p">(</span>registration <span class="o">=</span><span class="o">></span> <span class="p">{</span>
-  console<span class="p">.</span>log<span class="p">(</span><span class="s2">"success!"</span><span class="p">)</span><span class="p">;</span>
+// "/" in this example
+</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/serviceworker.js"</span><span class="p">).</span>then<span class="p">(</span>registration <span class="p">=></span> <span class="p">{</span>
+  console<span class="p">.</span>log<span class="p">(</span><span class="s2">"success!"</span><span class="p">);</span>
   <span class="k">if</span> <span class="p">(</span>registration<span class="p">.</span>installing<span class="p">)</span> <span class="p">{</span>
-    registration<span class="p">.</span>installing<span class="p">.</span>postMessage<span class="p">(</span><span class="s2">"Howdy from your installing page."</span><span class="p">)</span><span class="p">;</span>
+    registration<span class="p">.</span>installing<span class="p">.</span>postMessage<span class="p">(</span><span class="s2">"Howdy from your installing page."</span><span class="p">);</span>
   <span class="p">}</span>
-<span class="p">}</span><span class="p">,</span> err <span class="o">=</span><span class="o">></span> <span class="p">{</span>
-  console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Installing the worker failed!"</span><span class="p">,</span> err<span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+<span class="p">},</span> err <span class="p">=></span> <span class="p">{</span>
+  console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Installing the worker failed!"</span><span class="p">,</span> err<span class="p">);</span>
+<span class="p">});</span>
 </pre>
     </div>
     <section>
@@ -1896,7 +1896,7 @@ pre.idl.highlight { color: #708090; }
       <div class="example" id="example-3ff1f346">
        <a class="self-link" href="#example-3ff1f346"></a> For example, consider a document created by a navigation to <code>https://example.com/app.html</code> which <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-4">matches</a> via the following registration call which has been previously executed: 
 <pre class="highlight"><span class="c1">// Script on the page https://example.com/app.html
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/service_worker.js"</span><span class="p">)</span><span class="p">;</span>
+</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/service_worker.js"</span><span class="p">);</span>
 </pre>
        <p>The value of <code>navigator.serviceWorker.controller.scriptURL</code> will be "<code>https://example.com/service_worker.js</code>".</p>
       </div>
@@ -2395,37 +2395,37 @@ pre.idl.highlight { color: #708090; }
     <div class="example" id="example-744d6b8b">
      <a class="self-link" href="#example-744d6b8b"></a> Serving Cached Resources: 
 <pre class="highlight"><span class="c1">// caching.js
-</span>self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"install"</span><span class="p">,</span> event <span class="o">=</span><span class="o">></span> <span class="p">{</span>
+</span>self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"install"</span><span class="p">,</span> event <span class="p">=></span> <span class="p">{</span>
   event<span class="p">.</span>waitUntil<span class="p">(</span>
     <span class="c1">// Open a cache of resources.
-</span>    caches<span class="p">.</span>open<span class="p">(</span><span class="s2">"shell-v1"</span><span class="p">)</span><span class="p">.</span>then<span class="p">(</span>cache <span class="o">=</span><span class="o">></span> <span class="p">{</span>
+</span>    caches<span class="p">.</span>open<span class="p">(</span><span class="s2">"shell-v1"</span><span class="p">).</span>then<span class="p">(</span>cache <span class="p">=></span> <span class="p">{</span>
       <span class="c1">// Begins the process of fetching them.
 </span>      <span class="c1">// The coast is only clear when all the resources are ready.
-</span>      <span class="k">return</span> cache<span class="p">.</span>addAll<span class="p">(</span><span class="p">[</span>
+</span>      <span class="k">return</span> cache<span class="p">.</span>addAll<span class="p">([</span>
         <span class="s2">"/app.html"</span><span class="p">,</span>
         <span class="s2">"/assets/v1/base.css"</span><span class="p">,</span>
         <span class="s2">"/assets/v1/app.js"</span><span class="p">,</span>
         <span class="s2">"/assets/v1/logo.png"</span><span class="p">,</span>
         <span class="s2">"/assets/v1/intro_video.webm"</span>
-      <span class="p">]</span><span class="p">)</span><span class="p">;</span>
-    <span class="p">}</span><span class="p">)</span>
-  <span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+      <span class="p">]);</span>
+    <span class="p">})</span>
+  <span class="p">);</span>
+<span class="p">});</span>
 
-self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"fetch"</span><span class="p">,</span> event <span class="o">=</span><span class="o">></span> <span class="p">{</span>
+self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"fetch"</span><span class="p">,</span> event <span class="p">=></span> <span class="p">{</span>
   <span class="c1">// No "fetch" events are dispatched to the service worker until it
 </span>  <span class="c1">// successfully installs and activates.
 </span>
   <span class="c1">// All operations on caches are async, including matching URLs, so we use
 </span>  <span class="c1">// promises heavily. e.respondWith() even takes promises to enable this:
 </span>  event<span class="p">.</span>respondWith<span class="p">(</span>
-    caches<span class="p">.</span>match<span class="p">(</span>e<span class="p">.</span>request<span class="p">)</span><span class="p">.</span>then<span class="p">(</span>response <span class="o">=</span><span class="o">></span> <span class="p">{</span>
-      <span class="k">return</span> response <span class="o">||</span> fetch<span class="p">(</span>e<span class="p">.</span>request<span class="p">)</span><span class="p">;</span>
-    <span class="p">}</span><span class="p">)</span><span class="p">.</span><span class="k">catch</span><span class="p">(</span><span class="p">(</span><span class="p">)</span> <span class="o">=</span><span class="o">></span> <span class="p">{</span>
-      <span class="k">return</span> caches<span class="p">.</span>match<span class="p">(</span><span class="s2">"/fallback.html"</span><span class="p">)</span><span class="p">;</span>
-    <span class="p">}</span><span class="p">)</span>
-  <span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+    caches<span class="p">.</span>match<span class="p">(</span>e<span class="p">.</span>request<span class="p">).</span>then<span class="p">(</span>response <span class="p">=></span> <span class="p">{</span>
+      <span class="k">return</span> response <span class="o">||</span> fetch<span class="p">(</span>e<span class="p">.</span>request<span class="p">);</span>
+    <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+      <span class="k">return</span> caches<span class="p">.</span>match<span class="p">(</span><span class="s2">"/fallback.html"</span><span class="p">);</span>
+    <span class="p">})</span>
+  <span class="p">);</span>
+<span class="p">});</span>
 </pre>
     </div>
     <section>
@@ -3642,7 +3642,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-50">service worker registration</a> and its <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-12">scope url</a> are created by a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dfn-serviceworker-link">serviceworker link</dfn>, which is declared using a <a href="#serviceworker-link-header">"serviceworker" <code>Link</code> header</a> or a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code> element whose <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-rel">rel</a></code> attribute contains the keyword "<code><a data-link-type="attr-value" href="https://html.spec.whatwg.org/multipage/links.html#link-type-serviceworker">serviceworker</a></code>".</p>
     <section>
      <h3 class="heading settled" data-level="5.1" id="serviceworker-link-header"><span class="secno">5.1. </span><span class="content">Declaring a "serviceworker" <code>Link</code> header</span><a class="self-link" href="#serviceworker-link-header"></a></h3>
-     <p>A <a data-link-type="dfn" href="#dfn-serviceworker-link" id="ref-for-dfn-serviceworker-link-1">serviceworker link</a> can be declared using a <code>Link</code> header <a data-link-type="biblio" href="#biblio-rfc5988">[RFC5988]</a> with "<code>serviceworker</code>" as the value of the "<code>rel</code>" parameter and a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-3">script url</a> inside angle brackets  ("<code>&lt;></code>")as the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc5988#section-5.1">target IRI</a>, and the following optional <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc5988#section-5.4">target attributes</a>:</p>
+     <p>A <a data-link-type="dfn" href="#dfn-serviceworker-link" id="ref-for-dfn-serviceworker-link-1">serviceworker link</a> can be declared using a <code>Link</code> header <a data-link-type="biblio" href="#biblio-rfc5988">[RFC5988]</a> with "<code>serviceworker</code>" as the value of the "<code>rel</code>" parameter and a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-3">script url</a> inside angle brackets ("<code>&lt;></code>") as the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc5988#section-5.1">target IRI</a>, and the following optional <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc5988#section-5.4">target attributes</a>:</p>
      <dl>
       <dt data-md=""><code>scope</code>
       <dd data-md="">
@@ -3734,10 +3734,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
 <pre class="highlight">Link: &lt;/js/sw.js>; rel="serviceworker"; scope="/"
 </pre>
       <p>has more or less the same effect as a document being loaded in a secure context with the following <code>link</code> element:</p>
-<pre class="highlight"><span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"serviceworker"</span> <span class="na">href=</span><span class="s">"/js/sw.js"</span> <span class="na">scope=</span><span class="s">"/"</span><span class="nt">></span>
+<pre class="highlight"><span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"serviceworker"</span> <span class="na">href</span><span class="o">=</span><span class="s">"/js/sw.js"</span> <span class="na">scope</span><span class="o">=</span><span class="s">"/"</span><span class="p">></span>
 </pre>
       <p>which is more or less equivalent to the page containing JavaScript code like:</p>
-<pre class="highlight">navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
+<pre class="highlight">navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">});</span>
 </pre>
      </div>
     </section>
@@ -4730,12 +4730,32 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-2">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to resolve <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-3">job promise</a> with <var>value</var> on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-3">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a> as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a>.</p>
+       <p>Let <var>convertedValue</var> be null.</p>
+      <li data-md="">
+       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-2">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-3">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to run the following substeps:</p>
+       <ol>
+        <li data-md="">
+         <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-7">job type</a> is either <em>register</em> or <em>update</em>, set <var>convertedValue</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-17">ServiceWorkerRegistration</a></code> object that represents <var>value</var>, in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-4">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
+        <li data-md="">
+         <p>Else, set <var>convertedValue</var> to <var>value</var>, in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-5">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
+        <li data-md="">
+         <p>Resolve <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-3">job promise</a> with <var>convertedValue</var>.</p>
+       </ol>
       <li data-md="">
        <p>For each <var>equivalentJob</var> in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-list-of-equivalent-jobs" id="ref-for-dfn-job-list-of-equivalent-jobs-2">list of equivalent jobs</a>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-4">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to resolve <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-4">job promise</a> with <var>value</var> on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-5">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a> as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a>.</p>
+         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-6">client</a> is null, continue to the next iteration of the loop.</p>
+        <li data-md="">
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-7">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to run the following substeps:</p>
+         <ol>
+          <li data-md="">
+           <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-8">job type</a> is either <em>register</em> or <em>update</em>, set <var>convertedValue</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-18">ServiceWorkerRegistration</a></code> object that represents <var>value</var>, in <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-8">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
+          <li data-md="">
+           <p>Else, set <var>convertedValue</var> to <var>value</var>, in <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-9">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
+          <li data-md="">
+           <p>Resolve <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-4">job promise</a> with <var>convertedValue</var>.</p>
+         </ol>
        </ol>
      </ol>
     </section>
@@ -4753,12 +4773,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-6">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to reject <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-5">job promise</a> with <var>reason</var> on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-7">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a> as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a>.</p>
+       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-5">job promise</a> with an exception that is a copy of <var>reason</var>, in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-12">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
       <li data-md="">
        <p>For each <var>equivalentJob</var> in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-list-of-equivalent-jobs" id="ref-for-dfn-job-list-of-equivalent-jobs-3">list of equivalent jobs</a>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-8">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to reject <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-6">job promise</a> with <var>reason</var> on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-9">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a> as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a>.</p>
+         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-13">client</a> is null, continue to the next iteration of the loop:</p>
+        <li data-md="">
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-14">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-6">job promise</a> with an exception that is a copy of <var>reason</var>, in <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-15">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
        </ol>
      </ol>
     </section>
@@ -4860,7 +4882,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>If <var>newestWorker</var> is not null, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-5">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-4">script url</a> with the <em>exclude fragments flag</em> set, and <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-update-via-cache-mode" id="ref-for-dfn-job-update-via-cache-mode-2">update via cache mode</a>'s value equals <var>registration</var>’s <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache-5">update via cache mode</a>, then:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-1">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-17">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
+           <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-1">Resolve Job Promise</a> with <var>job</var> and <var>registration</var>.</p>
           <li data-md="">
            <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-4">Finish Job</a> with <var>job</var> and abort these steps.</p>
          </ol>
@@ -4899,7 +4921,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>newestWorker</var> be the result of running <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-3">Get Newest Worker</a> algorithm passing <var>registration</var> as the argument.</p>
       <li data-md="">
-       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-7">job type</a> is <em>update</em>, and <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-5">script url</a> does not <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equal</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-6">script url</a> with the <em>exclude fragments flag</em> set, then:</p>
+       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-9">job type</a> is <em>update</em>, and <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-5">script url</a> does not <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equal</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-6">script url</a> with the <em>exclude fragments flag</em> set, then:</p>
        <ol>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-5">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</p>
@@ -4915,10 +4937,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <dl>
         <dt data-md="">"<code>classic</code>"
         <dd data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a>, "<code>serviceworker</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-16">client</a>, "<code>serviceworker</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
         <dt data-md="">"<code>module</code>"
         <dd data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">Fetch a module worker script graph</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">Fetch a module worker script graph</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-17">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
        </dl>
        <p>To <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a> given <var>request</var>, run the following steps:</p>
        <ol>
@@ -5016,7 +5038,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>newestWorker</var> is not null, <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-6">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-11">script url</a> with the <em>exclude fragments flag</em> set, and <var>script</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-classic-script-source-text">source text</a> is a byte-for-byte match with <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-6">script resource</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-classic-script-source-text">source text</a>, if <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>, and <var>script</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-module-script-module-record">module record</a>'s [[ECMAScriptCode]] is a byte-for-byte match with <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-7">script resource</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-module-script-module-record">module record</a>'s [[ECMAScriptCode]] otherwise, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-2">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-18">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
+         <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-2">Resolve Job Promise</a> with <var>job</var> and <var>registration</var>.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-8">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -5105,9 +5127,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p class="assertion">Assert: <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-7">job promise</a> is not null.</p>
       <li data-md="">
-       <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-3">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-19">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
+       <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-3">Resolve Job Promise</a> with <var>job</var> and <var>registration</var>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-40">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-18">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-95">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-16">containing service worker registration</a> is <var>registration</var>.</p>
+       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-19">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-40">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-18">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-95">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-16">containing service worker registration</a> is <var>registration</var>.</p>
       <li data-md="">
        <p>Let <var>installingWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-8">installing worker</a>.</p>
       <li data-md="">
@@ -5877,7 +5899,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-9">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-12">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-9">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-18">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-11">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
@@ -6018,7 +6040,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>Let <var>registrationObjects</var> be an array containing all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-21">ServiceWorkerRegistration</a></code> objects associated with <var>registration</var>.</p>
+       <p>Let <var>registrationObjects</var> be an array containing all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects associated with <var>registration</var>.</p>
       <li data-md="">
        <p>If <var>target</var> is "<code>installing</code>", then:</p>
        <ol>
@@ -6574,37 +6596,37 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <div class="example" id="example-bf118df6">
       <a class="self-link" href="#example-bf118df6"></a> Default scope: 
 <pre class="highlight"><span class="c1">// Maximum allowed scope defaults to the path the script sits in
-</span><span class="c1">// "/js" in this example
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">)</span><span class="p">.</span>then<span class="p">(</span><span class="p">(</span><span class="p">)</span> <span class="o">=</span><span class="o">></span> <span class="p">{</span>
-  console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Install succeeded with the default scope '/js'."</span><span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+// "/js" in this example
+</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">).</span>then<span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+  console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Install succeeded with the default scope '/js'."</span><span class="p">);</span>
+<span class="p">});</span>
 </pre>
      </div>
      <div class="example" id="example-76c5aa8b">
       <a class="self-link" href="#example-76c5aa8b"></a> Upper path without Service-Worker-Allowed header: 
 <pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location
-</span><span class="c1">// Response has no Service-Worker-Allowed header
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}</span><span class="p">)</span><span class="p">.</span><span class="k">catch</span><span class="p">(</span><span class="p">(</span><span class="p">)</span> <span class="o">=</span><span class="o">></span> <span class="p">{</span>
-  console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Install failed due to the path restriction violation."</span><span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+// Response has no Service-Worker-Allowed header
+</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+  console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Install failed due to the path restriction violation."</span><span class="p">);</span>
+<span class="p">});</span>
 </pre>
      </div>
      <div class="example" id="example-49d267fe">
       <a class="self-link" href="#example-49d267fe"></a> Upper path with Service-Worker-Allowed header: 
 <pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location
-</span><span class="c1">// Response included "Service-Worker-Allowed : /"
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}</span><span class="p">)</span><span class="p">.</span>then<span class="p">(</span><span class="p">(</span><span class="p">)</span> <span class="o">=</span><span class="o">></span> <span class="p">{</span>
-  console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Install succeeded as the max allowed scope was overriden to '/'."</span><span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+// Response included "Service-Worker-Allowed : /"
+</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span>then<span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+  console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Install succeeded as the max allowed scope was overriden to '/'."</span><span class="p">);</span>
+<span class="p">});</span>
 </pre>
      </div>
      <div class="example" id="example-7a18b25f">
       <a class="self-link" href="#example-7a18b25f"></a> A path restriction voliation even with Service-Worker-Allowed header: 
 <pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location
-</span><span class="c1">// Response included "Service-Worker-Allowed : /foo"
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/foo/bar/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}</span><span class="p">)</span><span class="p">.</span><span class="k">catch</span><span class="p">(</span><span class="p">(</span><span class="p">)</span> <span class="o">=</span><span class="o">></span> <span class="p">{</span>
-  console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Install failed as the scope is still out of the overriden maximum allowed scope."</span><span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+// Response included "Service-Worker-Allowed : /foo"
+</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/foo/bar/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+  console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Install failed as the scope is still out of the overriden maximum allowed scope."</span><span class="p">);</span>
+<span class="p">});</span>
 </pre>
      </div>
     </section>
@@ -7349,7 +7371,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports">ports</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">realm</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">realm <small>(for environment settings object)</small></a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">realm <small>(for global object)</small></a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">realm execution context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-referrer-policy">referrer policy <small>(for WorkerGlobalScope)</small></a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-referrer-policy">referrer policy <small>(for environment settings object)</small></a>
@@ -8449,10 +8472,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworkerregistration-14">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-serviceworkerregistration-15">4.1.2. registration</a>
     <li><a href="#ref-for-serviceworkerregistration-16">8.1. Define API bound to Service Worker Registration</a>
-    <li><a href="#ref-for-serviceworkerregistration-17">Register</a>
-    <li><a href="#ref-for-serviceworkerregistration-18">Update</a>
-    <li><a href="#ref-for-serviceworkerregistration-19">Install</a> <a href="#ref-for-serviceworkerregistration-20">(2)</a>
-    <li><a href="#ref-for-serviceworkerregistration-21">Update Registration State</a>
+    <li><a href="#ref-for-serviceworkerregistration-17">Resolve Job Promise</a> <a href="#ref-for-serviceworkerregistration-18">(2)</a>
+    <li><a href="#ref-for-serviceworkerregistration-19">Install</a>
+    <li><a href="#ref-for-serviceworkerregistration-20">Update Registration State</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-serviceworkerupdateviacache">
@@ -9772,7 +9794,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-job-type-1">Appendix A: Algorithms</a>
     <li><a href="#ref-for-dfn-job-type-2">Create Job</a> <a href="#ref-for-dfn-job-type-3">(2)</a>
     <li><a href="#ref-for-dfn-job-type-4">Run Job</a> <a href="#ref-for-dfn-job-type-5">(2)</a> <a href="#ref-for-dfn-job-type-6">(3)</a>
-    <li><a href="#ref-for-dfn-job-type-7">Update</a>
+    <li><a href="#ref-for-dfn-job-type-7">Resolve Job Promise</a> <a href="#ref-for-dfn-job-type-8">(2)</a>
+    <li><a href="#ref-for-dfn-job-type-9">Update</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-scope-url">
@@ -9815,10 +9838,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dfn-job-client">#dfn-job-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-client-1">Create Job</a>
-    <li><a href="#ref-for-dfn-job-client-2">Resolve Job Promise</a> <a href="#ref-for-dfn-job-client-3">(2)</a> <a href="#ref-for-dfn-job-client-4">(3)</a> <a href="#ref-for-dfn-job-client-5">(4)</a>
-    <li><a href="#ref-for-dfn-job-client-6">Reject Job Promise</a> <a href="#ref-for-dfn-job-client-7">(2)</a> <a href="#ref-for-dfn-job-client-8">(3)</a> <a href="#ref-for-dfn-job-client-9">(4)</a>
-    <li><a href="#ref-for-dfn-job-client-10">Update</a> <a href="#ref-for-dfn-job-client-11">(2)</a>
-    <li><a href="#ref-for-dfn-job-client-12">Unregister</a>
+    <li><a href="#ref-for-dfn-job-client-2">Resolve Job Promise</a> <a href="#ref-for-dfn-job-client-3">(2)</a> <a href="#ref-for-dfn-job-client-4">(3)</a> <a href="#ref-for-dfn-job-client-5">(4)</a> <a href="#ref-for-dfn-job-client-6">(5)</a> <a href="#ref-for-dfn-job-client-7">(6)</a> <a href="#ref-for-dfn-job-client-8">(7)</a> <a href="#ref-for-dfn-job-client-9">(8)</a>
+    <li><a href="#ref-for-dfn-job-client-10">Reject Job Promise</a> <a href="#ref-for-dfn-job-client-11">(2)</a> <a href="#ref-for-dfn-job-client-12">(3)</a> <a href="#ref-for-dfn-job-client-13">(4)</a> <a href="#ref-for-dfn-job-client-14">(5)</a> <a href="#ref-for-dfn-job-client-15">(6)</a>
+    <li><a href="#ref-for-dfn-job-client-16">Update</a> <a href="#ref-for-dfn-job-client-17">(2)</a>
+    <li><a href="#ref-for-dfn-job-client-18">Unregister</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="job-referrer">

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>Service Workers Nightly</title>
-  <link href="https://www.w3.org/StyleSheets/TR/W3C-ED" rel="stylesheet" type="text/css">
+  <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
 <style data-fill-with="stylesheet">/******************************************************************************
  *                   Style sheet for the W3C specifications                   *
  *
@@ -471,7 +471,7 @@
 		font-style: normal;
 	}
 	dt dfn code, code.idl {
-		font-size: normal;
+		font-size: medium;
 	}
 	dfn var {
 		font-style: normal;
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 78add57678334db281af36bf567919103e7c1e66" name="generator">
+  <meta content="Bikeshed version 6de62f723758889927d2dc5378f7d1e02a3563f7" name="generator">
   <link href="https://www.w3.org/TR/service-workers/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1425,7 +1425,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-29">29 June 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-30">30 June 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1855,9 +1855,9 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     <h2 class="heading settled" data-level="3" id="document-context"><span class="secno">3. </span><span class="content">Client Context</span><a class="self-link" href="#document-context"></a></h2>
     <div class="example" id="example-7e94092e">
      <a class="self-link" href="#example-7e94092e"></a> Bootstrapping with a service worker: 
-<pre class="highlight"><span class="c1">// scope defaults to the path the script sits in
-// "/" in this example
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/serviceworker.js"</span><span class="p">).</span>then<span class="p">(</span>registration <span class="p">=></span> <span class="p">{</span>
+<pre class="highlight"><span class="c1">// scope defaults to the path the script sits in</span>
+<span class="c1">// "/" in this example</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/serviceworker.js"</span><span class="p">).</span>then<span class="p">(</span>registration <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>log<span class="p">(</span><span class="s2">"success!"</span><span class="p">);</span>
   <span class="k">if</span> <span class="p">(</span>registration<span class="p">.</span>installing<span class="p">)</span> <span class="p">{</span>
     registration<span class="p">.</span>installing<span class="p">.</span>postMessage<span class="p">(</span><span class="s2">"Howdy from your installing page."</span><span class="p">);</span>
@@ -1895,8 +1895,8 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorker" data-dfn-type="attribute" data-export="" id="dom-serviceworker-scripturl"><code><code>scriptURL</code></code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-45">service worker</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-1">script url</a>.</p>
       <div class="example" id="example-3ff1f346">
        <a class="self-link" href="#example-3ff1f346"></a> For example, consider a document created by a navigation to <code>https://example.com/app.html</code> which <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-4">matches</a> via the following registration call which has been previously executed: 
-<pre class="highlight"><span class="c1">// Script on the page https://example.com/app.html
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/service_worker.js"</span><span class="p">);</span>
+<pre class="highlight"><span class="c1">// Script on the page https://example.com/app.html</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/service_worker.js"</span><span class="p">);</span>
 </pre>
        <p>The value of <code>navigator.serviceWorker.controller.scriptURL</code> will be "<code>https://example.com/service_worker.js</code>".</p>
       </div>
@@ -2394,14 +2394,14 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     <h2 class="heading settled" data-level="4" id="execution-context"><span class="secno">4. </span><span class="content">Execution Context</span><a class="self-link" href="#execution-context"></a></h2>
     <div class="example" id="example-744d6b8b">
      <a class="self-link" href="#example-744d6b8b"></a> Serving Cached Resources: 
-<pre class="highlight"><span class="c1">// caching.js
-</span>self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"install"</span><span class="p">,</span> event <span class="p">=></span> <span class="p">{</span>
+<pre class="highlight"><span class="c1">// caching.js</span>
+<span class="c1"></span>self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"install"</span><span class="p">,</span> event <span class="p">=></span> <span class="p">{</span>
   event<span class="p">.</span>waitUntil<span class="p">(</span>
-    <span class="c1">// Open a cache of resources.
-</span>    caches<span class="p">.</span>open<span class="p">(</span><span class="s2">"shell-v1"</span><span class="p">).</span>then<span class="p">(</span>cache <span class="p">=></span> <span class="p">{</span>
-      <span class="c1">// Begins the process of fetching them.
-</span>      <span class="c1">// The coast is only clear when all the resources are ready.
-</span>      <span class="k">return</span> cache<span class="p">.</span>addAll<span class="p">([</span>
+    <span class="c1">// Open a cache of resources.</span>
+<span class="c1"></span>    caches<span class="p">.</span>open<span class="p">(</span><span class="s2">"shell-v1"</span><span class="p">).</span>then<span class="p">(</span>cache <span class="p">=></span> <span class="p">{</span>
+      <span class="c1">// Begins the process of fetching them.</span>
+<span class="c1"></span>      <span class="c1">// The coast is only clear when all the resources are ready.</span>
+<span class="c1"></span>      <span class="k">return</span> cache<span class="p">.</span>addAll<span class="p">([</span>
         <span class="s2">"/app.html"</span><span class="p">,</span>
         <span class="s2">"/assets/v1/base.css"</span><span class="p">,</span>
         <span class="s2">"/assets/v1/app.js"</span><span class="p">,</span>
@@ -2413,12 +2413,12 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
 <span class="p">});</span>
 
 self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"fetch"</span><span class="p">,</span> event <span class="p">=></span> <span class="p">{</span>
-  <span class="c1">// No "fetch" events are dispatched to the service worker until it
-</span>  <span class="c1">// successfully installs and activates.
-</span>
-  <span class="c1">// All operations on caches are async, including matching URLs, so we use
-</span>  <span class="c1">// promises heavily. e.respondWith() even takes promises to enable this:
-</span>  event<span class="p">.</span>respondWith<span class="p">(</span>
+  <span class="c1">// No "fetch" events are dispatched to the service worker until it</span>
+<span class="c1"></span>  <span class="c1">// successfully installs and activates.</span>
+<span class="c1"></span>
+  <span class="c1">// All operations on caches are async, including matching URLs, so we use</span>
+<span class="c1"></span>  <span class="c1">// promises heavily. e.respondWith() even takes promises to enable this:</span>
+<span class="c1"></span>  event<span class="p">.</span>respondWith<span class="p">(</span>
     caches<span class="p">.</span>match<span class="p">(</span>e<span class="p">.</span>request<span class="p">).</span>then<span class="p">(</span>response <span class="p">=></span> <span class="p">{</span>
       <span class="k">return</span> response <span class="o">||</span> fetch<span class="p">(</span>e<span class="p">.</span>request<span class="p">);</span>
     <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
@@ -4766,21 +4766,21 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-23">job</a></p>
       <dd data-md="">
-       <p><var>errorName</var>, a string</p>
+       <p><var>errorData</var>, the information necessary to <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">create an exception</a></p>
       <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-5">job promise</a> with a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">new</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a> with <var>errorName</var> and a user agent-defined <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-message">message</a>.</p>
+       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-5">job promise</a> with a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">new</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a> with <var>errorData</var> and a user agent-defined <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-message">message</a>, in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-12">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
       <li data-md="">
        <p>For each <var>equivalentJob</var> in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-list-of-equivalent-jobs" id="ref-for-dfn-job-list-of-equivalent-jobs-3">list of equivalent jobs</a>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-12">client</a> is null, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
+         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-13">client</a> is null, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-13">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-6">job promise</a> with a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">new</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a> with <var>errorName</var> and a user agent-defined <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-message">message</a>.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-14">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-6">job promise</a> with a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">new</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a> with <var>errorData</var> and a user agent-defined <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-message">message</a>, in <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-15">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
        </ol>
      </ol>
     </section>
@@ -4849,7 +4849,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If the result of running <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin">potentially trustworthy origin</a> with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-3">script url</a> as the argument is <code>Not Trusted</code>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-1">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-1">Reject Job Promise</a> with <var>job</var> and "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" DOMException.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-1">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4857,7 +4857,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-4">script url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#job-referrer" id="ref-for-job-referrer-3">referrer</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-2">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-2">Reject Job Promise</a> with <var>job</var> and "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" DOMException.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-2">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4865,7 +4865,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-5">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#job-referrer" id="ref-for-job-referrer-4">referrer</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-3">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-3">Reject Job Promise</a> with <var>job</var> and "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" DOMException.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-3">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4914,7 +4914,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-6">uninstalling flag</a> is set, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-4">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-4">Reject Job Promise</a> with <var>job</var> and <code>TypeError</code>.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-5">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4924,7 +4924,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-9">job type</a> is <em>update</em>, and <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-5">script url</a> does not <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equal</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-6">script url</a> with the <em>exclude fragments flag</em> set, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-5">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-5">Reject Job Promise</a> with <var>job</var> and <code>TypeError</code>.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-6">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4937,10 +4937,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <dl>
         <dt data-md="">"<code>classic</code>"
         <dd data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-14">client</a>, "<code>serviceworker</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-16">client</a>, "<code>serviceworker</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
         <dt data-md="">"<code>module</code>"
         <dd data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">Fetch a module worker script graph</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-15">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">Fetch a module worker script graph</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-17">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
        </dl>
        <p>To <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a> given <var>request</var>, run the following steps:</p>
        <ol>
@@ -4970,7 +4970,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">Extract a MIME type</a> from the <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#javascript-mime-type">JavaScript MIME type</a>, then:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-6">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
+           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-6">Reject Job Promise</a> with <var>job</var> and "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" DOMException.</p>
           <li data-md="">
            <p>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
          </ol>
@@ -5013,7 +5013,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Else:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-7">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
+           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-7">Reject Job Promise</a> with <var>job</var> and "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" DOMException.</p>
           <li data-md="">
            <p>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
          </ol>
@@ -5026,8 +5026,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If the algorithm asynchronously completes with null, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-8">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
-         <p class="note" role="note"><span>Note:</span> This will do nothing if <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-9">Reject Job Promise</a> was previously invoked with "<code>SecurityError</code>".</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-8">Reject Job Promise</a> with <var>job</var> and <code>TypeError</code>.</p>
+         <p class="note" role="note"><span>Note:</span> This will do nothing if <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-9">Reject Job Promise</a> was previously invoked with "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" DOMException.</p>
         <li data-md="">
          <p>If <var>newestWorker</var> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-1">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
         <li data-md="">
@@ -5061,7 +5061,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>If an uncaught runtime script error occurs during the above step, then:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-10">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
+           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-10">Reject Job Promise</a> with <var>job</var> and <code>TypeError</code>.</p>
           <li data-md="">
            <p>If <var>newestWorker</var> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-2">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
           <li data-md="">
@@ -5899,10 +5899,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-9">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-16">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-9">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-18">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-11">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-11">Reject Job Promise</a> with <var>job</var> and "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" DOMException.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-12">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -6595,36 +6595,36 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <div class="example" id="example-bf118df6">
       <a class="self-link" href="#example-bf118df6"></a> Default scope: 
-<pre class="highlight"><span class="c1">// Maximum allowed scope defaults to the path the script sits in
-// "/js" in this example
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">).</span>then<span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+<pre class="highlight"><span class="c1">// Maximum allowed scope defaults to the path the script sits in</span>
+<span class="c1">// "/js" in this example</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">).</span>then<span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Install succeeded with the default scope '/js'."</span><span class="p">);</span>
 <span class="p">});</span>
 </pre>
      </div>
      <div class="example" id="example-76c5aa8b">
       <a class="self-link" href="#example-76c5aa8b"></a> Upper path without Service-Worker-Allowed header: 
-<pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location
-// Response has no Service-Worker-Allowed header
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+<pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location</span>
+<span class="c1">// Response has no Service-Worker-Allowed header</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Install failed due to the path restriction violation."</span><span class="p">);</span>
 <span class="p">});</span>
 </pre>
      </div>
      <div class="example" id="example-49d267fe">
       <a class="self-link" href="#example-49d267fe"></a> Upper path with Service-Worker-Allowed header: 
-<pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location
-// Response included "Service-Worker-Allowed : /"
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span>then<span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+<pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location</span>
+<span class="c1">// Response included "Service-Worker-Allowed : /"</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span>then<span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Install succeeded as the max allowed scope was overriden to '/'."</span><span class="p">);</span>
 <span class="p">});</span>
 </pre>
      </div>
      <div class="example" id="example-7a18b25f">
       <a class="self-link" href="#example-7a18b25f"></a> A path restriction voliation even with Service-Worker-Allowed header: 
-<pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location
-// Response included "Service-Worker-Allowed : /foo"
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/foo/bar/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+<pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location</span>
+<span class="c1">// Response included "Service-Worker-Allowed : /foo"</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/foo/bar/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Install failed as the scope is still out of the overriden maximum allowed scope."</span><span class="p">);</span>
 <span class="p">});</span>
 </pre>
@@ -6681,6 +6681,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     be easy to understand and are not intended to be performant. Implementers
     are encouraged to optimize.</p>
   </div>
+  <p id="back-to-top" role="navigation"><a href="#toc"><abbr title="Back to top">↑</abbr></a></p>
+  . 
 <script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
@@ -9842,9 +9844,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-job-client-1">Create Job</a>
     <li><a href="#ref-for-dfn-job-client-2">Resolve Job Promise</a> <a href="#ref-for-dfn-job-client-3">(2)</a> <a href="#ref-for-dfn-job-client-4">(3)</a> <a href="#ref-for-dfn-job-client-5">(4)</a> <a href="#ref-for-dfn-job-client-6">(5)</a> <a href="#ref-for-dfn-job-client-7">(6)</a> <a href="#ref-for-dfn-job-client-8">(7)</a> <a href="#ref-for-dfn-job-client-9">(8)</a>
-    <li><a href="#ref-for-dfn-job-client-10">Reject Job Promise</a> <a href="#ref-for-dfn-job-client-11">(2)</a> <a href="#ref-for-dfn-job-client-12">(3)</a> <a href="#ref-for-dfn-job-client-13">(4)</a>
-    <li><a href="#ref-for-dfn-job-client-14">Update</a> <a href="#ref-for-dfn-job-client-15">(2)</a>
-    <li><a href="#ref-for-dfn-job-client-16">Unregister</a>
+    <li><a href="#ref-for-dfn-job-client-10">Reject Job Promise</a> <a href="#ref-for-dfn-job-client-11">(2)</a> <a href="#ref-for-dfn-job-client-12">(3)</a> <a href="#ref-for-dfn-job-client-13">(4)</a> <a href="#ref-for-dfn-job-client-14">(5)</a> <a href="#ref-for-dfn-job-client-15">(6)</a>
+    <li><a href="#ref-for-dfn-job-client-16">Update</a> <a href="#ref-for-dfn-job-client-17">(2)</a>
+    <li><a href="#ref-for-dfn-job-client-18">Unregister</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="job-referrer">

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -2165,28 +2165,37 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <h3 id="resolve-job-promise-algorithm"><dfn>Resolve Job Promise</dfn></h3>
 
       : Input
-      :: |job|, a <a>job</a>
+      :: |job|, a [=job=]
       :: |value|, any
       : Output
       :: none
 
-      1. If |job|'s [=job/client=] is not null, <a>queue a task</a> to resolve |job|'s [=job/job promise=] with |value| on |job|'s [=job/client=]'s <a>responsible event loop</a> using the <a>DOM manipulation task source</a> as the <a>task source</a>.
+      1. Let |convertedValue| be null.
+      1. If |job|'s [=job/client=] is not null, [=queue a task=], on |job|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to run the following substeps:
+          1. If |job|'s [=job/job type=] is either *register* or *update*, set |convertedValue| to the {{ServiceWorkerRegistration}} object that represents |value|, in |job|'s [=job/client=]'s [=environment settings object/Realm=].
+          1. Else, set |convertedValue| to |value|, in |job|'s [=job/client=]'s [=environment settings object/Realm=].
+          1. Resolve |job|'s [=job/job promise=] with |convertedValue|.
       1. For each |equivalentJob| in |job|'s <a>list of equivalent jobs</a>:
-          1. If |equivalentJob|'s [=job/client=] is not null, <a>queue a task</a> to resolve |equivalentJob|'s [=job/job promise=] with |value| on |equivalentJob|'s [=job/client=]'s <a>responsible event loop</a> using the <a>DOM manipulation task source</a> as the <a>task source</a>.
+          1. If |equivalentJob|'s [=job/client=] is null, continue to the next iteration of the loop.
+          1. [=Queue a task=], on |equivalentJob|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to run the following substeps:
+              1. If |equivalentJob|'s [=job/job type=] is either *register* or *update*, set |convertedValue| to the {{ServiceWorkerRegistration}} object that represents |value|, in |equivalentJob|'s [=job/client=]'s [=environment settings object/Realm=].
+              1. Else, set |convertedValue| to |value|, in |equivalentJob|'s [=job/client=]'s [=environment settings object/Realm=].
+              1. Resolve |equivalentJob|'s [=job/job promise=] with |convertedValue|.
   </section>
 
   <section algorithm>
     <h3 id="reject-job-promise-algorithm"><dfn>Reject Job Promise</dfn></h3>
 
       : Input
-      :: |job|, a <a>job</a>
-      :: |reason|, an <a>exception</a>
+      :: |job|, a [=job=]
+      :: |reason|, an [=exception=]
       : Output
       :: none
 
-      1. If |job|'s [=job/client=] is not null, <a>queue a task</a> to reject |job|'s [=job/job promise=] with |reason| on |job|'s [=job/client=]'s <a>responsible event loop</a> using the <a>DOM manipulation task source</a> as the <a>task source</a>.
-      1. For each |equivalentJob| in |job|'s <a>list of equivalent jobs</a>:
-          1. If |equivalentJob|'s [=job/client=] is not null, <a>queue a task</a> to reject |equivalentJob|'s [=job/job promise=] with |reason| on |equivalentJob|'s [=job/client=]'s <a>responsible event loop</a> using the <a>DOM manipulation task source</a> as the <a>task source</a>.
+      1. If |job|'s [=job/client=] is not null, [=queue a task=], on |job|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |job|'s [=job/job promise=] with an exception that is a copy of |reason|, in |job|'s [=job/client=]'s [=environment settings object/Realm=].
+      1. For each |equivalentJob| in |job|'s [=list of equivalent jobs=]:
+          1. If |equivalentJob|'s [=job/client=] is null, continue to the next iteration of the loop:
+          1. [=Queue a task=], on |equivalentJob|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |equivalentJob|'s [=job/job promise=] with an exception that is a copy of |reason|, in |equivalentJob|'s [=job/client=]'s [=environment settings object/Realm=].
   </section>
 
   <section algorithm>
@@ -2211,7 +2220,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. If |registration|'s <a>uninstalling flag</a> is set, unset it.
           1. Let |newestWorker| be the result of running the <a>Get Newest Worker</a> algorithm passing |registration| as the argument.
           1. If |newestWorker| is not null, |job|'s [=job/script url=] [=url/equals=] |newestWorker|'s [=service worker/script url=] with the *exclude fragments flag* set, and |job|'s [=job/update via cache mode=]'s value equals |registration|'s [=service worker registration/update via cache mode=]'s value, then:
-              1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
+              1. Invoke [=Resolve Job Promise=] with |job| and |registration|.
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Else:
           1. Invoke <a>Set Registration</a> algorithm with |job|'s [=job/scope url=] and |job|'s [=job/update via cache mode=].
@@ -2301,7 +2310,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           Else, continue the rest of these steps after the algorithm's asynchronous completion, with |script| being the asynchronous completion value.
 
       1. If |newestWorker| is not null, |newestWorker|'s [=service worker/script url=] [=url/equals=] |job|'s [=job/script url=] with the *exclude fragments flag* set, and |script|'s [=source text=] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=source text=], if |script| is a [=classic script=], and |script|'s [=module script/module record=]'s \[[ECMAScriptCode]] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=module script/module record=]'s \[[ECMAScriptCode]] otherwise, then:
-          1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
+          1. Invoke [=Resolve Job Promise=] with |job| and |registration|.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Else:
           1. Let |worker| be a new [=/service worker=].
@@ -2354,7 +2363,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and |worker| as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>installing worker</a> and *installing* as the arguments.
       1. Assert: |job|'s [=job/job promise=] is not null.
-      1. Invoke <a>Resolve Job Promise</a> with |job| and the {{ServiceWorkerRegistration}} object which represents |registration|.
+      1. Invoke [=Resolve Job Promise=] with |job| and |registration|.
       1. <a>Queue a task</a> to <a>fire an event</a> named <code>updatefound</code> at all the {{ServiceWorkerRegistration}} objects for all the [=/service worker clients=] whose <a>creation URL</a> <a lt="Match Service Worker Registration">matches</a> |registration|'s [=service worker registration/scope url=] and all the [=/service workers=] whose <a>containing service worker registration</a> is |registration|.
       1. Let |installingWorker| be |registration|'s <a>installing worker</a>.
       1. Invoke <a>Run Service Worker</a> algorithm given |installingWorker|, and with the *force bypass cache for importscripts flag* set if |job|'s [=job/force bypass cache flag=] is set.

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -2188,14 +2188,14 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       : Input
       :: |job|, a [=job=]
-      :: |reason|, an [=exception=]
+      :: |errorName|, a string
       : Output
       :: none
 
-      1. If |job|'s [=job/client=] is not null, [=queue a task=], on |job|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |job|'s [=job/job promise=] with an exception that is a copy of |reason|, in |job|'s [=job/client=]'s [=environment settings object/Realm=].
+      1. If |job|'s [=job/client=] is not null, [=queue a task=], on |job|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |job|'s [=job/job promise=] with a [=exception/create|new=] [=exception=] with |errorName| and a user agent-defined [=exception/message=].
       1. For each |equivalentJob| in |job|'s [=list of equivalent jobs=]:
-          1. If |equivalentJob|'s [=job/client=] is null, continue to the next iteration of the loop:
-          1. [=Queue a task=], on |equivalentJob|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |equivalentJob|'s [=job/job promise=] with an exception that is a copy of |reason|, in |equivalentJob|'s [=job/client=]'s [=environment settings object/Realm=].
+          1. If |equivalentJob|'s [=job/client=] is null, [=iteration/continue=].
+          1. [=Queue a task=], on |equivalentJob|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |equivalentJob|'s [=job/job promise=] with a [=exception/create|new=] [=exception=] with |errorName| and a user agent-defined [=exception/message=].
   </section>
 
   <section algorithm>
@@ -2207,13 +2207,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: none
 
       1. If the result of running <a>potentially trustworthy origin</a> with the [=environment settings object/origin=] of |job|'s [=job/script url=] as the argument is <code>Not Trusted</code>, then:
-          1. Invoke <a>Reject Job Promise</a> with |job| and a "{{SecurityError}}" exception.
+          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. If the [=environment settings object/origin=] of |job|'s [=job/script url=] is not |job|'s [=job/client=]'s [=environment settings object/origin=], then:
-          1. Invoke <a>Reject Job Promise</a> with |job| and a "{{SecurityError}}" exception.
+          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. If the [=environment settings object/origin=] of |job|'s [=job/scope url=] is not |job|'s [=job/client=]'s [=environment settings object/origin=], then:
-          1. Invoke <a>Reject Job Promise</a> with |job| and a "{{SecurityError}}" exception.
+          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |registration| be the result of running the <a>Get Registration</a> algorithm passing |job|'s [=job/scope url=] as the argument.
       1. If |registration| is not null, then:
@@ -2237,11 +2237,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       1. Let |registration| be the result of running the <a>Get Registration</a> algorithm passing |job|'s [=job/scope url=] as the argument.
       1. If |registration| is null or |registration|'s <a>uninstalling flag</a> is set, then:
-          1. Invoke <a>Reject Job Promise</a> with |job| and a <code>TypeError</code>.
+          1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |newestWorker| be the result of running <a>Get Newest Worker</a> algorithm passing |registration| as the argument.
       1. If |job|'s <a>job type</a> is *update*, and |newestWorker|'s [=service worker/script url=] does not [=url/equal=] |job|'s [=job/script url=] with the *exclude fragments flag* set, then:
-          1. Invoke <a>Reject Job Promise</a> with |job| and a <code>TypeError</code>.
+          1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |httpsState| be "<code>none</code>".
       1. Let |referrerPolicy| be the empty string.
@@ -2270,7 +2270,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Set |request|'s [=request/redirect mode=] to "<code>error</code>".
           1. [=/Fetch=] |request|, and asynchronously wait to run the remaining steps as part of fetch's <a>process response</a> for the [=/response=] |response|.
           1. [=Extract a MIME type=] from the |response|'s [=response/header list=]. If this MIME type (ignoring parameters) is not a [=JavaScript MIME type=], then:
-              1. Invoke [=Reject Job Promise=] with |job| and a "{{SecurityError}}" exception.
+              1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
               1. Asynchronously complete these steps with a [=network error=].
           1. Let |serviceWorkerAllowed| be the result of [=extracting header list values=] given \`<code>Service-Worker-Allowed</code>\` and |response|'s [=response/header list=].
 
@@ -2290,7 +2290,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Let |scopeString| be "<code>/</code>" concatenated with the strings in |scopeURL|'s [=url/path=] (including empty strings), separated from each other by "<code>/</code>".
           1. If |scopeString| starts with |maxScopeString|, do nothing.
           1. Else:
-              1. Invoke <a>Reject Job Promise</a> with |job| and a "{{SecurityError}}" exception.
+              1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
               1. Asynchronously complete these steps with a <a>network error</a>.
           1. If |response|'s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|'s <a>last update check time</a> to the current time.
 
@@ -2300,9 +2300,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
           If the algorithm asynchronously completes with null, then:
 
-              1. Invoke <a>Reject Job Promise</a> with |job| and a <code>TypeError</code>.
+              1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
 
-                  Note: This will do nothing if <a>Reject Job Promise</a> was previously invoked with a "{{SecurityError}}" exception.
+                  Note: This will do nothing if [=Reject Job Promise=] was previously invoked with "`SecurityError`".
 
               1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
@@ -2320,7 +2320,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
           1. Invoke <a>Run Service Worker</a> algorithm given |worker|, and with the *force bypass cache for importscripts flag* set if |job|'s [=job/force bypass cache flag=] is set.
           1. If an uncaught runtime script error occurs during the above step, then:
-              1. Invoke <a>Reject Job Promise</a> with |job| and a <code>TypeError</code>.
+              1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
               1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Invoke <a>Install</a> algorithm with |job|, |worker|, and |registration| as its arguments.
@@ -2708,7 +2708,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: none
 
       1. If the [=environment settings object/origin=] of |job|'s [=job/scope url=] is not |job|'s [=job/client=]'s [=environment settings object/origin=], then:
-          1. Invoke <a>Reject Job Promise</a> with |job| and a "{{SecurityError}}" exception.
+          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |registration| be the result of running <a>Get Registration</a> algorithm passing |job|'s [=job/scope url=] as the argument.
       1. If |registration| is null, then:

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -2188,14 +2188,14 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       : Input
       :: |job|, a [=job=]
-      :: |errorName|, a string
+      :: |errorData|, the information necessary to [=exception/create|create an exception=]
       : Output
       :: none
 
-      1. If |job|'s [=job/client=] is not null, [=queue a task=], on |job|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |job|'s [=job/job promise=] with a [=exception/create|new=] [=exception=] with |errorName| and a user agent-defined [=exception/message=].
+      1. If |job|'s [=job/client=] is not null, [=queue a task=], on |job|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |job|'s [=job/job promise=] with a [=exception/create|new=] [=exception=] with |errorData| and a user agent-defined [=exception/message=], in |job|'s [=job/client=]'s [=environment settings object/Realm=].
       1. For each |equivalentJob| in |job|'s [=list of equivalent jobs=]:
           1. If |equivalentJob|'s [=job/client=] is null, [=iteration/continue=].
-          1. [=Queue a task=], on |equivalentJob|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |equivalentJob|'s [=job/job promise=] with a [=exception/create|new=] [=exception=] with |errorName| and a user agent-defined [=exception/message=].
+          1. [=Queue a task=], on |equivalentJob|'s [=job/client=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to reject |equivalentJob|'s [=job/job promise=] with a [=exception/create|new=] [=exception=] with |errorData| and a user agent-defined [=exception/message=], in |equivalentJob|'s [=job/client=]'s [=environment settings object/Realm=].
   </section>
 
   <section algorithm>
@@ -2207,13 +2207,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: none
 
       1. If the result of running <a>potentially trustworthy origin</a> with the [=environment settings object/origin=] of |job|'s [=job/script url=] as the argument is <code>Not Trusted</code>, then:
-          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
+          1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" DOMException.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. If the [=environment settings object/origin=] of |job|'s [=job/script url=] is not |job|'s [=job/client=]'s [=environment settings object/origin=], then:
-          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
+          1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" DOMException.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. If the [=environment settings object/origin=] of |job|'s [=job/scope url=] is not |job|'s [=job/client=]'s [=environment settings object/origin=], then:
-          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
+          1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" DOMException.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |registration| be the result of running the <a>Get Registration</a> algorithm passing |job|'s [=job/scope url=] as the argument.
       1. If |registration| is not null, then:
@@ -2237,11 +2237,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       1. Let |registration| be the result of running the <a>Get Registration</a> algorithm passing |job|'s [=job/scope url=] as the argument.
       1. If |registration| is null or |registration|'s <a>uninstalling flag</a> is set, then:
-          1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
+          1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |newestWorker| be the result of running <a>Get Newest Worker</a> algorithm passing |registration| as the argument.
       1. If |job|'s <a>job type</a> is *update*, and |newestWorker|'s [=service worker/script url=] does not [=url/equal=] |job|'s [=job/script url=] with the *exclude fragments flag* set, then:
-          1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
+          1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |httpsState| be "<code>none</code>".
       1. Let |referrerPolicy| be the empty string.
@@ -2270,7 +2270,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Set |request|'s [=request/redirect mode=] to "<code>error</code>".
           1. [=/Fetch=] |request|, and asynchronously wait to run the remaining steps as part of fetch's <a>process response</a> for the [=/response=] |response|.
           1. [=Extract a MIME type=] from the |response|'s [=response/header list=]. If this MIME type (ignoring parameters) is not a [=JavaScript MIME type=], then:
-              1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
+              1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" DOMException.
               1. Asynchronously complete these steps with a [=network error=].
           1. Let |serviceWorkerAllowed| be the result of [=extracting header list values=] given \`<code>Service-Worker-Allowed</code>\` and |response|'s [=response/header list=].
 
@@ -2290,7 +2290,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Let |scopeString| be "<code>/</code>" concatenated with the strings in |scopeURL|'s [=url/path=] (including empty strings), separated from each other by "<code>/</code>".
           1. If |scopeString| starts with |maxScopeString|, do nothing.
           1. Else:
-              1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
+              1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" DOMException.
               1. Asynchronously complete these steps with a <a>network error</a>.
           1. If |response|'s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|'s <a>last update check time</a> to the current time.
 
@@ -2300,9 +2300,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
           If the algorithm asynchronously completes with null, then:
 
-              1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
+              1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
 
-                  Note: This will do nothing if [=Reject Job Promise=] was previously invoked with "`SecurityError`".
+                  Note: This will do nothing if [=Reject Job Promise=] was previously invoked with "{{SecurityError}}" DOMException.
 
               1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
@@ -2320,7 +2320,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
           1. Invoke <a>Run Service Worker</a> algorithm given |worker|, and with the *force bypass cache for importscripts flag* set if |job|'s [=job/force bypass cache flag=] is set.
           1. If an uncaught runtime script error occurs during the above step, then:
-              1. Invoke [=Reject Job Promise=] with |job| and "`TypeError`".
+              1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
               1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Invoke <a>Install</a> algorithm with |job|, |worker|, and |registration| as its arguments.
@@ -2708,7 +2708,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: none
 
       1. If the [=environment settings object/origin=] of |job|'s [=job/scope url=] is not |job|'s [=job/client=]'s [=environment settings object/origin=], then:
-          1. Invoke [=Reject Job Promise=] with |job| and "`SecurityError`".
+          1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" DOMException.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |registration| be the result of running <a>Get Registration</a> algorithm passing |job|'s [=job/scope url=] as the argument.
       1. If |registration| is null, then:

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 39e591568007a470c8705dd14db3d9d86db98356" name="generator">
+  <meta content="Bikeshed version bab6032cf8759f7d2fb1341d02aa48484a5a3187" name="generator">
   <link href="https://www.w3.org/TR/service-workers/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1365,67 +1365,67 @@ Possible extra rowspan handling
         </style>
 <style>/* style-syntax-highlighting */
 pre.idl.highlight { color: #708090; }
-        .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
-        code.highlight { padding: .1em; border-radius: .3em; }
-        pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-        .highlight .c { color: #708090 } /* Comment */
-        .highlight .k { color: #990055 } /* Keyword */
-        .highlight .l { color: #000000 } /* Literal */
-        .highlight .n { color: #0077aa } /* Name */
-        .highlight .o { color: #999999 } /* Operator */
-        .highlight .p { color: #999999 } /* Punctuation */
-        .highlight .cm { color: #708090 } /* Comment.Multiline */
-        .highlight .cp { color: #708090 } /* Comment.Preproc */
-        .highlight .c1 { color: #708090 } /* Comment.Single */
-        .highlight .cs { color: #708090 } /* Comment.Special */
-        .highlight .kc { color: #990055 } /* Keyword.Constant */
-        .highlight .kd { color: #990055 } /* Keyword.Declaration */
-        .highlight .kn { color: #990055 } /* Keyword.Namespace */
-        .highlight .kp { color: #990055 } /* Keyword.Pseudo */
-        .highlight .kr { color: #990055 } /* Keyword.Reserved */
-        .highlight .kt { color: #990055 } /* Keyword.Type */
-        .highlight .ld { color: #000000 } /* Literal.Date */
-        .highlight .m { color: #000000 } /* Literal.Number */
-        .highlight .s { color: #a67f59 } /* Literal.String */
-        .highlight .na { color: #0077aa } /* Name.Attribute */
-        .highlight .nc { color: #0077aa } /* Name.Class */
-        .highlight .no { color: #0077aa } /* Name.Constant */
-        .highlight .nd { color: #0077aa } /* Name.Decorator */
-        .highlight .ni { color: #0077aa } /* Name.Entity */
-        .highlight .ne { color: #0077aa } /* Name.Exception */
-        .highlight .nf { color: #0077aa } /* Name.Function */
-        .highlight .nl { color: #0077aa } /* Name.Label */
-        .highlight .nn { color: #0077aa } /* Name.Namespace */
-        .highlight .py { color: #0077aa } /* Name.Property */
-        .highlight .nt { color: #669900 } /* Name.Tag */
-        .highlight .nv { color: #222222 } /* Name.Variable */
-        .highlight .ow { color: #999999 } /* Operator.Word */
-        .highlight .mb { color: #000000 } /* Literal.Number.Bin */
-        .highlight .mf { color: #000000 } /* Literal.Number.Float */
-        .highlight .mh { color: #000000 } /* Literal.Number.Hex */
-        .highlight .mi { color: #000000 } /* Literal.Number.Integer */
-        .highlight .mo { color: #000000 } /* Literal.Number.Oct */
-        .highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
-        .highlight .sc { color: #a67f59 } /* Literal.String.Char */
-        .highlight .sd { color: #a67f59 } /* Literal.String.Doc */
-        .highlight .s2 { color: #a67f59 } /* Literal.String.Double */
-        .highlight .se { color: #a67f59 } /* Literal.String.Escape */
-        .highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
-        .highlight .si { color: #a67f59 } /* Literal.String.Interpol */
-        .highlight .sx { color: #a67f59 } /* Literal.String.Other */
-        .highlight .sr { color: #a67f59 } /* Literal.String.Regex */
-        .highlight .s1 { color: #a67f59 } /* Literal.String.Single */
-        .highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
-        .highlight .vc { color: #0077aa } /* Name.Variable.Class */
-        .highlight .vg { color: #0077aa } /* Name.Variable.Global */
-        .highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-        .highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
-        </style>
+.highlight:not(.idl) { background: hsl(24, 20%, 95%); }
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+.highlight .c { color: #708090 } /* Comment */
+.highlight .k { color: #990055 } /* Keyword */
+.highlight .l { color: #000000 } /* Literal */
+.highlight .n { color: #0077aa } /* Name */
+.highlight .o { color: #999999 } /* Operator */
+.highlight .p { color: #999999 } /* Punctuation */
+.highlight .cm { color: #708090 } /* Comment.Multiline */
+.highlight .cp { color: #708090 } /* Comment.Preproc */
+.highlight .c1 { color: #708090 } /* Comment.Single */
+.highlight .cs { color: #708090 } /* Comment.Special */
+.highlight .kc { color: #990055 } /* Keyword.Constant */
+.highlight .kd { color: #990055 } /* Keyword.Declaration */
+.highlight .kn { color: #990055 } /* Keyword.Namespace */
+.highlight .kp { color: #990055 } /* Keyword.Pseudo */
+.highlight .kr { color: #990055 } /* Keyword.Reserved */
+.highlight .kt { color: #990055 } /* Keyword.Type */
+.highlight .ld { color: #000000 } /* Literal.Date */
+.highlight .m { color: #000000 } /* Literal.Number */
+.highlight .s { color: #a67f59 } /* Literal.String */
+.highlight .na { color: #0077aa } /* Name.Attribute */
+.highlight .nc { color: #0077aa } /* Name.Class */
+.highlight .no { color: #0077aa } /* Name.Constant */
+.highlight .nd { color: #0077aa } /* Name.Decorator */
+.highlight .ni { color: #0077aa } /* Name.Entity */
+.highlight .ne { color: #0077aa } /* Name.Exception */
+.highlight .nf { color: #0077aa } /* Name.Function */
+.highlight .nl { color: #0077aa } /* Name.Label */
+.highlight .nn { color: #0077aa } /* Name.Namespace */
+.highlight .py { color: #0077aa } /* Name.Property */
+.highlight .nt { color: #669900 } /* Name.Tag */
+.highlight .nv { color: #222222 } /* Name.Variable */
+.highlight .ow { color: #999999 } /* Operator.Word */
+.highlight .mb { color: #000000 } /* Literal.Number.Bin */
+.highlight .mf { color: #000000 } /* Literal.Number.Float */
+.highlight .mh { color: #000000 } /* Literal.Number.Hex */
+.highlight .mi { color: #000000 } /* Literal.Number.Integer */
+.highlight .mo { color: #000000 } /* Literal.Number.Oct */
+.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
+.highlight .sc { color: #a67f59 } /* Literal.String.Char */
+.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
+.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
+.highlight .se { color: #a67f59 } /* Literal.String.Escape */
+.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
+.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
+.highlight .sx { color: #a67f59 } /* Literal.String.Other */
+.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
+.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
+.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
+.highlight .vc { color: #0077aa } /* Name.Variable.Class */
+.highlight .vg { color: #0077aa } /* Name.Variable.Global */
+.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
+.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+</style>
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-12">12 June 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-26">26 June 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1818,15 +1818,15 @@ pre.idl.highlight { color: #708090; }
     <div class="example" id="example-7e94092e">
      <a class="self-link" href="#example-7e94092e"></a> Bootstrapping with a service worker: 
 <pre class="highlight"><span class="c1">// scope defaults to the path the script sits in
-</span><span class="c1">// "/" in this example
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/serviceworker.js"</span><span class="p">)</span><span class="p">.</span>then<span class="p">(</span>registration <span class="p">=></span> <span class="p">{</span>
-  console<span class="p">.</span>log<span class="p">(</span><span class="s2">"success!"</span><span class="p">)</span><span class="p">;</span>
+// "/" in this example
+</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/serviceworker.js"</span><span class="p">).</span>then<span class="p">(</span>registration <span class="p">=></span> <span class="p">{</span>
+  console<span class="p">.</span>log<span class="p">(</span><span class="s2">"success!"</span><span class="p">);</span>
   <span class="k">if</span> <span class="p">(</span>registration<span class="p">.</span>installing<span class="p">)</span> <span class="p">{</span>
-    registration<span class="p">.</span>installing<span class="p">.</span>postMessage<span class="p">(</span><span class="s2">"Howdy from your installing page."</span><span class="p">)</span><span class="p">;</span>
+    registration<span class="p">.</span>installing<span class="p">.</span>postMessage<span class="p">(</span><span class="s2">"Howdy from your installing page."</span><span class="p">);</span>
   <span class="p">}</span>
-<span class="p">}</span><span class="p">,</span> err <span class="p">=></span> <span class="p">{</span>
-  console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Installing the worker failed!"</span><span class="p">,</span> err<span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+<span class="p">},</span> err <span class="p">=></span> <span class="p">{</span>
+  console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Installing the worker failed!"</span><span class="p">,</span> err<span class="p">);</span>
+<span class="p">});</span>
 </pre>
     </div>
     <section>
@@ -1858,7 +1858,7 @@ pre.idl.highlight { color: #708090; }
       <div class="example" id="example-3ff1f346">
        <a class="self-link" href="#example-3ff1f346"></a> For example, consider a document created by a navigation to <code>https://example.com/app.html</code> which <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-4">matches</a> via the following registration call which has been previously executed: 
 <pre class="highlight"><span class="c1">// Script on the page https://example.com/app.html
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/service_worker.js"</span><span class="p">)</span><span class="p">;</span>
+</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/service_worker.js"</span><span class="p">);</span>
 </pre>
        <p>The value of <code>navigator.serviceWorker.controller.scriptURL</code> will be "<code>https://example.com/service_worker.js</code>".</p>
       </div>
@@ -2302,19 +2302,19 @@ pre.idl.highlight { color: #708090; }
 </span>self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"install"</span><span class="p">,</span> event <span class="p">=></span> <span class="p">{</span>
   event<span class="p">.</span>waitUntil<span class="p">(</span>
     <span class="c1">// Open a cache of resources.
-</span>    caches<span class="p">.</span>open<span class="p">(</span><span class="s2">"shell-v1"</span><span class="p">)</span><span class="p">.</span>then<span class="p">(</span>cache <span class="p">=></span> <span class="p">{</span>
+</span>    caches<span class="p">.</span>open<span class="p">(</span><span class="s2">"shell-v1"</span><span class="p">).</span>then<span class="p">(</span>cache <span class="p">=></span> <span class="p">{</span>
       <span class="c1">// Begins the process of fetching them.
 </span>      <span class="c1">// The coast is only clear when all the resources are ready.
-</span>      <span class="k">return</span> cache<span class="p">.</span>addAll<span class="p">(</span><span class="p">[</span>
+</span>      <span class="k">return</span> cache<span class="p">.</span>addAll<span class="p">([</span>
         <span class="s2">"/app.html"</span><span class="p">,</span>
         <span class="s2">"/assets/v1/base.css"</span><span class="p">,</span>
         <span class="s2">"/assets/v1/app.js"</span><span class="p">,</span>
         <span class="s2">"/assets/v1/logo.png"</span><span class="p">,</span>
         <span class="s2">"/assets/v1/intro_video.webm"</span>
-      <span class="p">]</span><span class="p">)</span><span class="p">;</span>
-    <span class="p">}</span><span class="p">)</span>
-  <span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+      <span class="p">]);</span>
+    <span class="p">})</span>
+  <span class="p">);</span>
+<span class="p">});</span>
 
 self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"fetch"</span><span class="p">,</span> event <span class="p">=></span> <span class="p">{</span>
   <span class="c1">// No "fetch" events are dispatched to the service worker until it
@@ -2323,13 +2323,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="c1">// All operations on caches are async, including matching URLs, so we use
 </span>  <span class="c1">// promises heavily. e.respondWith() even takes promises to enable this:
 </span>  event<span class="p">.</span>respondWith<span class="p">(</span>
-    caches<span class="p">.</span>match<span class="p">(</span>e<span class="p">.</span>request<span class="p">)</span><span class="p">.</span>then<span class="p">(</span>response <span class="p">=></span> <span class="p">{</span>
-      <span class="k">return</span> response <span class="o">||</span> fetch<span class="p">(</span>e<span class="p">.</span>request<span class="p">)</span><span class="p">;</span>
-    <span class="p">}</span><span class="p">)</span><span class="p">.</span><span class="k">catch</span><span class="p">(</span><span class="p">(</span><span class="p">)</span> <span class="p">=></span> <span class="p">{</span>
-      <span class="k">return</span> caches<span class="p">.</span>match<span class="p">(</span><span class="s2">"/fallback.html"</span><span class="p">)</span><span class="p">;</span>
-    <span class="p">}</span><span class="p">)</span>
-  <span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+    caches<span class="p">.</span>match<span class="p">(</span>e<span class="p">.</span>request<span class="p">).</span>then<span class="p">(</span>response <span class="p">=></span> <span class="p">{</span>
+      <span class="k">return</span> response <span class="o">||</span> fetch<span class="p">(</span>e<span class="p">.</span>request<span class="p">);</span>
+    <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+      <span class="k">return</span> caches<span class="p">.</span>match<span class="p">(</span><span class="s2">"/fallback.html"</span><span class="p">);</span>
+    <span class="p">})</span>
+  <span class="p">);</span>
+<span class="p">});</span>
 </pre>
     </div>
     <section>
@@ -4254,12 +4254,32 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-2">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to resolve <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-3">job promise</a> with <var>value</var> on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-3">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a> as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a>.</p>
+       <p>Let <var>convertedValue</var> be null.</p>
+      <li data-md="">
+       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-2">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-3">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to run the following substeps:</p>
+       <ol>
+        <li data-md="">
+         <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-7">job type</a> is either <em>register</em> or <em>update</em>, set <var>convertedValue</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-17">ServiceWorkerRegistration</a></code> object that represents <var>value</var>, in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-4">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
+        <li data-md="">
+         <p>Else, set <var>convertedValue</var> to <var>value</var>, in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-5">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
+        <li data-md="">
+         <p>Resolve <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-3">job promise</a> with <var>convertedValue</var>.</p>
+       </ol>
       <li data-md="">
        <p>For each <var>equivalentJob</var> in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-list-of-equivalent-jobs" id="ref-for-dfn-job-list-of-equivalent-jobs-2">list of equivalent jobs</a>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-4">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to resolve <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-4">job promise</a> with <var>value</var> on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-5">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a> as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a>.</p>
+         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-6">client</a> is null, continue to the next iteration of the loop.</p>
+        <li data-md="">
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-7">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to run the following substeps:</p>
+         <ol>
+          <li data-md="">
+           <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-8">job type</a> is either <em>register</em> or <em>update</em>, set <var>convertedValue</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-18">ServiceWorkerRegistration</a></code> object that represents <var>value</var>, in <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-8">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
+          <li data-md="">
+           <p>Else, set <var>convertedValue</var> to <var>value</var>, in <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-9">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
+          <li data-md="">
+           <p>Resolve <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-4">job promise</a> with <var>convertedValue</var>.</p>
+         </ol>
        </ol>
      </ol>
     </section>
@@ -4277,12 +4297,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-6">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to reject <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-5">job promise</a> with <var>reason</var> on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-7">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a> as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a>.</p>
+       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-5">job promise</a> with an exception that is a copy of <var>reason</var>, in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-12">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
       <li data-md="">
        <p>For each <var>equivalentJob</var> in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-list-of-equivalent-jobs" id="ref-for-dfn-job-list-of-equivalent-jobs-3">list of equivalent jobs</a>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-8">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a> to reject <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-6">job promise</a> with <var>reason</var> on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-9">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a> as the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a>.</p>
+         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-13">client</a> is null, continue to the next iteration of the loop:</p>
+        <li data-md="">
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-14">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-6">job promise</a> with an exception that is a copy of <var>reason</var>, in <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-15">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
        </ol>
      </ol>
     </section>
@@ -4306,7 +4328,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-1">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
-       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-4">script url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-4">script url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-16">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-2">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
@@ -4314,7 +4336,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-2">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
-       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-5">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-5">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-17">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-3">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
@@ -4334,7 +4356,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>If <var>newestWorker</var> is not null, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-5">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-3">script url</a> with the <em>exclude fragments flag</em> set, and <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-update-via-cache-mode" id="ref-for-dfn-job-update-via-cache-mode-2">update via cache mode</a>'s value equals <var>registration</var>’s <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache-3">update via cache mode</a>'s value, then:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-1">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-17">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
+           <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-1">Resolve Job Promise</a> with <var>job</var> and <var>registration</var>.</p>
           <li data-md="">
            <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-4">Finish Job</a> with <var>job</var> and abort these steps.</p>
          </ol>
@@ -4373,7 +4395,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>newestWorker</var> be the result of running <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-3">Get Newest Worker</a> algorithm passing <var>registration</var> as the argument.</p>
       <li data-md="">
-       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-7">job type</a> is <em>update</em>, and <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-4">script url</a> does not <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equal</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-6">script url</a> with the <em>exclude fragments flag</em> set, then:</p>
+       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-9">job type</a> is <em>update</em>, and <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-4">script url</a> does not <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equal</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-6">script url</a> with the <em>exclude fragments flag</em> set, then:</p>
        <ol>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-5">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</p>
@@ -4389,10 +4411,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <dl>
         <dt data-md="">"<code>classic</code>"
         <dd data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-12">client</a>, "<code>serviceworker</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-18">client</a>, "<code>serviceworker</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
         <dt data-md="">"<code>module</code>"
         <dd data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">Fetch a module worker script graph</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-13">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">Fetch a module worker script graph</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-19">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
        </dl>
        <p>To <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a> given <var>request</var>, run the following steps:</p>
        <ol>
@@ -4490,7 +4512,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>newestWorker</var> is not null, <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-5">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equals</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-11">script url</a> with the <em>exclude fragments flag</em> set, and <var>script</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-classic-script-source-text">source text</a> is a byte-for-byte match with <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-6">script resource</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-classic-script-source-text">source text</a>, if <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>, and <var>script</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-module-script-module-record">module record</a>'s [[ECMAScriptCode]] is a byte-for-byte match with <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-7">script resource</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-module-script-module-record">module record</a>'s [[ECMAScriptCode]] otherwise, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-2">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-18">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
+         <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-2">Resolve Job Promise</a> with <var>job</var> and <var>registration</var>.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-8">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4579,9 +4601,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p class="assertion">Assert: <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-7">job promise</a> is not null.</p>
       <li data-md="">
-       <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-3">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-19">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
+       <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-3">Resolve Job Promise</a> with <var>job</var> and <var>registration</var>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-39">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-15">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-89">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a> is <var>registration</var>.</p>
+       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-19">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-39">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-15">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-89">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a> is <var>registration</var>.</p>
       <li data-md="">
        <p>Let <var>installingWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-8">installing worker</a>.</p>
       <li data-md="">
@@ -5169,7 +5191,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-9">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-14">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-9">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-20">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-11">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
@@ -5310,7 +5332,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>Let <var>registrationObjects</var> be an array containing all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-21">ServiceWorkerRegistration</a></code> objects associated with <var>registration</var>.</p>
+       <p>Let <var>registrationObjects</var> be an array containing all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects associated with <var>registration</var>.</p>
       <li data-md="">
        <p>If <var>target</var> is "<code>installing</code>", then:</p>
        <ol>
@@ -5831,37 +5853,37 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <div class="example" id="example-bf118df6">
       <a class="self-link" href="#example-bf118df6"></a> Default scope: 
 <pre class="highlight"><span class="c1">// Maximum allowed scope defaults to the path the script sits in
-</span><span class="c1">// "/js" in this example
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">)</span><span class="p">.</span>then<span class="p">(</span><span class="p">(</span><span class="p">)</span> <span class="p">=></span> <span class="p">{</span>
-  console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Install succeeded with the default scope '/js'."</span><span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+// "/js" in this example
+</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">).</span>then<span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+  console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Install succeeded with the default scope '/js'."</span><span class="p">);</span>
+<span class="p">});</span>
 </pre>
      </div>
      <div class="example" id="example-76c5aa8b">
       <a class="self-link" href="#example-76c5aa8b"></a> Upper path without Service-Worker-Allowed header: 
 <pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location
-</span><span class="c1">// Response has no Service-Worker-Allowed header
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}</span><span class="p">)</span><span class="p">.</span><span class="k">catch</span><span class="p">(</span><span class="p">(</span><span class="p">)</span> <span class="p">=></span> <span class="p">{</span>
-  console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Install failed due to the path restriction violation."</span><span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+// Response has no Service-Worker-Allowed header
+</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+  console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Install failed due to the path restriction violation."</span><span class="p">);</span>
+<span class="p">});</span>
 </pre>
      </div>
      <div class="example" id="example-49d267fe">
       <a class="self-link" href="#example-49d267fe"></a> Upper path with Service-Worker-Allowed header: 
 <pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location
-</span><span class="c1">// Response included "Service-Worker-Allowed : /"
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}</span><span class="p">)</span><span class="p">.</span>then<span class="p">(</span><span class="p">(</span><span class="p">)</span> <span class="p">=></span> <span class="p">{</span>
-  console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Install succeeded as the max allowed scope was overriden to '/'."</span><span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+// Response included "Service-Worker-Allowed : /"
+</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span>then<span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+  console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Install succeeded as the max allowed scope was overriden to '/'."</span><span class="p">);</span>
+<span class="p">});</span>
 </pre>
      </div>
      <div class="example" id="example-7a18b25f">
       <a class="self-link" href="#example-7a18b25f"></a> A path restriction voliation even with Service-Worker-Allowed header: 
 <pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location
-</span><span class="c1">// Response included "Service-Worker-Allowed : /foo"
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/foo/bar/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}</span><span class="p">)</span><span class="p">.</span><span class="k">catch</span><span class="p">(</span><span class="p">(</span><span class="p">)</span> <span class="p">=></span> <span class="p">{</span>
-  console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Install failed as the scope is still out of the overriden maximum allowed scope."</span><span class="p">)</span><span class="p">;</span>
-<span class="p">}</span><span class="p">)</span><span class="p">;</span>
+// Response included "Service-Worker-Allowed : /foo"
+</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/foo/bar/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+  console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Install failed as the scope is still out of the overriden maximum allowed scope."</span><span class="p">);</span>
+<span class="p">});</span>
 </pre>
      </div>
     </section>
@@ -6509,7 +6531,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports">ports</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">realm</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">realm <small>(for environment settings object)</small></a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">realm <small>(for global object)</small></a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">realm execution context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-referrer-policy">referrer policy <small>(for WorkerGlobalScope)</small></a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-referrer-policy">referrer policy <small>(for environment settings object)</small></a>
@@ -7484,10 +7507,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworkerregistration-14">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-serviceworkerregistration-15">4.1.2. registration</a>
     <li><a href="#ref-for-serviceworkerregistration-16">7.1. Define API bound to Service Worker Registration</a>
-    <li><a href="#ref-for-serviceworkerregistration-17">Register</a>
-    <li><a href="#ref-for-serviceworkerregistration-18">Update</a>
-    <li><a href="#ref-for-serviceworkerregistration-19">Install</a> <a href="#ref-for-serviceworkerregistration-20">(2)</a>
-    <li><a href="#ref-for-serviceworkerregistration-21">Update Registration State</a>
+    <li><a href="#ref-for-serviceworkerregistration-17">Resolve Job Promise</a> <a href="#ref-for-serviceworkerregistration-18">(2)</a>
+    <li><a href="#ref-for-serviceworkerregistration-19">Install</a>
+    <li><a href="#ref-for-serviceworkerregistration-20">Update Registration State</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-serviceworkerupdateviacache">
@@ -8567,7 +8589,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-job-type-1">Appendix A: Algorithms</a>
     <li><a href="#ref-for-dfn-job-type-2">Create Job</a> <a href="#ref-for-dfn-job-type-3">(2)</a>
     <li><a href="#ref-for-dfn-job-type-4">Run Job</a> <a href="#ref-for-dfn-job-type-5">(2)</a> <a href="#ref-for-dfn-job-type-6">(3)</a>
-    <li><a href="#ref-for-dfn-job-type-7">Update</a>
+    <li><a href="#ref-for-dfn-job-type-7">Resolve Job Promise</a> <a href="#ref-for-dfn-job-type-8">(2)</a>
+    <li><a href="#ref-for-dfn-job-type-9">Update</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-scope-url">
@@ -8609,11 +8632,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dfn-job-client">#dfn-job-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-client-1">Create Job</a>
-    <li><a href="#ref-for-dfn-job-client-2">Resolve Job Promise</a> <a href="#ref-for-dfn-job-client-3">(2)</a> <a href="#ref-for-dfn-job-client-4">(3)</a> <a href="#ref-for-dfn-job-client-5">(4)</a>
-    <li><a href="#ref-for-dfn-job-client-6">Reject Job Promise</a> <a href="#ref-for-dfn-job-client-7">(2)</a> <a href="#ref-for-dfn-job-client-8">(3)</a> <a href="#ref-for-dfn-job-client-9">(4)</a>
-    <li><a href="#ref-for-dfn-job-client-10">Register</a> <a href="#ref-for-dfn-job-client-11">(2)</a>
-    <li><a href="#ref-for-dfn-job-client-12">Update</a> <a href="#ref-for-dfn-job-client-13">(2)</a>
-    <li><a href="#ref-for-dfn-job-client-14">Unregister</a>
+    <li><a href="#ref-for-dfn-job-client-2">Resolve Job Promise</a> <a href="#ref-for-dfn-job-client-3">(2)</a> <a href="#ref-for-dfn-job-client-4">(3)</a> <a href="#ref-for-dfn-job-client-5">(4)</a> <a href="#ref-for-dfn-job-client-6">(5)</a> <a href="#ref-for-dfn-job-client-7">(6)</a> <a href="#ref-for-dfn-job-client-8">(7)</a> <a href="#ref-for-dfn-job-client-9">(8)</a>
+    <li><a href="#ref-for-dfn-job-client-10">Reject Job Promise</a> <a href="#ref-for-dfn-job-client-11">(2)</a> <a href="#ref-for-dfn-job-client-12">(3)</a> <a href="#ref-for-dfn-job-client-13">(4)</a> <a href="#ref-for-dfn-job-client-14">(5)</a> <a href="#ref-for-dfn-job-client-15">(6)</a>
+    <li><a href="#ref-for-dfn-job-client-16">Register</a> <a href="#ref-for-dfn-job-client-17">(2)</a>
+    <li><a href="#ref-for-dfn-job-client-18">Update</a> <a href="#ref-for-dfn-job-client-19">(2)</a>
+    <li><a href="#ref-for-dfn-job-client-20">Unregister</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-promise">

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -3,7 +3,7 @@
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>Service Workers 1</title>
-  <link href="https://www.w3.org/StyleSheets/TR/W3C-ED" rel="stylesheet" type="text/css">
+  <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
 <style data-fill-with="stylesheet">/******************************************************************************
  *                   Style sheet for the W3C specifications                   *
  *
@@ -471,7 +471,7 @@
 		font-style: normal;
 	}
 	dt dfn code, code.idl {
-		font-size: normal;
+		font-size: medium;
 	}
 	dfn var {
 		font-style: normal;
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 78add57678334db281af36bf567919103e7c1e66" name="generator">
+  <meta content="Bikeshed version 6de62f723758889927d2dc5378f7d1e02a3563f7" name="generator">
   <link href="https://www.w3.org/TR/service-workers/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1425,7 +1425,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-29">29 June 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-30">30 June 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1817,9 +1817,9 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     <h2 class="heading settled" data-level="3" id="document-context"><span class="secno">3. </span><span class="content">Client Context</span><a class="self-link" href="#document-context"></a></h2>
     <div class="example" id="example-7e94092e">
      <a class="self-link" href="#example-7e94092e"></a> Bootstrapping with a service worker: 
-<pre class="highlight"><span class="c1">// scope defaults to the path the script sits in
-// "/" in this example
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/serviceworker.js"</span><span class="p">).</span>then<span class="p">(</span>registration <span class="p">=></span> <span class="p">{</span>
+<pre class="highlight"><span class="c1">// scope defaults to the path the script sits in</span>
+<span class="c1">// "/" in this example</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/serviceworker.js"</span><span class="p">).</span>then<span class="p">(</span>registration <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>log<span class="p">(</span><span class="s2">"success!"</span><span class="p">);</span>
   <span class="k">if</span> <span class="p">(</span>registration<span class="p">.</span>installing<span class="p">)</span> <span class="p">{</span>
     registration<span class="p">.</span>installing<span class="p">.</span>postMessage<span class="p">(</span><span class="s2">"Howdy from your installing page."</span><span class="p">);</span>
@@ -1857,8 +1857,8 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorker" data-dfn-type="attribute" data-export="" id="dom-serviceworker-scripturl"><code><code>scriptURL</code></code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-43">service worker</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-1">script url</a>.</p>
       <div class="example" id="example-3ff1f346">
        <a class="self-link" href="#example-3ff1f346"></a> For example, consider a document created by a navigation to <code>https://example.com/app.html</code> which <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-4">matches</a> via the following registration call which has been previously executed: 
-<pre class="highlight"><span class="c1">// Script on the page https://example.com/app.html
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/service_worker.js"</span><span class="p">);</span>
+<pre class="highlight"><span class="c1">// Script on the page https://example.com/app.html</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/service_worker.js"</span><span class="p">);</span>
 </pre>
        <p>The value of <code>navigator.serviceWorker.controller.scriptURL</code> will be "<code>https://example.com/service_worker.js</code>".</p>
       </div>
@@ -2298,14 +2298,14 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     <h2 class="heading settled" data-level="4" id="execution-context"><span class="secno">4. </span><span class="content">Execution Context</span><a class="self-link" href="#execution-context"></a></h2>
     <div class="example" id="example-744d6b8b">
      <a class="self-link" href="#example-744d6b8b"></a> Serving Cached Resources: 
-<pre class="highlight"><span class="c1">// caching.js
-</span>self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"install"</span><span class="p">,</span> event <span class="p">=></span> <span class="p">{</span>
+<pre class="highlight"><span class="c1">// caching.js</span>
+<span class="c1"></span>self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"install"</span><span class="p">,</span> event <span class="p">=></span> <span class="p">{</span>
   event<span class="p">.</span>waitUntil<span class="p">(</span>
-    <span class="c1">// Open a cache of resources.
-</span>    caches<span class="p">.</span>open<span class="p">(</span><span class="s2">"shell-v1"</span><span class="p">).</span>then<span class="p">(</span>cache <span class="p">=></span> <span class="p">{</span>
-      <span class="c1">// Begins the process of fetching them.
-</span>      <span class="c1">// The coast is only clear when all the resources are ready.
-</span>      <span class="k">return</span> cache<span class="p">.</span>addAll<span class="p">([</span>
+    <span class="c1">// Open a cache of resources.</span>
+<span class="c1"></span>    caches<span class="p">.</span>open<span class="p">(</span><span class="s2">"shell-v1"</span><span class="p">).</span>then<span class="p">(</span>cache <span class="p">=></span> <span class="p">{</span>
+      <span class="c1">// Begins the process of fetching them.</span>
+<span class="c1"></span>      <span class="c1">// The coast is only clear when all the resources are ready.</span>
+<span class="c1"></span>      <span class="k">return</span> cache<span class="p">.</span>addAll<span class="p">([</span>
         <span class="s2">"/app.html"</span><span class="p">,</span>
         <span class="s2">"/assets/v1/base.css"</span><span class="p">,</span>
         <span class="s2">"/assets/v1/app.js"</span><span class="p">,</span>
@@ -2317,12 +2317,12 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
 <span class="p">});</span>
 
 self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"fetch"</span><span class="p">,</span> event <span class="p">=></span> <span class="p">{</span>
-  <span class="c1">// No "fetch" events are dispatched to the service worker until it
-</span>  <span class="c1">// successfully installs and activates.
-</span>
-  <span class="c1">// All operations on caches are async, including matching URLs, so we use
-</span>  <span class="c1">// promises heavily. e.respondWith() even takes promises to enable this:
-</span>  event<span class="p">.</span>respondWith<span class="p">(</span>
+  <span class="c1">// No "fetch" events are dispatched to the service worker until it</span>
+<span class="c1"></span>  <span class="c1">// successfully installs and activates.</span>
+<span class="c1"></span>
+  <span class="c1">// All operations on caches are async, including matching URLs, so we use</span>
+<span class="c1"></span>  <span class="c1">// promises heavily. e.respondWith() even takes promises to enable this:</span>
+<span class="c1"></span>  event<span class="p">.</span>respondWith<span class="p">(</span>
     caches<span class="p">.</span>match<span class="p">(</span>e<span class="p">.</span>request<span class="p">).</span>then<span class="p">(</span>response <span class="p">=></span> <span class="p">{</span>
       <span class="k">return</span> response <span class="o">||</span> fetch<span class="p">(</span>e<span class="p">.</span>request<span class="p">);</span>
     <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
@@ -4290,21 +4290,21 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-22">job</a></p>
       <dd data-md="">
-       <p><var>errorName</var>, a string</p>
+       <p><var>errorData</var>, the information necessary to <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">create an exception</a></p>
       <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-5">job promise</a> with a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">new</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a> with <var>errorName</var> and a user agent-defined <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-message">message</a>.</p>
+       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-5">job promise</a> with a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">new</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a> with <var>errorData</var> and a user agent-defined <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-message">message</a>, in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-12">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
       <li data-md="">
        <p>For each <var>equivalentJob</var> in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-list-of-equivalent-jobs" id="ref-for-dfn-job-list-of-equivalent-jobs-3">list of equivalent jobs</a>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-12">client</a> is null, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
+         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-13">client</a> is null, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-13">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-6">job promise</a> with a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">new</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a> with <var>errorName</var> and a user agent-defined <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-message">message</a>.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-14">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-6">job promise</a> with a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">new</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a> with <var>errorData</var> and a user agent-defined <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-message">message</a>, in <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-15">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
        </ol>
      </ol>
     </section>
@@ -4323,23 +4323,23 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If the result of running <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin">potentially trustworthy origin</a> with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-3">script url</a> as the argument is <code>Not Trusted</code>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-1">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-1">Reject Job Promise</a> with <var>job</var> and "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" DOMException.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-1">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
-       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-4">script url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-14">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-4">script url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-16">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-2">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-2">Reject Job Promise</a> with <var>job</var> and "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" DOMException.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-2">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
-       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-5">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-15">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-5">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-17">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-3">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-3">Reject Job Promise</a> with <var>job</var> and "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" DOMException.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-3">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4388,7 +4388,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-5">uninstalling flag</a> is set, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-4">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-4">Reject Job Promise</a> with <var>job</var> and <code>TypeError</code>.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-5">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4398,7 +4398,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-9">job type</a> is <em>update</em>, and <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-4">script url</a> does not <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equal</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-6">script url</a> with the <em>exclude fragments flag</em> set, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-5">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-5">Reject Job Promise</a> with <var>job</var> and <code>TypeError</code>.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-6">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4411,10 +4411,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <dl>
         <dt data-md="">"<code>classic</code>"
         <dd data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-16">client</a>, "<code>serviceworker</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-18">client</a>, "<code>serviceworker</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
         <dt data-md="">"<code>module</code>"
         <dd data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">Fetch a module worker script graph</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-17">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">Fetch a module worker script graph</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-19">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
        </dl>
        <p>To <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a> given <var>request</var>, run the following steps:</p>
        <ol>
@@ -4444,7 +4444,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">Extract a MIME type</a> from the <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#javascript-mime-type">JavaScript MIME type</a>, then:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-6">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
+           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-6">Reject Job Promise</a> with <var>job</var> and "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" DOMException.</p>
           <li data-md="">
            <p>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
          </ol>
@@ -4487,7 +4487,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Else:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-7">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
+           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-7">Reject Job Promise</a> with <var>job</var> and "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" DOMException.</p>
           <li data-md="">
            <p>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
          </ol>
@@ -4500,8 +4500,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If the algorithm asynchronously completes with null, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-8">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
-         <p class="note" role="note"><span>Note:</span> This will do nothing if <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-9">Reject Job Promise</a> was previously invoked with "<code>SecurityError</code>".</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-8">Reject Job Promise</a> with <var>job</var> and <code>TypeError</code>.</p>
+         <p class="note" role="note"><span>Note:</span> This will do nothing if <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-9">Reject Job Promise</a> was previously invoked with "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" DOMException.</p>
         <li data-md="">
          <p>If <var>newestWorker</var> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-1">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
         <li data-md="">
@@ -4535,7 +4535,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>If an uncaught runtime script error occurs during the above step, then:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-10">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
+           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-10">Reject Job Promise</a> with <var>job</var> and <code>TypeError</code>.</p>
           <li data-md="">
            <p>If <var>newestWorker</var> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-2">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
           <li data-md="">
@@ -5191,10 +5191,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-9">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-18">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-9">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-20">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-11">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-11">Reject Job Promise</a> with <var>job</var> and "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" DOMException.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-12">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -5852,36 +5852,36 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <div class="example" id="example-bf118df6">
       <a class="self-link" href="#example-bf118df6"></a> Default scope: 
-<pre class="highlight"><span class="c1">// Maximum allowed scope defaults to the path the script sits in
-// "/js" in this example
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">).</span>then<span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+<pre class="highlight"><span class="c1">// Maximum allowed scope defaults to the path the script sits in</span>
+<span class="c1">// "/js" in this example</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">).</span>then<span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Install succeeded with the default scope '/js'."</span><span class="p">);</span>
 <span class="p">});</span>
 </pre>
      </div>
      <div class="example" id="example-76c5aa8b">
       <a class="self-link" href="#example-76c5aa8b"></a> Upper path without Service-Worker-Allowed header: 
-<pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location
-// Response has no Service-Worker-Allowed header
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+<pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location</span>
+<span class="c1">// Response has no Service-Worker-Allowed header</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Install failed due to the path restriction violation."</span><span class="p">);</span>
 <span class="p">});</span>
 </pre>
      </div>
      <div class="example" id="example-49d267fe">
       <a class="self-link" href="#example-49d267fe"></a> Upper path with Service-Worker-Allowed header: 
-<pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location
-// Response included "Service-Worker-Allowed : /"
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span>then<span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+<pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location</span>
+<span class="c1">// Response included "Service-Worker-Allowed : /"</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span>then<span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Install succeeded as the max allowed scope was overriden to '/'."</span><span class="p">);</span>
 <span class="p">});</span>
 </pre>
      </div>
      <div class="example" id="example-7a18b25f">
       <a class="self-link" href="#example-7a18b25f"></a> A path restriction voliation even with Service-Worker-Allowed header: 
-<pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location
-// Response included "Service-Worker-Allowed : /foo"
-</span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/foo/bar/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
+<pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location</span>
+<span class="c1">// Response included "Service-Worker-Allowed : /foo"</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/foo/bar/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Install failed as the scope is still out of the overriden maximum allowed scope."</span><span class="p">);</span>
 <span class="p">});</span>
 </pre>
@@ -5938,6 +5938,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     be easy to understand and are not intended to be performant. Implementers
     are encouraged to optimize.</p>
   </div>
+  <p id="back-to-top" role="navigation"><a href="#toc"><abbr title="Back to top">↑</abbr></a></p>
+  . 
 <script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
@@ -8636,10 +8638,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-job-client-1">Create Job</a>
     <li><a href="#ref-for-dfn-job-client-2">Resolve Job Promise</a> <a href="#ref-for-dfn-job-client-3">(2)</a> <a href="#ref-for-dfn-job-client-4">(3)</a> <a href="#ref-for-dfn-job-client-5">(4)</a> <a href="#ref-for-dfn-job-client-6">(5)</a> <a href="#ref-for-dfn-job-client-7">(6)</a> <a href="#ref-for-dfn-job-client-8">(7)</a> <a href="#ref-for-dfn-job-client-9">(8)</a>
-    <li><a href="#ref-for-dfn-job-client-10">Reject Job Promise</a> <a href="#ref-for-dfn-job-client-11">(2)</a> <a href="#ref-for-dfn-job-client-12">(3)</a> <a href="#ref-for-dfn-job-client-13">(4)</a>
-    <li><a href="#ref-for-dfn-job-client-14">Register</a> <a href="#ref-for-dfn-job-client-15">(2)</a>
-    <li><a href="#ref-for-dfn-job-client-16">Update</a> <a href="#ref-for-dfn-job-client-17">(2)</a>
-    <li><a href="#ref-for-dfn-job-client-18">Unregister</a>
+    <li><a href="#ref-for-dfn-job-client-10">Reject Job Promise</a> <a href="#ref-for-dfn-job-client-11">(2)</a> <a href="#ref-for-dfn-job-client-12">(3)</a> <a href="#ref-for-dfn-job-client-13">(4)</a> <a href="#ref-for-dfn-job-client-14">(5)</a> <a href="#ref-for-dfn-job-client-15">(6)</a>
+    <li><a href="#ref-for-dfn-job-client-16">Register</a> <a href="#ref-for-dfn-job-client-17">(2)</a>
+    <li><a href="#ref-for-dfn-job-client-18">Update</a> <a href="#ref-for-dfn-job-client-19">(2)</a>
+    <li><a href="#ref-for-dfn-job-client-20">Unregister</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-promise">

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version bab6032cf8759f7d2fb1341d02aa48484a5a3187" name="generator">
+  <meta content="Bikeshed version 78add57678334db281af36bf567919103e7c1e66" name="generator">
   <link href="https://www.w3.org/TR/service-workers/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1425,7 +1425,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-26">26 June 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-29">29 June 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -4290,21 +4290,21 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-22">job</a></p>
       <dd data-md="">
-       <p><var>reason</var>, an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a></p>
+       <p><var>errorName</var>, a string</p>
       <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-5">job promise</a> with an exception that is a copy of <var>reason</var>, in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-12">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
+       <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a> is not null, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>, on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-5">job promise</a> with a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">new</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a> with <var>errorName</var> and a user agent-defined <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-message">message</a>.</p>
       <li data-md="">
        <p>For each <var>equivalentJob</var> in <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-list-of-equivalent-jobs" id="ref-for-dfn-job-list-of-equivalent-jobs-3">list of equivalent jobs</a>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-13">client</a> is null, continue to the next iteration of the loop:</p>
+         <p>If <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-12">client</a> is null, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-14">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-6">job promise</a> with an exception that is a copy of <var>reason</var>, in <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-15">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">Realm</a>.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a>, on <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-13">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> using the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>, to reject <var>equivalentJob</var>’s <a data-link-type="dfn" href="#dfn-job-promise" id="ref-for-dfn-job-promise-6">job promise</a> with a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-exception">new</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a> with <var>errorName</var> and a user agent-defined <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception-message">message</a>.</p>
        </ol>
      </ol>
     </section>
@@ -4323,23 +4323,23 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If the result of running <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin">potentially trustworthy origin</a> with the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-3">script url</a> as the argument is <code>Not Trusted</code>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-1">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-1">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-1">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
-       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-4">script url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-16">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-4">script url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-14">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-2">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-2">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-2">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
-       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-5">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-17">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-5">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-15">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-3">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-3">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-3">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4388,7 +4388,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-5">uninstalling flag</a> is set, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-4">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-4">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-5">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4398,7 +4398,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-9">job type</a> is <em>update</em>, and <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-4">script url</a> does not <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals">equal</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-6">script url</a> with the <em>exclude fragments flag</em> set, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-5">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-5">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-6">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -4411,10 +4411,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <dl>
         <dt data-md="">"<code>classic</code>"
         <dd data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-18">client</a>, "<code>serviceworker</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-16">client</a>, "<code>serviceworker</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
         <dt data-md="">"<code>module</code>"
         <dd data-md="">
-         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">Fetch a module worker script graph</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-19">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
+         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">Fetch a module worker script graph</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-17">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
        </dl>
        <p>To <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a> given <var>request</var>, run the following steps:</p>
        <ol>
@@ -4444,7 +4444,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">Extract a MIME type</a> from the <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#javascript-mime-type">JavaScript MIME type</a>, then:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-6">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
+           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-6">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
           <li data-md="">
            <p>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
          </ol>
@@ -4487,7 +4487,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Else:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-7">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
+           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-7">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
           <li data-md="">
            <p>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
          </ol>
@@ -4500,8 +4500,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If the algorithm asynchronously completes with null, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-8">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</p>
-         <p class="note" role="note"><span>Note:</span> This will do nothing if <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-9">Reject Job Promise</a> was previously invoked with a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-8">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
+         <p class="note" role="note"><span>Note:</span> This will do nothing if <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-9">Reject Job Promise</a> was previously invoked with "<code>SecurityError</code>".</p>
         <li data-md="">
          <p>If <var>newestWorker</var> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-1">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
         <li data-md="">
@@ -4535,7 +4535,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>If an uncaught runtime script error occurs during the above step, then:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-10">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</p>
+           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-10">Reject Job Promise</a> with <var>job</var> and "<code>TypeError</code>".</p>
           <li data-md="">
            <p>If <var>newestWorker</var> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-2">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
           <li data-md="">
@@ -5191,10 +5191,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-9">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-20">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-9">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-18">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-11">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-11">Reject Job Promise</a> with <var>job</var> and "<code>SecurityError</code>".</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-12">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
@@ -6570,6 +6570,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://infra.spec.whatwg.org/#set-append">append</a>
      <li><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ascii case-insensitive</a>
      <li><a href="https://infra.spec.whatwg.org/#list-contain">contain</a>
+     <li><a href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>
      <li><a href="https://infra.spec.whatwg.org/#map-exists">exist</a>
      <li><a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
      <li><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">get the keys</a>
@@ -6654,8 +6655,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://heycam.github.io/webidl/#securityerror">SecurityError</a>
      <li><a href="https://heycam.github.io/webidl/#idl-USVString">USVString</a>
      <li><a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>
+     <li><a href="https://heycam.github.io/webidl/#dfn-create-exception">created</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-exception">exception</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-frozen-array-type">frozen array type</a>
+     <li><a href="https://heycam.github.io/webidl/#dfn-exception-message">message</a>
      <li><a href="https://heycam.github.io/webidl/#idl-object">object</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-partial-interface">partial interface</a>
      <li><a href="https://heycam.github.io/webidl/#dfn-present">present</a>
@@ -8633,10 +8636,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-job-client-1">Create Job</a>
     <li><a href="#ref-for-dfn-job-client-2">Resolve Job Promise</a> <a href="#ref-for-dfn-job-client-3">(2)</a> <a href="#ref-for-dfn-job-client-4">(3)</a> <a href="#ref-for-dfn-job-client-5">(4)</a> <a href="#ref-for-dfn-job-client-6">(5)</a> <a href="#ref-for-dfn-job-client-7">(6)</a> <a href="#ref-for-dfn-job-client-8">(7)</a> <a href="#ref-for-dfn-job-client-9">(8)</a>
-    <li><a href="#ref-for-dfn-job-client-10">Reject Job Promise</a> <a href="#ref-for-dfn-job-client-11">(2)</a> <a href="#ref-for-dfn-job-client-12">(3)</a> <a href="#ref-for-dfn-job-client-13">(4)</a> <a href="#ref-for-dfn-job-client-14">(5)</a> <a href="#ref-for-dfn-job-client-15">(6)</a>
-    <li><a href="#ref-for-dfn-job-client-16">Register</a> <a href="#ref-for-dfn-job-client-17">(2)</a>
-    <li><a href="#ref-for-dfn-job-client-18">Update</a> <a href="#ref-for-dfn-job-client-19">(2)</a>
-    <li><a href="#ref-for-dfn-job-client-20">Unregister</a>
+    <li><a href="#ref-for-dfn-job-client-10">Reject Job Promise</a> <a href="#ref-for-dfn-job-client-11">(2)</a> <a href="#ref-for-dfn-job-client-12">(3)</a> <a href="#ref-for-dfn-job-client-13">(4)</a>
+    <li><a href="#ref-for-dfn-job-client-14">Register</a> <a href="#ref-for-dfn-job-client-15">(2)</a>
+    <li><a href="#ref-for-dfn-job-client-16">Update</a> <a href="#ref-for-dfn-job-client-17">(2)</a>
+    <li><a href="#ref-for-dfn-job-client-18">Unregister</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-promise">


### PR DESCRIPTION
This changes Resolve Job Promise algorithm to use a right value for
equivalent job promises by specifying the value should be the one for
its relevant Realm.

Fixes #829.