### PR TITLE
Improve Activate with Try Activate

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -168,7 +168,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A [=/service worker=] has an associated <dfn export id="dfn-set-of-event-types-to-handle">set of event types to handle</dfn> (a [=ordered set|set=]) whose [=item=] is an <a>event listener</a>'s event type. It is initially an empty set.
 
-    A [=/service worker=] has an associated <dfn export id="dfn-set-of-extended-events">set of extended events</dfn> (a [=ordered set|set=]) whose [=item=] is an [=event=]. It is initially an empty set.
+    A [=/service worker=] has an associated <dfn export id="dfn-set-of-extended-events">set of extended events</dfn> (a [=ordered set|set=]) whose [=item=] is an {{ExtendableEvent}}. It is initially an empty set.
 
     A [=/service worker=] has an associated <dfn export id="dfn-foreign-fetch-scopes">list of foreign fetch scopes</dfn> whose element type is a [=/URL=]. It is initially empty.
 
@@ -2701,7 +2701,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       1. Let |installFailed| be false.
       1. Let |newestWorker| be the result of running <a>Get Newest Worker</a> algorithm passing |registration| as its argument.
-      1. Let |redundantWorker| be null.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and |worker| as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>installing worker</a> and *installing* as the arguments.
       1. Assert: |job|'s [=job/job promise=] is not null.
@@ -2722,19 +2721,17 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Wait for |task| to have executed or been discarded.
       1. Wait for the step labeled *WaitForAsynchronousExtensions* to complete.
       1. If |installFailed| is true, then:
-          1. Set |redundantWorker| to |registration|'s <a>installing worker</a>.
+          1. Run the <a>Update Worker State</a> algorithm passing |registration|'s [=installing worker=] and *redundant* as the arguments.
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and null as the arguments.
-          1. Run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
           1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Set |registration|'s <a>installing worker</a>'s <a>imported scripts updated flag</a>.
       1. If |registration|'s <a>waiting worker</a> is not null, then:
-          1. Set |redundantWorker| to |registration|'s <a>waiting worker</a>.
-          1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
+          1. [=Terminate Service Worker|Terminate=] |registration|'s [=waiting worker=].
+          1. Run the [=Update Worker State=] algorithm passing |registration|'s [=waiting worker=] and *redundant* as the arguments.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>waiting</code>" and |registration|'s <a>installing worker</a> as the arguments.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and null as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>waiting worker</a> and *installed* as the arguments.
-      1. If |redundantWorker| is not null, run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. Invoke <a>Finish Job</a> with |job|.
       1. Wait for all the <a>tasks</a> <a lt="queue a task">queued</a> by <a>Update Worker State</a> invoked in this algorithm have executed.
       1. Invoke [=Try Activate=] with |registration|.
@@ -2751,15 +2748,15 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: None
 
       1. If |registration|'s <a>waiting worker</a> is null, abort these steps.
-      1. Let |redundantWorker| be null.
-      1. If |registration|'s [=active worker=] is not null, |redundantWorker| be |registration|'s [=active worker=].
+      1. If |registration|'s [=active worker=] is not null, then:
+          1. [=Terminate Service Worker|Terminate=] |registration|'s [=active worker=].
+          1. Run the [=Update Worker State=] algorithm passing |registration|'s [=active worker=] and *redundant* as the arguments.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>active</code>" and |registration|'s <a>waiting worker</a> as the arguments.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>waiting</code>" and null as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>active worker</a> and *activating* as the arguments.
 
           Note: Once an active worker is activating, neither a runtime script error nor a force termination of the active worker prevents the active worker from getting activated.
 
-      1. If |redundantWorker| is not null, run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. For each [=/service worker client=] |client| whose <a>creation URL</a> <a lt="Match Service Worker Registration">matches</a> |registration|'s [=service worker registration/scope url=]:
           1. If |client| is a <a>window client</a>, unassociate |client|'s <a>responsible document</a> from its <a>application cache</a>, if it has one.
           1. Else if |client| is a <a>shared worker client</a>, unassociate |client|'s [=environment settings object/global object=] from its <a>application cache</a>, if it has one.
@@ -2789,8 +2786,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: None
 
-      1. Assert: |registration|'s [=waiting worker=] is not null.
-      1. If |registration|'s [=active worker=] is null, or if the result of running [=Service Worker Has No Pending Events=] with |registration|'s [=active worker=] is true, and no [=/service worker client=] is [=using=] |registration| or |registration|’s [=waiting worker=]'s [=skip waiting flag=] is set, then invoke [=Activate=] with |registration|.
+      1. If |registration|'s [=waiting worker=] is null, return.
+      1. Invoke [=Activate=] with |registration| if either of the following is true:
+        * |registration|'s [=active worker=] is null.
+        * The result of running [=Service Worker Has No Pending Events=] with |registration|’s [=active worker=] is true, and no [=/service worker client=] is [=using=] |registration| or |registration|’s [=waiting worker=]'s [=skip waiting flag=] is set.
   </section>
 
   <section algorithm>
@@ -2865,6 +2864,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If |serviceWorker| is not running, abort these steps.
       1. Let |serviceWorkerGlobalScope| be |serviceWorker|'s [=service worker/global object=].
       1. Set |serviceWorkerGlobalScope|'s closing flag to true.
+      1. [=set/Remove=] all the [=items=] from |serviceWorker|'s [=set of extended events=].
       1. If there are any <a>tasks</a>, whose <a>task source</a> is either the <a>handle fetch task source</a> or the <a>handle functional event task source</a>, queued in |serviceWorkerGlobalScope|'s <a>event loop</a>'s [=/task queues=], <a lt="queue a task">queue</a> them to |serviceWorker|'s <a>containing service worker registration</a>'s corresponding [=service worker registration/task queues=] in the same order using their original <a>task sources</a>, and discard all the <a>tasks</a> (including <a>tasks</a> whose <a>task source</a> is neither the <a>handle fetch task source</a> nor the <a>handle functional event task source</a>) from |serviceWorkerGlobalScope|'s <a>event loop</a>'s [=/task queues=] without processing them.
 
           Note: This effectively means that the fetch events and the other functional events such as push events are backed up by the registration's task queues while the other tasks including message events are discarded.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -168,6 +168,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A [=/service worker=] has an associated <dfn export id="dfn-set-of-event-types-to-handle">set of event types to handle</dfn> (a [=ordered set|set=]) whose [=item=] is an <a>event listener</a>'s event type. It is initially an empty set.
 
+    A [=/service worker=] has an associated <dfn export id="dfn-set-of-extended-events">set of extended events</dfn> (a [=ordered set|set=]) whose [=item=] is an [=event=]. It is initially an empty set.
+
     A [=/service worker=] has an associated <dfn export id="dfn-foreign-fetch-scopes">list of foreign fetch scopes</dfn> whose element type is a [=/URL=]. It is initially empty.
 
     A [=/service worker=] has an associated <dfn export id="dfn-foreign-fetch-origins">list of foreign fetch origins</dfn> whose element type is a [=/URL=]. It is initially empty.
@@ -364,6 +366,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             1. Else, let it be initialized to a new {{Client}} object that represents the worker associated with |incumbentGlobal|.
             1. Let the {{ExtendableMessageEvent/ports}} attribute of |e| be initialized to |newPorts|.
             1. <a>Dispatch</a> |e| at |destination|.
+            1. Invoke [=Update Service Worker Extended Events Set=] with |serviceWorker| and |e|.
 
             The <a>task</a> *must* use the <a>DOM manipulation task source</a>.
     </section>
@@ -903,7 +906,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
         1. Let |promise| be a new <a>promise</a>.
         1. Run the following substeps <a>in parallel</a>:
-            1. Set [=/service worker=]'s <a>skip waiting flag</a>.
+            1. Set [=ServiceWorkerGlobalScope/service worker=]'s <a>skip waiting flag</a>.
+            1. Invoke [=Try Activate=] with [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
             1. Resolve |promise| with undefined.
         1. Return |promise|.
     </section>
@@ -1313,11 +1317,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             Note: If no lifetime extension promise has been added in the task that called the event handlers), calling {{ExtendableEvent/waitUntil()}} in subsequent asynchronous tasks will throw.
 
         1. Add |f| to the [=ExtendableEvent/extend lifetime promises=].
-        1. Increase the [=ExtendableEvent/pending promises count=] by one.
+        1. Increment the [=ExtendableEvent/pending promises count=] by one.
 
-            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done in the microtask queued by the reaction to the promise.
+            Note: The [=ExtendableEvent/pending promises count=] is incremented even if the given promise has already been settled. The corresponding count decrement is done in the microtask queued by the reaction to the promise.
 
-        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |f|, [=queue a microtask=] to decrease the [=ExtendableEvent/pending promises count=] by one.
+        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |f|, [=queue a microtask=] to run these substeps:
+            1. Decrement the [=ExtendableEvent/pending promises count=] by one.
+            1. Invoke [=Try Activate=] with the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
 
         The user agent *should not* <a lt="terminate service worker">terminate</a> the [=/service worker=] associated with |event|'s <a>relevant settings object</a>'s [=environment settings object/global object=] when |event|'s [=dispatch flag=] is set or |event|'s [=ExtendableEvent/pending promises count=] is not zero. However, the user agent *may* impose a time limit to this lifetime extension.
     </section>
@@ -1462,11 +1468,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             1. <a>Throw</a> an "{{InvalidStateError}}" exception.
             1. Abort these steps.
         1. Add |r| to the <a>extend lifetime promises</a>.
-        1. Increase the [=ExtendableEvent/pending promises count=] by one.
+        1. Increment the [=ExtendableEvent/pending promises count=] by one.
 
-            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done in the microtask queued by the reaction to the promise.
+            Note: The [=ExtendableEvent/pending promises count=] is incremented even if the given promise has already been settled. The corresponding count decrement is done in the microtask queued by the reaction to the promise.
 
-        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |r|, [=queue a microtask=] to decrease the [=ExtendableEvent/pending promises count=] by one.
+        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |r|, [=queue a microtask=] to run these substeps:
+            1. Decrement the [=ExtendableEvent/pending promises count=] by one.
+            1. Invoke [=Try Activate=] with the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
 
             Note: {{FetchEvent/respondWith(r)|event.respondWith(r)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(r)}} is called.
 
@@ -1578,11 +1586,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             1. <a>Throw</a> an "{{InvalidStateError}}" exception.
             1. Abort these steps.
         1. Add |r| to the <a>extend lifetime promises</a>.
-        1. Increase the [=ExtendableEvent/pending promises count=] by one.
+        1. Increment the [=ExtendableEvent/pending promises count=] by one.
 
-            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done in the microtask queued by the reaction to the promise.
+            Note: The [=ExtendableEvent/pending promises count=] is incremented even if the given promise has already been settled. The corresponding count decrement is done in the microtask queued by the reaction to the promise.
 
-        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |r|, [=queue a microtask=] to decrease the [=ExtendableEvent/pending promises count=] by one.
+        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |r|, [=queue a microtask=] to run these substeps:
+            1. Decrement the [=ExtendableEvent/pending promises count=] by one.
+            1. Invoke [=Try Activate=] with the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
 
             Note: {{ForeignFetchEvent/respondWith(r)|event.respondWith(r)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(r)}} is called.
 
@@ -2721,15 +2731,15 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If |registration|'s <a>waiting worker</a> is not null, then:
           1. Set |redundantWorker| to |registration|'s <a>waiting worker</a>.
           1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
-          1. The user agent *may* abort in-flight requests triggered by |redundantWorker|.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>waiting</code>" and |registration|'s <a>installing worker</a> as the arguments.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and null as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>waiting worker</a> and *installed* as the arguments.
       1. If |redundantWorker| is not null, run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. Invoke <a>Finish Job</a> with |job|.
       1. Wait for all the <a>tasks</a> <a lt="queue a task">queued</a> by <a>Update Worker State</a> invoked in this algorithm have executed.
-      1. Wait until no [=/service worker client=] is <a>using</a> |registration| or |registration|'s <a>waiting worker</a>'s <a>skip waiting flag</a> is set.
-      1. If |registration|'s <a>waiting worker</a> is not null, invoke <a>Activate</a> algorithm with |registration| as its argument.
+      1. Invoke [=Try Activate=] with |registration|.
+
+          Note: If [=Try Activate=] does not trigger [=Activate=] here, [=Activate=] is tried again when the last client controlled by the existing [=active worker=] is [=Handle Service Worker Client Unload|unloaded=], {{ServiceWorkerGlobalScope/skipWaiting()}} is asynchronously called, and the [=extend lifetime promises=] for the existing [=active worker=] settle.
   </section>
 
   <section algorithm>
@@ -2742,10 +2752,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       1. If |registration|'s <a>waiting worker</a> is null, abort these steps.
       1. Let |redundantWorker| be null.
-      1. If |registration|'s <a>active worker</a> is not null, then:
-          1. Set |redundantWorker| to |registration|'s <a>active worker</a>.
-          1. Wait for |redundantWorker| to finish handling any in-progress requests.
-          1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
+      1. If |registration|'s [=active worker=] is not null, |redundantWorker| be |registration|'s [=active worker=].
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>active</code>" and |registration|'s <a>waiting worker</a> as the arguments.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>waiting</code>" and null as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>active worker</a> and *activating* as the arguments.
@@ -2772,6 +2779,18 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Wait for |task| to have executed or been discarded, or the script to have been aborted by the <a lt="terminate service worker">termination</a> of |activeWorker|.
       1. Wait for the step labeled *WaitForAsynchronousExtensions* to complete.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>active worker</a> and *activated* as the arguments.
+  </section>
+
+  <section algorithm>
+    <h3 id="try-activate-algorithm"><dfn>Try Activate</dfn></h3>
+
+      : Input
+      :: |registration|, a [=/service worker registration=]
+      : Output
+      :: None
+
+      1. Assert: |registration|'s [=waiting worker=] is not null.
+      1. If |registration|'s [=active worker=] is null, or if the result of running [=Service Worker Has No Pending Events=] with |registration|'s [=active worker=] is true, and no [=/service worker client=] is [=using=] |registration| or |registration|’s [=waiting worker=]'s [=skip waiting flag=] is set, then invoke [=Activate=] with |registration|.
   </section>
 
   <section algorithm>
@@ -2934,6 +2953,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. If |request| is a <a>navigation request</a>, initialize |e|'s {{FetchEvent/targetClientId}} attribute to |request|'s [=request/target client id=], and to the empty string otherwise.
           1. Let the {{FetchEvent/isReload}} attribute of |e| be initialized to <code>true</code> if |request|'s [=request/client=] is a <a>window client</a> and the event was dispatched with the user's intention for the page reload, and <code>false</code> otherwise.
           1. <a>Dispatch</a> |e| at |activeWorker|'s [=service worker/global object=].
+          1. Invoke [=Update Service Worker Extended Events Set=] with |activeWorker| and |e|.
           1. If |e|'s [=FetchEvent/respond-with entered flag=] is set, set |respondWithEntered| to true.
           1. If |e|'s [=FetchEvent/wait to respond flag=] is set, then:
               1. Wait until |e|'s [=FetchEvent/wait to respond flag=] is unset.
@@ -2997,6 +3017,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Initialize |e|’s {{ForeignFetchEvent/request}} attribute to |r|.
           1. Initialize |e|’s {{ForeignFetchEvent/origin}} attribute to the  <a lt="Unicode serialization of an origin">Unicode serialization</a> of |request|'s [=request/origin=].
           1. <a>Dispatch</a> |e| at |activeWorker|'s [=service worker/global object=].
+          1. Invoke [=Update Service Worker Extended Events Set=] with |activeWorker| and |e|.
           1. If |e|'s [=ForeignFetchEvent/respond-with entered flag=] is set, set |respondWithEntered| to true.
           1. If |e|'s <a>wait to respond flag</a> is set, wait until |e|'s <a>wait to respond flag</a> is unset.
           1. Let |internalResponse| be |e|'s [=ForeignFetchEvent/potential response=].
@@ -3058,6 +3079,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Invoke <a>Run Service Worker</a> algorithm with |activeWorker| as the argument.
       1. <a>Queue a task</a> |task| to run these substeps:
           1. Invoke |callbackSteps| with |activeWorker|'s [=service worker/global object=] as its argument.
+          1. Invoke [=Update Service Worker Extended Events Set=] with |activeWorker| and |event|.
 
           The |task| *must* use |activeWorker|'s <a>event loop</a> and the <a>handle functional event task source</a>.
 
@@ -3080,7 +3102,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If |registration| is null, abort these steps.
       1. If any other [=/service worker client=] is <a>using</a> |registration|, abort these steps.
       1. If |registration|'s <a>uninstalling flag</a> is set, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument and abort these steps.
-      1. If |registration|'s <a>waiting worker</a> is not null, run <a>Activate</a> algorithm with |registration| as the argument.
+      1. If |registration|'s <a>waiting worker</a> is not null, invoke [=Try Activate=] with |registration|.
   </section>
 
   <section algorithm>
@@ -3097,6 +3119,21 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. Else, set |registration|'s <a>installing worker</a> to null.
           1. If |registration|'s <a>waiting worker</a> is not null, run the following substep <a>in parallel</a>:
               1. Invoke <a>Activate</a> with |registration|.
+  </section>
+
+  <section algorithm>
+    <h3 id="update-service-worker-extended-events-set-algorithm"><dfn>Update Service Worker Extended Events Set</dfn></h3>
+
+      : Input
+      :: |worker|, a [=/service worker=]
+      :: |event|, an [=event=]
+      : Output
+      :: None
+
+      1. Assert: |event|'s [=dispatch flag=] is unset.
+      1. For each |item| of |worker|'s [=set of extended events=]:
+          1. If |item|'s [=pending promises count=] is zero, [=set/remove=] |item| from |worker|'s [=set of extended events=].
+      1. If |event|'s [=pending promises count=] is not zero, [=set/append=] |event| to |worker|'s [=set of extended events=].
   </section>
 
   <section algorithm>
@@ -3152,19 +3189,16 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If |registration|'s <a>installing worker</a> is not null, then:
           1. Set |redundantWorker| to |registration|'s <a>installing worker</a>.
           1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
-          1. The user agent *may* abort in-flight requests triggered by |redundantWorker|.
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and null as the arguments.
           1. Run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. If |registration|'s <a>waiting worker</a> is not null, then:
           1. Set |redundantWorker| to |registration|'s <a>waiting worker</a>.
           1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
-          1. The user agent *may* abort in-flight requests triggered by |redundantWorker|.
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>waiting</code>" and null as the arguments.
           1. Run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. If |registration|'s <a>active worker</a> is not null, then:
           1. Set |redundantWorker| to |registration|'s <a>active worker</a>.
           1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
-          1. The user agent *may* abort in-flight requests triggered by |redundantWorker|.
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>active</code>" and null as the arguments.
           1. Run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. Let |scopeString| be <a lt="URL serializer">serialized</a> |registration|'s [=service worker registration/scope url=] with the *exclude fragment flag* set.
@@ -3330,6 +3364,21 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Else if |registration|'s <a>waiting worker</a> is not null, set |newestWorker| to |registration|'s <a>waiting worker</a>.
       1. Else if |registration|'s <a>active worker</a> is not null, set |newestWorker| to |registration|'s <a>active worker</a>.
       1. Return |newestWorker|.
+  </section>
+
+  <section algorithm>
+    <h3 id="service-worker-has-no-pending-events-algorithm"><dfn>Service Worker Has No Pending Events</dfn></h3>
+
+      : Input
+      :: |worker|, a [=/service worker=]
+      : Output
+      :: True or false, a boolean
+
+      1. Let |sum| be zero.
+      1. For each |item| of |worker|'s [=set of extended events=]:
+          1. Add |item|'s [=pending promises count=] to |sum|.
+      1. If |sum| is zero, return true.
+      1. Else, return false.
   </section>
 
   <section algorithm>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 2de6f41e63a9bd84932e1a28745f8d452d3b0e46" name="generator">
+  <meta content="Bikeshed version 70f542b3eb403344eee83c57e6631f734b1c4427" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-08">8 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-16">16 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -3122,7 +3122,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <p>For each <var>origin</var> in <var>options</var>.origins:</p>
           <ol>
            <li data-md="">
-            <p>If the value of <var>origin</var> is not an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#syntax-url-absolute">absolute-URL string</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code> and abort these steps.</p>
+            <p>If the value of <var>origin</var> is not an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#absolute-url-string">absolute-URL string</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code> and abort these steps.</p>
            <li data-md="">
             <p>Add the result of <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-parser">parsing</a> <var>origin</var> to <var>originURLs</var>.</p>
           </ol>
@@ -4916,7 +4916,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          </ul>
          <p class="note" role="note"><span>Note:</span> Even if the cache mode is not set to "<code>no-cache</code>", the user agent obeys Cache-Control header’s max-age value in the network layer to determine if it should bypass the browser cache.</p>
         <li data-md="">
-         <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#skip-service-worker-flag">skip-service-worker flag</a>.</p>
+         <p>Set <var>request</var>’s <a data-link-type="dfn">skip-service-worker flag</a>.</p>
         <li data-md="">
          <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-is-top-level">is top-level</a> flag is unset, then return the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetching</a> <var>request</var>.</p>
         <li data-md="">
@@ -5476,7 +5476,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <li data-md="">
            <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-list-append">Append</a> to <var>preloadRequestHeaders</var> a new <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-name">name</a> is `<code>Service-Worker-Navigation-Preload</code>` and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-value">value</a> is <var>registration</var>’s <a data-link-type="dfn" href="#service-worker-registration-navigation-preload-header-value" id="ref-for-service-worker-registration-navigation-preload-header-value-3">navigation preload header value</a>.</p>
           <li data-md="">
-           <p>Set <var>preloadRequest</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#skip-service-worker-flag">skip-service-worker flag</a>.</p>
+           <p>Set <var>preloadRequest</var>’s <a data-link-type="dfn">skip-service-worker flag</a>.</p>
           <li data-md="">
            <p>Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
            <ol>
@@ -7282,7 +7282,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://fetch.spec.whatwg.org/#concept-response">response</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-response-response">response <small>(for Response)</small></a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-response-tainting">response tainting</a>
-     <li><a href="https://fetch.spec.whatwg.org/#skip-service-worker-flag">skip-service-worker flag</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-response-status">status</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-body-stream">stream</a>
      <li><a href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a>
@@ -7477,8 +7476,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li>
     <a data-link-type="biblio">[WHATWG-URL]</a> defines the following terms:
     <ul>
-     <li><a href="https://url.spec.whatwg.org/#syntax-url-absolute">absolute-url string</a>
-     <li><a href="https://url.spec.whatwg.org/#concept-url-equals">equals</a>
+     <li><a href="https://url.spec.whatwg.org/#absolute-url-string">absolute-url string</a>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-equals">equal</a>
      <li><a href="https://url.spec.whatwg.org/#is-local">is local</a>
      <li><a href="https://url.spec.whatwg.org/#concept-url-origin">origin</a>
      <li><a href="https://url.spec.whatwg.org/#concept-url-path">path</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 6ef2009a74468c39cdee1058d2c325259bdcb4fa" name="generator">
+  <meta content="Bikeshed version 90eb18a0d2a7680cdd94ecc3b342163de5a3fd43" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-02">2 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-03">3 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1687,6 +1687,7 @@ pre.idl.highlight { color: #708090; }
       <li><a href="#soft-update-algorithm"><span class="secno"></span> <span class="content"><span>Soft Update</span></span></a>
       <li><a href="#installation-algorithm"><span class="secno"></span> <span class="content"><span>Install</span></span></a>
       <li><a href="#activation-algorithm"><span class="secno"></span> <span class="content"><span>Activate</span></span></a>
+      <li><a href="#try-activate-algorithm"><span class="secno"></span> <span class="content"><span>Try Activate</span></span></a>
       <li><a href="#run-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Run Service Worker</span></span></a>
       <li><a href="#terminate-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Terminate Service Worker</span></span></a>
       <li><a href="#on-fetch-request-algorithm"><span class="secno"></span> <span class="content"><span>Handle Fetch</span></span></a>
@@ -1694,6 +1695,7 @@ pre.idl.highlight { color: #708090; }
       <li><a href="#handle-functional-event-algorithm"><span class="secno"></span> <span class="content"><span>Handle Functional Event</span></span></a>
       <li><a href="#on-client-unload-algorithm"><span class="secno"></span> <span class="content"><span>Handle Service Worker Client Unload</span></span></a>
       <li><a href="#on-user-agent-shutdown-algorithm"><span class="secno"></span> <span class="content"><span>Handle User Agent Shutdown</span></span></a>
+      <li><a href="#update-service-worker-extended-events-set-algorithm"><span class="secno"></span> <span class="content"><span>Update Service Worker Extended Events Set</span></span></a>
       <li><a href="#unregister-algorithm"><span class="secno"></span> <span class="content"><span>Unregister</span></span></a>
       <li><a href="#set-registration-algorithm"><span class="secno"></span> <span class="content"><span>Set Registration</span></span></a>
       <li><a href="#clear-registration-algorithm"><span class="secno"></span> <span class="content"><span>Clear Registration</span></span></a>
@@ -1704,6 +1706,7 @@ pre.idl.highlight { color: #708090; }
       <li><a href="#foreign-fetch-scope-match-algorithm"><span class="secno"></span> <span class="content"><span>Match Service Worker for Foreign Fetch</span></span></a>
       <li><a href="#get-registration-algorithm"><span class="secno"></span> <span class="content"><span>Get Registration</span></span></a>
       <li><a href="#get-newest-worker-algorithm"><span class="secno"></span> <span class="content"><span>Get Newest Worker</span></span></a>
+      <li><a href="#service-worker-has-no-pending-events-algorithm"><span class="secno"></span> <span class="content"><span>Service Worker Has No Pending Events</span></span></a>
       <li><a href="#create-client-algorithm"><span class="secno"></span> <span class="content"><span>Create Client</span></span></a>
       <li><a href="#create-windowclient-algorithm"><span class="secno"></span> <span class="content"><span>Create Window Client</span></span></a>
       <li><a href="#query-cache-algorithm"><span class="secno"></span> <span class="content"><span>Query Cache</span></span></a>
@@ -1770,12 +1773,13 @@ pre.idl.highlight { color: #708090; }
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-25">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-skip-waiting-flag">skip waiting flag</dfn>. Unless stated otherwise it is unset.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-26">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-imported-scripts-updated-flag">imported scripts updated flag</dfn>. It is initially unset.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-27">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-set-of-event-types-to-handle">set of event types to handle</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a>) whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item">item</a> is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-listener">event listener</a>’s event type. It is initially an empty set.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-28">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-foreign-fetch-scopes">list of foreign fetch scopes</dfn> whose element type is a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>. It is initially empty.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-29">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-foreign-fetch-origins">list of foreign fetch origins</dfn> whose element type is a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>. It is initially empty.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-28">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-set-of-extended-events">set of extended events</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a>) whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item">item</a> is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event">event</a>. It is initially an empty set.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-29">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-foreign-fetch-scopes">list of foreign fetch scopes</dfn> whose element type is a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>. It is initially empty.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-30">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-foreign-fetch-origins">list of foreign fetch origins</dfn> whose element type is a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>. It is initially empty.</p>
      <section>
       <h4 class="heading settled" data-level="2.1.1" id="service-worker-lifetime"><span class="secno">2.1.1. </span><span class="content">Lifetime</span><a class="self-link" href="#service-worker-lifetime"></a></h4>
-      <p>The lifetime of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-30">service worker</a> is tied to the execution lifetime of events and not references held by <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-2">service worker clients</a> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-1">ServiceWorker</a></code> object.</p>
-      <p>A user agent <em>may</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-1">terminate</a> <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-31">service workers</a> at any time it:</p>
+      <p>The lifetime of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-31">service worker</a> is tied to the execution lifetime of events and not references held by <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-2">service worker clients</a> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-1">ServiceWorker</a></code> object.</p>
+      <p>A user agent <em>may</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-1">terminate</a> <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-32">service workers</a> at any time it:</p>
       <ul>
        <li data-md="">
         <p>Has no event to handle.</p>
@@ -1786,11 +1790,11 @@ pre.idl.highlight { color: #708090; }
     </section>
     <section>
      <h3 class="heading settled" data-level="2.2" id="service-worker-registration-concept"><span class="secno">2.2. </span><span class="content">Service Worker Registration</span><a class="self-link" href="#service-worker-registration-concept"></a></h3>
-     <p>A <dfn class="dfn-paneled" data-dfn-for="" data-dfn-type="dfn" data-export="" id="dfn-service-worker-registration">service worker registration</dfn> is a tuple of a <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-1">scope url</a> and a set of <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-32">service workers</a>, an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-1">installing worker</a>, a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-1">waiting worker</a>, and an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-1">active worker</a>. A user agent <em>may</em> enable many <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-2">service worker registrations</a> at a single origin so long as the <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-2">scope url</a> of the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-3">service worker registration</a> differs. A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-4">service worker registration</a> of an identical <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-3">scope url</a> when one already exists in the user agent causes the existing <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-5">service worker registration</a> to be replaced.</p>
+     <p>A <dfn class="dfn-paneled" data-dfn-for="" data-dfn-type="dfn" data-export="" id="dfn-service-worker-registration">service worker registration</dfn> is a tuple of a <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-1">scope url</a> and a set of <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-33">service workers</a>, an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-1">installing worker</a>, a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-1">waiting worker</a>, and an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-1">active worker</a>. A user agent <em>may</em> enable many <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-2">service worker registrations</a> at a single origin so long as the <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-2">scope url</a> of the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-3">service worker registration</a> differs. A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-4">service worker registration</a> of an identical <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-3">scope url</a> when one already exists in the user agent causes the existing <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-5">service worker registration</a> to be replaced.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-6">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-scope-url">scope url</dfn> (a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>).</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-7">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-installing-worker">installing worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-33">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-1">state</a> is <em>installing</em>. It is initially set to null.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-8">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-waiting-worker">waiting worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-34">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-2">state</a> is <em>installed</em>. It is initially set to null.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-9">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-active-worker">active worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-35">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-3">state</a> is either <em>activating</em> or <em>activated</em>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-7">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-installing-worker">installing worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-34">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-1">state</a> is <em>installing</em>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-8">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-waiting-worker">waiting worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-35">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-2">state</a> is <em>installed</em>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-9">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-active-worker">active worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-36">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-3">state</a> is either <em>activating</em> or <em>activated</em>. It is initially set to null.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-10">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-last-update-check-time">last update check time</dfn>. It is initially set to null.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-11">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-use-cache">use cache</dfn> (a boolean). It is initially set to false.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-12">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-uninstalling-flag">uninstalling flag</dfn>. It is initially unset.</p>
@@ -1821,16 +1825,16 @@ pre.idl.highlight { color: #708090; }
     </section>
     <section>
      <h3 class="heading settled" data-level="2.5" id="task-sources"><span class="secno">2.5. </span><span class="content">Task Sources</span><a class="self-link" href="#task-sources"></a></h3>
-     <p>The following additional <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a> are used by <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-36">service workers</a>.</p>
+     <p>The following additional <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a> are used by <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-37">service workers</a>.</p>
      <dl>
       <dt data-md="">
        <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-handle-fetch-task-source">handle fetch task source</dfn></p>
       <dd data-md="">
-       <p>This <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is used for <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-2">fetch</a></code> events to <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-37">service workers</a>.</p>
+       <p>This <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is used for <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-2">fetch</a></code> events to <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-38">service workers</a>.</p>
       <dt data-md="">
        <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-handle-functional-event-task-source">handle functional event task source</dfn></p>
       <dd data-md="">
-       <p>This <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is used for features that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> other <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-1">functional events</a>, e.g. <code class="idl"><a class="idl-code" data-link-type="event" href="https://w3c.github.io/push-api/#h-the-push-event">push</a></code> events, to <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-38">service workers</a>.</p>
+       <p>This <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is used for features that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> other <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-1">functional events</a>, e.g. <code class="idl"><a class="idl-code" data-link-type="event" href="https://w3c.github.io/push-api/#h-the-push-event">push</a></code> events, to <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-39">service workers</a>.</p>
        <p class="note" role="note"><span>Note:</span> A user agent may use a separate task source for each functional event type in order to avoid a head-of-line blocking phenomenon for certain functional events.</p>
      </dl>
     </section>
@@ -1839,7 +1843,7 @@ pre.idl.highlight { color: #708090; }
      <p>A user agent <em>must</em> maintain the state of its stored <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-31">service worker registrations</a> across restarts with the following rules:</p>
      <ul>
       <li data-md="">
-       <p>An <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-2">installing worker</a> does not persist but discarded. If the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-3">installing worker</a> was the only <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-39">service worker</a> for the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-32">service worker registration</a>, the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-33">service worker registration</a> is discarded.</p>
+       <p>An <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-2">installing worker</a> does not persist but discarded. If the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-3">installing worker</a> was the only <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-40">service worker</a> for the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-32">service worker registration</a>, the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-33">service worker registration</a> is discarded.</p>
       <li data-md="">
        <p>A <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-2">waiting worker</a> promotes to an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-10">active worker</a>.</p>
      </ul>
@@ -1883,11 +1887,11 @@ pre.idl.highlight { color: #708090; }
   <dfn class="s dfn-paneled idl-code" data-dfn-for="ServiceWorkerState" data-dfn-type="enum-value" data-export="" data-lt="&quot;redundant&quot;|redundant" id="dom-serviceworkerstate-redundant">"redundant"</dfn>
 };
 </pre>
-     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-4">ServiceWorker</a></code> object represents a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-40">service worker</a>. Each <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-5">ServiceWorker</a></code> object is associated with a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-41">service worker</a>. Multiple separate objects implementing the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-6">ServiceWorker</a></code> interface across documents and workers can all be associated with the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-42">service worker</a> simultaneously.</p>
-     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-7">ServiceWorker</a></code> object has an associated <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate-2">ServiceWorkerState</a></code> object which is itself associated with <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-43">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-4">state</a>.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-4">ServiceWorker</a></code> object represents a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-41">service worker</a>. Each <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-5">ServiceWorker</a></code> object is associated with a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-42">service worker</a>. Multiple separate objects implementing the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-6">ServiceWorker</a></code> interface across documents and workers can all be associated with the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-43">service worker</a> simultaneously.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-7">ServiceWorker</a></code> object has an associated <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate-2">ServiceWorkerState</a></code> object which is itself associated with <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-44">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-4">state</a>.</p>
      <section>
       <h4 class="heading settled" data-level="3.1.1" id="service-worker-url"><span class="secno">3.1.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworker-scripturl" id="ref-for-dom-serviceworker-scripturl-2">scriptURL</a></code></span><a class="self-link" href="#service-worker-url"></a></h4>
-      <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorker" data-dfn-type="attribute" data-export="" id="dom-serviceworker-scripturl"><code>scriptURL</code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-44">service worker</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-1">script url</a>.</p>
+      <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorker" data-dfn-type="attribute" data-export="" id="dom-serviceworker-scripturl"><code>scriptURL</code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-45">service worker</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-1">script url</a>.</p>
       <div class="example" id="example-3ff1f346">
        <a class="self-link" href="#example-3ff1f346"></a> For example, consider a document created by a navigation to <code>https://example.com/app.html</code> which <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-4">matches</a> via the following registration call which has been previously executed: 
 <pre class="highlight"><span class="c1">// Script on the page https://example.com/app.html
@@ -1907,7 +1911,7 @@ pre.idl.highlight { color: #708090; }
        <li data-md="">
         <p>If the <code class="idl"><a data-link-type="idl" href="#dom-serviceworker-state" id="ref-for-dom-serviceworker-state-3">state</a></code> attribute value of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> is <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-redundant" id="ref-for-dom-serviceworkerstate-redundant-1">"redundant"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" exception and abort these steps.</p>
        <li data-md="">
-        <p>Let <var>serviceWorker</var> be the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-45">service worker</a> represented by the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+        <p>Let <var>serviceWorker</var> be the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-46">service worker</a> represented by the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
        <li data-md="">
         <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-1">Run Service Worker</a> algorithm with <var>serviceWorker</var> as the argument.</p>
        <li data-md="">
@@ -1941,6 +1945,8 @@ pre.idl.highlight { color: #708090; }
           <p>Let the <code class="idl"><a data-link-type="idl" href="#dom-extendablemessageevent-ports" id="ref-for-dom-extendablemessageevent-ports-1">ports</a></code> attribute of <var>e</var> be initialized to <var>newPorts</var>.</p>
          <li data-md="">
           <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>destination</var>.</p>
+         <li data-md="">
+          <p>Invoke <a data-link-type="dfn" href="#update-service-worker-extended-events-set" id="ref-for-update-service-worker-extended-events-set-1">Update Service Worker Extended Events Set</a> with <var>serviceWorker</var> and <var>e</var>.</p>
         </ol>
         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <em>must</em> use the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>.</p>
       </ol>
@@ -1983,17 +1989,17 @@ pre.idl.highlight { color: #708090; }
      <section class="algorithm" data-algorithm="navigator-service-worker-installing">
       <h4 class="heading settled" data-level="3.2.1" id="navigator-service-worker-installing"><span class="secno">3.2.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-installing" id="ref-for-dom-serviceworkerregistration-installing-2">installing</a></code></span><a class="self-link" href="#navigator-service-worker-installing"></a></h4>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export="" id="dom-serviceworkerregistration-installing"><code>installing</code></dfn> attribute <em>must</em> return the value to which it was last set.</p>
-      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-13">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-46">service worker</a> are the same objects.</p>
+      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-13">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-47">service worker</a> are the same objects.</p>
      </section>
      <section class="algorithm" data-algorithm="navigator-service-worker-waiting">
       <h4 class="heading settled" data-level="3.2.2" id="navigator-service-worker-waiting"><span class="secno">3.2.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-waiting" id="ref-for-dom-serviceworkerregistration-waiting-2">waiting</a></code></span><a class="self-link" href="#navigator-service-worker-waiting"></a></h4>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export="" id="dom-serviceworkerregistration-waiting"><code>waiting</code></dfn> attribute <em>must</em> return the value to which it was last set.</p>
-      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-14">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-47">service worker</a> are the same objects.</p>
+      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-14">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-48">service worker</a> are the same objects.</p>
      </section>
      <section class="algorithm" data-algorithm="navigator-service-worker-active">
       <h4 class="heading settled" data-level="3.2.3" id="navigator-service-worker-active"><span class="secno">3.2.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-2">active</a></code></span><a class="self-link" href="#navigator-service-worker-active"></a></h4>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export="" id="dom-serviceworkerregistration-active"><code>active</code></dfn> attribute <em>must</em> return the value to which it was last set.</p>
-      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-15">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-48">service worker</a> are the same objects.</p>
+      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-15">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-49">service worker</a> are the same objects.</p>
      </section>
      <section class="algorithm" data-algorithm="service-worker-registration-navigationpreload">
       <h4 class="heading settled" data-level="3.2.4" id="service-worker-registration-navigationpreload"><span class="secno">3.2.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-navigationpreload" id="ref-for-dom-serviceworkerregistration-navigationpreload-2">navigationPreload</a></code></span><a class="self-link" href="#service-worker-registration-navigationpreload"></a></h4>
@@ -2101,7 +2107,7 @@ pre.idl.highlight { color: #708090; }
 };
 </pre>
      <p>The user agent <em>must</em> create a <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-5">ServiceWorkerContainer</a></code> object when a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#navigator">Navigator</a></code> object or a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">WorkerNavigator</a></code> object is created and associate it with that object.</p>
-     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-6">ServiceWorkerContainer</a></code> provides capabilities to register, unregister, and update the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-39">service worker registrations</a>, and provides access to the state of the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-40">service worker registrations</a> and their associated <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-49">service workers</a>.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-6">ServiceWorkerContainer</a></code> provides capabilities to register, unregister, and update the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-39">service worker registrations</a>, and provides access to the state of the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-40">service worker registrations</a> and their associated <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-50">service workers</a>.</p>
      <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-7">ServiceWorkerContainer</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerContainer" data-dfn-type="dfn" data-noexport="" id="serviceworkercontainer-service-worker-client">service worker client</dfn>, which is a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-22">service worker client</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> is associated with the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#navigator">Navigator</a></code> object or the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">WorkerNavigator</a></code> object that the <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-8">ServiceWorkerContainer</a></code> is retrieved from.</p>
      <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-9">ServiceWorkerContainer</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerContainer" data-dfn-type="dfn" data-noexport="" id="serviceworkercontainer-ready-promise">ready promise</dfn> (a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>). It is initially set to a new <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>.</p>
      <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-10">ServiceWorkerContainer</a></code> object has a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> called the <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerContainer" data-dfn-type="dfn" data-export="" id="dfn-client-message-queue">client message queue</dfn>, initially empty. A <a data-link-type="dfn" href="#dfn-client-message-queue" id="ref-for-dfn-client-message-queue-1">client message queue</a> can be enabled or disabled, and is initially disabled. When a <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-11">ServiceWorkerContainer</a></code> object’s <a data-link-type="dfn" href="#dfn-client-message-queue" id="ref-for-dfn-client-message-queue-2">client message queue</a> is enabled, the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> <em>must</em> use it as one of its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>. When the <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-12">ServiceWorkerContainer</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object, all <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> on its <a data-link-type="dfn" href="#dfn-client-message-queue" id="ref-for-dfn-client-message-queue-3">client message queue</a> <em>must</em> be associated with its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a>.</p>
@@ -2114,7 +2120,7 @@ pre.idl.highlight { color: #708090; }
        <li data-md="">
         <p>Return the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-17">ServiceWorker</a></code> object that represents <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>.</p>
       </ol>
-      <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="#dom-serviceworkercontainer-controller" id="ref-for-dom-serviceworkercontainer-controller-3">navigator.serviceWorker.controller</a></code> returns <code>null</code> if the request is a force refresh (shift+refresh). The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-18">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-50">service worker</a> are the same objects.</p>
+      <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="#dom-serviceworkercontainer-controller" id="ref-for-dom-serviceworkercontainer-controller-3">navigator.serviceWorker.controller</a></code> returns <code>null</code> if the request is a force refresh (shift+refresh). The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-18">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-51">service worker</a> are the same objects.</p>
      </section>
      <section class="algorithm" data-algorithm="navigator-service-worker-ready">
       <h4 class="heading settled" data-level="3.4.2" id="navigator-service-worker-ready"><span class="secno">3.4.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkercontainer-ready" id="ref-for-dom-serviceworkercontainer-ready-2">ready</a></code></span><a class="self-link" href="#navigator-service-worker-ready"></a></h4>
@@ -2301,7 +2307,7 @@ pre.idl.highlight { color: #708090; }
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerContainer" data-dfn-type="event" data-export="" id="service-worker-container-controllerchange-event"><code>controllerchange</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code>
-        <td>The <a data-link-type="dfn" href="#serviceworkercontainer-service-worker-client" id="ref-for-serviceworkercontainer-service-worker-client-6">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> changes. (See step 9.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-2">Activate</a> algorithm. The <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-1">skip waiting flag</a> of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-51">service worker</a> causes <a data-link-type="dfn" href="#activate" id="ref-for-activate-3">activation</a> of the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-44">service worker registration</a> to occur while <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-23">service worker clients</a> are <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-2">using</a> the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-45">service worker registration</a>, <code class="idl"><a data-link-type="idl" href="#dom-serviceworkercontainer-controller" id="ref-for-dom-serviceworkercontainer-controller-4">navigator.serviceWorker.controller</a></code> immediately reflects the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-14">active worker</a> as the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-52">service worker</a> that <a data-link-type="dfn" href="#dfn-control" id="ref-for-dfn-control-3">controls</a> the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-24">service worker client</a>.)
+        <td>The <a data-link-type="dfn" href="#serviceworkercontainer-service-worker-client" id="ref-for-serviceworkercontainer-service-worker-client-6">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> changes. (See step 9.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-2">Activate</a> algorithm. The <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-1">skip waiting flag</a> of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-52">service worker</a> causes <a data-link-type="dfn" href="#activate" id="ref-for-activate-3">activation</a> of the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-44">service worker registration</a> to occur while <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-23">service worker clients</a> are <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-2">using</a> the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-45">service worker registration</a>, <code class="idl"><a data-link-type="idl" href="#dom-serviceworkercontainer-controller" id="ref-for-dom-serviceworkercontainer-controller-4">navigator.serviceWorker.controller</a></code> immediately reflects the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-14">active worker</a> as the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-53">service worker</a> that <a data-link-type="dfn" href="#dfn-control" id="ref-for-dfn-control-3">controls</a> the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-24">service worker client</a>.)
      </table>
     </section>
    </section>
@@ -2437,8 +2443,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dom-serviceworkerglobalscope-onmessage" id="ref-for-dom-serviceworkerglobalscope-onmessage-1">onmessage</a>; // event.source of the message events is Client object
 };
 </pre>
-     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-6">ServiceWorkerGlobalScope</a></code> object represents the global execution context of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-53">service worker</a>. A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-7">ServiceWorkerGlobalScope</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="dfn" data-noexport="" id="serviceworkerglobalscope-service-worker">service worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-54">service worker</a>). A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-8">ServiceWorkerGlobalScope</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="dfn" data-noexport="" id="serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">force bypass cache for importscripts flag</dfn>. It is initially unset.</p>
-     <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-9">ServiceWorkerGlobalScope</a></code> object provides generic, event-driven, time-limited script execution contexts that run at an origin. Once successfully <a data-link-type="dfn" href="#register" id="ref-for-register-2">registered</a>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-55">service worker</a> is started, kept alive and killed by their relationship to events, not <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-25">service worker clients</a>. Any type of synchronous requests must not be initiated inside of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-56">service worker</a>.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-6">ServiceWorkerGlobalScope</a></code> object represents the global execution context of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-54">service worker</a>. A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-7">ServiceWorkerGlobalScope</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="dfn" data-noexport="" id="serviceworkerglobalscope-service-worker">service worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-55">service worker</a>). A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-8">ServiceWorkerGlobalScope</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="dfn" data-noexport="" id="serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">force bypass cache for importscripts flag</dfn>. It is initially unset.</p>
+     <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-9">ServiceWorkerGlobalScope</a></code> object provides generic, event-driven, time-limited script execution contexts that run at an origin. Once successfully <a data-link-type="dfn" href="#register" id="ref-for-register-2">registered</a>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-56">service worker</a> is started, kept alive and killed by their relationship to events, not <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-25">service worker clients</a>. Any type of synchronous requests must not be initiated inside of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-57">service worker</a>.</p>
      <section>
       <h4 class="heading settled" data-level="4.1.1" id="service-worker-global-scope-clients"><span class="secno">4.1.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-clients" id="ref-for-dom-serviceworkerglobalscope-clients-2">clients</a></code></span><a class="self-link" href="#service-worker-global-scope-clients"></a></h4>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export="" id="dom-serviceworkerglobalscope-clients"><code>clients</code></dfn> attribute <em>must</em> return the <code class="idl"><a data-link-type="idl" href="#clients" id="ref-for-clients-2">Clients</a></code> object that is associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
@@ -2449,7 +2455,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </section>
      <section class="algorithm" data-algorithm="service-worker-global-scope-skipwaiting">
       <h4 class="heading settled" data-level="4.1.3" id="service-worker-global-scope-skipwaiting"><span class="secno">4.1.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-skipwaiting" id="ref-for-dom-serviceworkerglobalscope-skipwaiting-2">skipWaiting()</a></code></span><a class="self-link" href="#service-worker-global-scope-skipwaiting"></a></h4>
-      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-skipwaiting" id="ref-for-dom-serviceworkerglobalscope-skipwaiting-3">skipWaiting()</a></code> method allows this <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-57">service worker</a> to progress from the <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-5">registration</a>'s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-3">waiting</a> position to <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-18">active</a> even while <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-26">service worker clients</a> are <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-3">using</a> the <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-6">registration</a>.</p>
+      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-skipwaiting" id="ref-for-dom-serviceworkerglobalscope-skipwaiting-3">skipWaiting()</a></code> method allows this <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-58">service worker</a> to progress from the <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-5">registration</a>'s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-3">waiting</a> position to <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-18">active</a> even while <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-26">service worker clients</a> are <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-3">using</a> the <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-6">registration</a>.</p>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="method" data-export="" id="dom-serviceworkerglobalscope-skipwaiting"><code>skipWaiting()</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
@@ -2458,7 +2464,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
         <ol>
          <li data-md="">
-          <p>Set <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-58">service worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-2">skip waiting flag</a>.</p>
+          <p>Set <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-4">service worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-2">skip waiting flag</a>.</p>
+         <li data-md="">
+          <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-1">Try Activate</a> with <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-5">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-7">containing service worker registration</a>.</p>
          <li data-md="">
           <p>Resolve <var>promise</var> with undefined.</p>
         </ol>
@@ -2570,7 +2578,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Let the <a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin">origin</a> attribute of <var>e</var> be initialized to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin">Unicode serialization</a> of <var>sourceSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
          <li data-md="">
-          <p>Let the <a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source">source</a> attribute of <var>e</var> be initialized to a <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-22">ServiceWorker</a></code> object, which represents the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-4">service worker</a> associated with <var>sourceSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>.</p>
+          <p>Let the <a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source">source</a> attribute of <var>e</var> be initialized to a <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-22">ServiceWorker</a></code> object, which represents the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-6">service worker</a> associated with <var>sourceSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>.</p>
          <li data-md="">
           <p>Let the <a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports">ports</a> attribute of <var>e</var> be initialized to <var>newPorts</var>.</p>
          <li data-md="">
@@ -2645,7 +2653,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>If <var>url</var> is <code>about:blank</code>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with a <code>TypeError</code>.</p>
        <li data-md="">
-        <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-11">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-5">service worker</a>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with a <code>TypeError</code>.</p>
+        <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-11">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-7">service worker</a>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with a <code>TypeError</code>.</p>
        <li data-md="">
         <p>Let <var>promise</var> be a new <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>.</p>
        <li data-md="">
@@ -2682,7 +2690,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>If <var>navigateFailed</var> is true, reject <var>promise</var> with a <code>TypeError</code> and abort these steps.</p>
          <li data-md="">
-          <p>If <var>browsingContext</var>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin</a> is not the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-6">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+          <p>If <var>browsingContext</var>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin</a> is not the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-8">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
           <ol>
            <li data-md="">
             <p>Resolve <var>promise</var> with null.</p>
@@ -2734,7 +2742,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>Run these substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
         <ol>
          <li data-md="">
-          <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-28">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="#service-worker-client-origin" id="ref-for-service-worker-client-origin-1">origin</a> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-7">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>:</p>
+          <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-28">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="#service-worker-client-origin" id="ref-for-service-worker-client-origin-1">origin</a> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-9">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>:</p>
           <ol>
            <li data-md="">
             <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id">id</a> is not <var>id</var>, continue to the next iteration of the loop.</p>
@@ -2810,7 +2818,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Let <var>targetClients</var> be an empty array.</p>
          <li data-md="">
-          <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-29">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="#service-worker-client-origin" id="ref-for-service-worker-client-origin-2">origin</a> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-8">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>:</p>
+          <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-29">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="#service-worker-client-origin" id="ref-for-service-worker-client-origin-2">origin</a> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-10">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>:</p>
           <ol>
            <li data-md="">
             <p>If <var>client</var> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a>, then:</p>
@@ -2828,7 +2836,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
             <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-includeuncontrolled" id="ref-for-dom-clientqueryoptions-includeuncontrolled-1">includeUncontrolled</a></code> is false, then:</p>
             <ol>
              <li data-md="">
-              <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-9">service worker</a>, continue to the next iteration of the loop.</p>
+              <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-11">service worker</a>, continue to the next iteration of the loop.</p>
             </ol>
            <li data-md="">
             <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-includereserved" id="ref-for-dom-clientqueryoptions-includereserved-1">includeReserved</a></code> is false, then:</p>
@@ -2959,7 +2967,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>If <var>openWindowFailed</var> is true, reject <var>promise</var> with a <code>TypeError</code> and abort these steps.</p>
          <li data-md="">
-          <p>If <var>newContext</var>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> is not the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-10">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+          <p>If <var>newContext</var>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> is not the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-12">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
           <ol>
            <li data-md="">
             <p>Resolve <var>promise</var> with null.</p>
@@ -2980,14 +2988,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Clients" data-dfn-type="method" data-export="" id="dom-clients-claim"><code>claim()</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
-        <p>If the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-11">service worker</a> is not an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-19">active worker</a>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" exception.</p>
+        <p>If the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-13">service worker</a> is not an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-19">active worker</a>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" exception.</p>
        <li data-md="">
         <p>Let <var>promise</var> be a new <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>.</p>
        <li data-md="">
         <p>Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
         <ol>
          <li data-md="">
-          <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-31">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="#service-worker-client-origin" id="ref-for-service-worker-client-origin-3">origin</a> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-12">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>:</p>
+          <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-31">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="#service-worker-client-origin" id="ref-for-service-worker-client-origin-3">origin</a> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-14">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>:</p>
           <ol>
            <li data-md="">
             <p>If <var>client</var> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a>, then:</p>
@@ -3004,14 +3012,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <li data-md="">
             <p>Let <var>registration</var> be the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-7">Match Service Worker Registration</a> algorithm passing <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> as the argument.</p>
            <li data-md="">
-            <p>If <var>registration</var> is not the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-13">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-7">containing service worker registration</a>, continue to the next iteration of the loop.</p>
+            <p>If <var>registration</var> is not the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-15">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-8">containing service worker registration</a>, continue to the next iteration of the loop.</p>
            <li data-md="">
-            <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-14">service worker</a>, then:</p>
+            <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-16">service worker</a>, then:</p>
             <ol>
              <li data-md="">
               <p>Invoke <a data-link-type="dfn" href="#handle-service-worker-client-unload" id="ref-for-handle-service-worker-client-unload-1">Handle Service Worker Client Unload</a> with <var>client</var> as the argument.</p>
              <li data-md="">
-              <p>Set <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-15">service worker</a>.</p>
+              <p>Set <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-17">service worker</a>.</p>
              <li data-md="">
               <p>Invoke <a data-link-type="dfn" href="#notify-controller-change" id="ref-for-notify-controller-change-1">Notify Controller Change</a> algorithm with <var>client</var> as the argument.</p>
             </ol>
@@ -3056,10 +3064,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>Add <var>f</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-8">extend lifetime promises</a>.</p>
        <li data-md="">
-        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-2">pending promises count</a> by one.</p>
-        <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-3">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done in the microtask queued by the reaction to the promise.</p>
+        <p>Increment the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-2">pending promises count</a> by one.</p>
+        <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-3">pending promises count</a> is incremented even if the given promise has already been settled. The corresponding count decrement is done in the microtask queued by the reaction to the promise.</p>
        <li data-md="">
-        <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>f</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a> to decrease the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> by one.</p>
+        <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>f</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a> to run these substeps:</p>
+        <ol>
+         <li data-md="">
+          <p>Decrement the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> by one.</p>
+         <li data-md="">
+          <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-2">Try Activate</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>'s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-18">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>.</p>
+        </ol>
       </ol>
       <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-3">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> when <var>event</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is set or <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-5">pending promises count</a> is not zero. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
      </section>
@@ -3116,7 +3130,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-foreignfetchoptions-scopes" id="ref-for-dom-foreignfetchoptions-scopes-1">scopes</a></code> is empty <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code> and abort these steps.</p>
        <li data-md="">
-        <p>Let <var>scopeString</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-16">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-8">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-11">scope url</a>, <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a>.</p>
+        <p>Let <var>scopeString</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-19">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-10">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-11">scope url</a>, <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a>.</p>
        <li data-md="">
         <p>Let <var>subScopeURLs</var> be an empty list of <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URLs</a>.</p>
        <li data-md="">
@@ -3222,10 +3236,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-9">extend lifetime promises</a>.</p>
        <li data-md="">
-        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-6">pending promises count</a> by one.</p>
-        <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-7">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done in the microtask queued by the reaction to the promise.</p>
+        <p>Increment the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-6">pending promises count</a> by one.</p>
+        <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-7">pending promises count</a> is incremented even if the given promise has already been settled. The corresponding count decrement is done in the microtask queued by the reaction to the promise.</p>
        <li data-md="">
-        <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>r</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a> to decrease the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> by one.</p>
+        <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>r</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a> to run these substeps:</p>
+        <ol>
+         <li data-md="">
+          <p>Decrement the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> by one.</p>
+         <li data-md="">
+          <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-3">Try Activate</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>'s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-20">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-11">containing service worker registration</a>.</p>
+        </ol>
         <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-3">event.respondWith(r)</a></code> extends the lifetime of the event by default as if <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">event.waitUntil(r)</a></code> is called.</p>
        <li data-md="">
         <p>Set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-propagation-flag">stop propagation flag</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">stop immediate propagation flag</a>.</p>
@@ -3398,10 +3418,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-10">extend lifetime promises</a>.</p>
         <li data-md="">
-         <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-9">pending promises count</a> by one.</p>
-         <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-10">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done in the microtask queued by the reaction to the promise.</p>
+         <p>Increment the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-9">pending promises count</a> by one.</p>
+         <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-10">pending promises count</a> is incremented even if the given promise has already been settled. The corresponding count decrement is done in the microtask queued by the reaction to the promise.</p>
         <li data-md="">
-         <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>r</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a> to decrease the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-11">pending promises count</a> by one.</p>
+         <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>r</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a> to run these substeps:</p>
+         <ol>
+          <li data-md="">
+           <p>Decrement the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-11">pending promises count</a> by one.</p>
+          <li data-md="">
+           <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-4">Try Activate</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>'s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-21">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-12">containing service worker registration</a>.</p>
+         </ol>
          <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="#dom-foreignfetchevent-respondwith" id="ref-for-dom-foreignfetchevent-respondwith-3">event.respondWith(r)</a></code> extends the lifetime of the event by default as if <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">event.waitUntil(r)</a></code> is called.</p>
         <li data-md="">
          <p>Set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-propagation-flag">stop propagation flag</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">stop immediate propagation flag</a>.</p>
@@ -3568,19 +3594,19 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-install-event"><code>install</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#installevent" id="ref-for-installevent-2">InstallEvent</a></code>
-        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-2">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-17">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-6">installing worker</a> changes. (See step 11.2 of the <a data-link-type="dfn" href="#install" id="ref-for-install-4">Install</a> algorithm.)
+        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-2">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-22">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-13">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-6">installing worker</a> changes. (See step 11.2 of the <a data-link-type="dfn" href="#install" id="ref-for-install-4">Install</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-activate-event"><code>activate</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-13">ExtendableEvent</a></code>
-        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-3">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-18">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-10">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-21">active worker</a> changes. (See step 12.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-6">Activate</a> algorithm.)
+        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-3">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-23">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-21">active worker</a> changes. (See step 12.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-6">Activate</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-fetch-event"><code>fetch</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-4">FetchEvent</a></code>
-        <td>[<a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-5">Functional event</a>] The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a> invokes <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-4">Handle Fetch</a> with <var>request</var>. As a result of performing <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-5">Handle Fetch</a>, the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-19">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-1">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
+        <td>[<a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-5">Functional event</a>] The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a> invokes <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-4">Handle Fetch</a> with <var>request</var>. As a result of performing <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-5">Handle Fetch</a>, the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-24">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-1">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-foreignfetch-event"><code>foreignfetch</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-5">FetchEvent</a></code>
-        <td>[<a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-6">Functional event</a>] The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a> invokes <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-3">Handle Foreign Fetch</a> with <var>request</var>. As a result of performing <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-4">Handle Foreign Fetch</a>, the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-20">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-2">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
+        <td>[<a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-6">Functional event</a>] The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a> invokes <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-3">Handle Foreign Fetch</a> with <var>request</var>. As a result of performing <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-4">Handle Foreign Fetch</a>, the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-25">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-2">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="eventdef-serviceworkerglobalscope-message"><code>message</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-4">ExtendableMessageEvent</a></code>
@@ -4415,12 +4441,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="method" data-export="" id="importscripts-method"><code>importScripts(<var>urls</var>)</code></dfn> method is called on a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-14">ServiceWorkerGlobalScope</a></code> object, the user agent <em>must</em> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">import scripts into worker global scope</a>, given this <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-15">ServiceWorkerGlobalScope</a></code> object and <var>urls</var>, and with the following steps to <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a> given the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> <var>request</var>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>serviceWorker</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-21">service worker</a>.</p>
+        <p>Let <var>serviceWorker</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-26">service worker</a>.</p>
        <li data-md="">
         <p>If <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-imported-scripts-updated-flag" id="ref-for-dfn-imported-scripts-updated-flag-1">imported scripts updated flag</a> is unset, then:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>registration</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-11">containing service worker registration</a>.</p>
+          <p>Let <var>registration</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-15">containing service worker registration</a>.</p>
          <li data-md="">
           <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">cache mode</a> to "<code>no-cache</code>" if any of the following are true:</p>
           <ul>
@@ -5069,7 +5095,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-3">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-19">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-39">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-17">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-95">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-12">containing service worker registration</a> is <var>registration</var>.</p>
+       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-39">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-17">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-95">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-16">containing service worker registration</a> is <var>registration</var>.</p>
       <li data-md="">
        <p>Let <var>installingWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-8">installing worker</a>.</p>
       <li data-md="">
@@ -5120,8 +5146,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-7">waiting worker</a>.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-5">Terminate</a> <var>redundantWorker</var>.</p>
-        <li data-md="">
-         <p>The user agent <em>may</em> abort in-flight requests triggered by <var>redundantWorker</var>.</p>
        </ol>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-3">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-11">installing worker</a> as the arguments.</p>
@@ -5136,9 +5160,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Wait for all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-5">Update Worker State</a> invoked in this algorithm have executed.</p>
       <li data-md="">
-       <p>Wait until no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-40">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-4">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-9">waiting worker</a>’s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set.</p>
-      <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-10">waiting worker</a> is not null, invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-7">Activate</a> algorithm with <var>registration</var> as its argument.</p>
+       <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-5">Try Activate</a> with <var>registration</var>.</p>
+       <p class="note" role="note"><span>Note:</span> If <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-6">Try Activate</a> does not trigger <a data-link-type="dfn" href="#activate" id="ref-for-activate-7">Activate</a> here, <a data-link-type="dfn" href="#activate" id="ref-for-activate-8">Activate</a> is tried again when the last client controlled by the existing <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-22">active worker</a> is <a data-link-type="dfn" href="#handle-service-worker-client-unload" id="ref-for-handle-service-worker-client-unload-2">unloaded</a>, <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-skipwaiting" id="ref-for-dom-serviceworkerglobalscope-skipwaiting-4">skipWaiting()</a></code> is asynchronously called, and the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-12">extend lifetime promises</a> for the existing <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-23">active worker</a> settle.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Activate">
@@ -5155,30 +5178,22 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-11">waiting worker</a> is null, abort these steps.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-9">waiting worker</a> is null, abort these steps.</p>
       <li data-md="">
        <p>Let <var>redundantWorker</var> be null.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-22">active worker</a> is not null, then:</p>
-       <ol>
-        <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-23">active worker</a>.</p>
-        <li data-md="">
-         <p>Wait for <var>redundantWorker</var> to finish handling any in-progress requests.</p>
-        <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-6">Terminate</a> <var>redundantWorker</var>.</p>
-       </ol>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-24">active worker</a> is not null, <var>redundantWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-25">active worker</a>.</p>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-5">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-5">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-10">waiting worker</a> as the arguments.</p>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-6">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and null as the arguments.</p>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-6">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-24">active worker</a> and <em>activating</em> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-6">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a> and <em>activating</em> as the arguments.</p>
        <p class="note" role="note"><span>Note:</span> Once an active worker is activating, neither a runtime script error nor a force termination of the active worker prevents the active worker from getting activated.</p>
       <li data-md="">
        <p>If <var>redundantWorker</var> is not null, run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-7">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
       <li data-md="">
-       <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-41">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-9">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-18">scope url</a>:</p>
+       <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-40">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-9">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-18">scope url</a>:</p>
        <ol>
         <li data-md="">
          <p>If <var>client</var> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-6">window client</a>, unassociate <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a> from its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#application-cache">application cache</a>, if it has one.</p>
@@ -5187,15 +5202,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        </ol>
        <p class="note" role="note"><span>Note:</span> Resources will now use the service worker registration instead of the existing application cache.</p>
       <li data-md="">
-       <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-42">service worker client</a> <var>client</var> who is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-5">using</a> <var>registration</var>:</p>
+       <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-41">service worker client</a> <var>client</var> who is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-4">using</a> <var>registration</var>:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>client</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-25">active worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a>.</p>
+         <p>Set <var>client</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-27">active worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-28">active worker</a>.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#notify-controller-change" id="ref-for-notify-controller-change-2">Notify Controller Change</a> algorithm with <var>client</var> as the argument.</p>
        </ol>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-27">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-29">active worker</a>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-5">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
@@ -5211,11 +5226,30 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><em>WaitForAsynchronousExtensions</em>: Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-13">pending promises count</a> is zero.</p>
        </ol>
       <li data-md="">
-       <p>Wait for <var>task</var> to have executed or been discarded, or the script to have been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">termination</a> of <var>activeWorker</var>.</p>
+       <p>Wait for <var>task</var> to have executed or been discarded, or the script to have been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-6">termination</a> of <var>activeWorker</var>.</p>
       <li data-md="">
        <p>Wait for the step labeled <em>WaitForAsynchronousExtensions</em> to complete.</p>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-8">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-28">active worker</a> and <em>activated</em> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-8">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a> and <em>activated</em> as the arguments.</p>
+     </ol>
+    </section>
+    <section class="algorithm" data-algorithm="Try Activate">
+     <h3 class="heading settled" id="try-activate-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="try-activate">Try Activate</dfn></span><a class="self-link" href="#try-activate-algorithm"></a></h3>
+     <dl>
+      <dt data-md="">
+       <p>Input</p>
+      <dd data-md="">
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-62">service worker registration</a></p>
+      <dt data-md="">
+       <p>Output</p>
+      <dd data-md="">
+       <p>None</p>
+     </dl>
+     <ol>
+      <li data-md="">
+       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-11">waiting worker</a> is not null.</p>
+      <li data-md="">
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-31">active worker</a> is null, or if the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-1">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-32">active worker</a> is true, and no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-42">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-5">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set, then invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-9">Activate</a> with <var>registration</var>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Run Service Worker">
@@ -5306,7 +5340,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Create a new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">WorkerLocation</a></code> object and associate it with <var>workerGlobalScope</var>.</p>
       <li data-md="">
-       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-29">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-13">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
+       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-33">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-17">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
       <li data-md="">
        <p>If <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>, then <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">run the classic script</a> <var>script</var>. Otherwise, it is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">module script</a>; <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">run the module script</a> <var>script</var>.</p>
        <p class="note" role="note"><span>Note:</span> In addition to the usual possibilities of returning a value or failing due to an exception, this could be prematurely aborted by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">kill a worker</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">terminate a worker</a> algorithms.</p>
@@ -5317,7 +5351,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>For each <var>eventType</var> of <var>settingsObject</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s associated list of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-listener">event listeners</a>' event types:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append">Append</a> <var>eventType</var> to <var>workerGlobalScope</var>’s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-22">service worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-1">set of event types to handle</a>.</p>
+           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append">Append</a> <var>eventType</var> to <var>workerGlobalScope</var>’s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-27">service worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-1">set of event types to handle</a>.</p>
          </ol>
        </ol>
        <p class="note" role="note"><span>Note:</span> If the global object’s associated list of event listeners does not have any event listener added at this moment, the service worker’s set of event types to handle remains an empty set. The user agents are encouraged to show a warning that the event listeners must be added on the very first evaluation of the worker script.</p>
@@ -5351,7 +5385,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>serviceWorkerGlobalScope</var>’s closing flag to true.</p>
       <li data-md="">
-       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
+       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-18">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
        <p class="note" role="note"><span>Note:</span> This effectively means that the fetch events and the other functional events such as push events are backed up by the registration’s task queues while the other tasks including message events are discarded.</p>
       <li data-md="">
        <p>Abort the script currently running in <var>serviceWorker</var>.</p>
@@ -5422,12 +5456,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>registration</var> to the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-10">Match Service Worker Registration</a> algorithm passing <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url">url</a> as the argument.</p>
         <li data-md="">
-         <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a> is null, return null.</p>
+         <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-34">active worker</a> is null, return null.</p>
         <li data-md="">
-         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-31">active worker</a>.</p>
+         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-35">active worker</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request">navigation request</a>, <var>registration</var>’s <a data-link-type="dfn" href="#service-worker-registration-navigation-preload-enabled-flag" id="ref-for-service-worker-registration-navigation-preload-enabled-flag-4">navigation preload enabled flag</a> is set, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method">method</a> is `<code>GET</code>`, and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-32">active worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-2">set of event types to handle</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contains</a> <code>fetch</code>, then:</p>
-         <p class="note" role="note"><span>Note:</span> If the above is true except <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-33">active worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-3">set of event types to handle</a> <strong>does not</strong> contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer’s intent isn’t clear.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request">navigation request</a>, <var>registration</var>’s <a data-link-type="dfn" href="#service-worker-registration-navigation-preload-enabled-flag" id="ref-for-service-worker-registration-navigation-preload-enabled-flag-4">navigation preload enabled flag</a> is set, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method">method</a> is `<code>GET</code>`, and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-36">active worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-2">set of event types to handle</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contains</a> <code>fetch</code>, then:</p>
+         <p class="note" role="note"><span>Note:</span> If the above is true except <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-3">set of event types to handle</a> <strong>does not</strong> contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer’s intent isn’t clear.</p>
          <ol>
           <li data-md="">
            <p>Let <var>preloadRequest</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-clone">cloning</a> the request <var>request</var>.</p>
@@ -5458,17 +5492,17 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Else, resolve <var>preloadResponse</var> with undefined.</p>
        </ol>
-       <p class="note" role="note"><span>Note:</span> From this point, the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-44">service worker client</a> starts to <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-6">use</a> its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-15">containing service worker registration</a>.</p>
+       <p class="note" role="note"><span>Note:</span> From this point, the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-44">service worker client</a> starts to <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-6">use</a> its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-19">containing service worker registration</a>.</p>
       <li data-md="">
        <p>Else if <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is non-null, set <var>registration</var> to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-16">containing service worker registration</a>.</p>
+         <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is non-null, set <var>registration</var> to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-20">containing service worker registration</a>.</p>
         <li data-md="">
          <p>Else, return null.</p>
        </ol>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-34">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a>.</p>
       <li data-md="">
        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-4">set of event types to handle</a> does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> <code>fetch</code>, then:</p>
        <ol>
@@ -5508,6 +5542,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-5">global object</a>.</p>
         <li data-md="">
+         <p>Invoke <a data-link-type="dfn" href="#update-service-worker-extended-events-set" id="ref-for-update-service-worker-extended-events-set-2">Update Service Worker Extended Events Set</a> with <var>activeWorker</var> and <var>e</var>.</p>
+        <li data-md="">
          <p>If <var>e</var>’s <a data-link-type="dfn" href="#fetchevent-respond-with-entered-flag" id="ref-for-fetchevent-respond-with-entered-flag-3">respond-with entered flag</a> is set, set <var>respondWithEntered</var> to true.</p>
         <li data-md="">
          <p>If <var>e</var>’s <a data-link-type="dfn" href="#fetchevent-wait-to-respond-flag" id="ref-for-fetchevent-wait-to-respond-flag-3">wait to respond flag</a> is set, then:</p>
@@ -5522,7 +5558,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>If <var>e</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#canceled-flag">canceled flag</a> is set, set <var>eventCanceled</var> to true.</p>
        </ol>
-       <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-8">termination</a> of <var>activeWorker</var>, set <var>handleFetchFailed</var> to true.</p>
+       <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">termination</a> of <var>activeWorker</var>, set <var>handleFetchFailed</var> to true.</p>
        <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-4">handle fetch task source</a>.</p>
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded.</p>
@@ -5626,6 +5662,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-6">global object</a>.</p>
          <li data-md="">
+          <p>Invoke <a data-link-type="dfn" href="#update-service-worker-extended-events-set" id="ref-for-update-service-worker-extended-events-set-3">Update Service Worker Extended Events Set</a> with <var>activeWorker</var> and <var>e</var>.</p>
+         <li data-md="">
           <p>If <var>e</var>’s <a data-link-type="dfn" href="#foreignfetchevent-respond-with-entered-flag" id="ref-for-foreignfetchevent-respond-with-entered-flag-3">respond-with entered flag</a> is set, set <var>respondWithEntered</var> to true.</p>
          <li data-md="">
           <p>If <var>e</var>’s <a data-link-type="dfn" href="#foreignfetchevent-wait-to-respond-flag" id="ref-for-foreignfetchevent-wait-to-respond-flag-3">wait to respond flag</a> is set, wait until <var>e</var>’s <a data-link-type="dfn" href="#foreignfetchevent-wait-to-respond-flag" id="ref-for-foreignfetchevent-wait-to-respond-flag-4">wait to respond flag</a> is unset.</p>
@@ -5666,7 +5704,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>If <var>e</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#canceled-flag">canceled flag</a> is set, set <var>eventCanceled</var> to true.</p>
         </ol>
-        <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-9">termination</a> of <var>activeWorker</var>, set <var>handleFetchFailed</var> to true.</p>
+        <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-8">termination</a> of <var>activeWorker</var>, set <var>handleFetchFailed</var> to true.</p>
         <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-5">handle fetch task source</a>.</p>
        <li data-md="">
         <p>Wait for <var>task</var> to have executed or been discarded.</p>
@@ -5709,7 +5747,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dd data-md="">
        <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code> object</p>
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-62">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-63">service worker registration</a></p>
       <dd data-md="">
        <p><var>callbackSteps</var>, an algorithm</p>
       <dt data-md="">
@@ -5721,9 +5759,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p class="assertion">Assert: <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-7">scope to registration map</a> contains a value equal to <var>registration</var>.</p>
       <li data-md="">
-       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-35">active worker</a> is not null.</p>
+       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a> is not null.</p>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-36">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a>.</p>
       <li data-md="">
        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-5">set of event types to handle</a> does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> <var>event</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code>, then:</p>
        <ol>
@@ -5744,6 +5782,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <ol>
         <li data-md="">
          <p>Invoke <var>callbackSteps</var> with <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-7">global object</a> as its argument.</p>
+        <li data-md="">
+         <p>Invoke <a data-link-type="dfn" href="#update-service-worker-extended-events-set" id="ref-for-update-service-worker-extended-events-set-4">Update Service Worker Extended Events Set</a> with <var>activeWorker</var> and <var>event</var>.</p>
        </ol>
        <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-4">handle functional event task source</a>.</p>
       <li data-md="">
@@ -5754,7 +5794,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section class="algorithm" data-algorithm="Handle Service Worker Client Unload">
      <h3 class="heading settled" id="on-client-unload-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="handle-service-worker-client-unload">Handle Service Worker Client Unload</dfn></span><a class="self-link" href="#on-client-unload-algorithm"></a></h3>
-     <p>The user agent <em>must</em> run these steps when a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-45">service worker client</a> unloads by <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unload-a-document">unloading</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">being killed</a>, or <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-10">terminating</a>.</p>
+     <p>The user agent <em>must</em> run these steps when a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-45">service worker client</a> unloads by <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unload-a-document">unloading</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">being killed</a>, or <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-9">terminating</a>.</p>
      <dl>
       <dt data-md="">
        <p>Input</p>
@@ -5769,7 +5809,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Run the following steps atomically.</p>
       <li data-md="">
-       <p>Let <var>registration</var> be the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-63">service worker registration</a> <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-7">used</a> by <var>client</var>.</p>
+       <p>Let <var>registration</var> be the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-64">service worker registration</a> <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-7">used</a> by <var>client</var>.</p>
       <li data-md="">
        <p>If <var>registration</var> is null, abort these steps.</p>
       <li data-md="">
@@ -5777,7 +5817,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-4">uninstalling flag</a> is set, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-4">Clear Registration</a> algorithm passing <var>registration</var> as its argument and abort these steps.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a> is not null, run <a data-link-type="dfn" href="#activate" id="ref-for-activate-8">Activate</a> algorithm with <var>registration</var> as the argument.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a> is not null, invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-7">Try Activate</a> with <var>registration</var>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle User Agent Shutdown">
@@ -5808,9 +5848,36 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-14">waiting worker</a> is not null, run the following substep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-9">Activate</a> with <var>registration</var>.</p>
+           <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-10">Activate</a> with <var>registration</var>.</p>
          </ol>
        </ol>
+     </ol>
+    </section>
+    <section class="algorithm" data-algorithm="Update Service Worker Extended Events Set">
+     <h3 class="heading settled" id="update-service-worker-extended-events-set-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="update-service-worker-extended-events-set">Update Service Worker Extended Events Set</dfn></span><a class="self-link" href="#update-service-worker-extended-events-set-algorithm"></a></h3>
+     <dl>
+      <dt data-md="">
+       <p>Input</p>
+      <dd data-md="">
+       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a></p>
+      <dd data-md="">
+       <p><var>event</var>, an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event">event</a></p>
+      <dt data-md="">
+       <p>Output</p>
+      <dd data-md="">
+       <p>None</p>
+     </dl>
+     <ol>
+      <li data-md="">
+       <p class="assertion">Assert: <var>event</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is unset.</p>
+      <li data-md="">
+       <p>For each <var>item</var> of <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-1">set of extended events</a>:</p>
+       <ol>
+        <li data-md="">
+         <p>If <var>item</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-14">pending promises count</a> is zero, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove">remove</a> <var>item</var> from <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-2">set of extended events</a>.</p>
+       </ol>
+      <li data-md="">
+       <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-15">pending promises count</a> is not zero, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append">append</a> <var>event</var> to <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-3">set of extended events</a>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Unregister">
@@ -5867,7 +5934,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-64">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-65">service worker registration</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -5875,7 +5942,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>scopeString</var> be <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <var>scope</var> with the <em>exclude fragment flag</em> set.</p>
       <li data-md="">
-       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-65">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-19">scope url</a> is set to <var>scope</var> and <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-5">use cache</a> is set to <var>useCache</var>.</p>
+       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-66">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-19">scope url</a> is set to <var>scope</var> and <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-5">use cache</a> is set to <var>useCache</var>.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set">Set</a> <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-9">scope to registration map</a>[<var>scopeString</var>] to <var>registration</var>.</p>
       <li data-md="">
@@ -5888,7 +5955,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-66">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-67">service worker registration</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5905,9 +5972,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-15">installing worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-11">Terminate</a> <var>redundantWorker</var>.</p>
-        <li data-md="">
-         <p>The user agent <em>may</em> abort in-flight requests triggered by <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-10">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-7">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and null as the arguments.</p>
         <li data-md="">
@@ -5919,23 +5984,19 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-16">waiting worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-12">Terminate</a> <var>redundantWorker</var>.</p>
-        <li data-md="">
-         <p>The user agent <em>may</em> abort in-flight requests triggered by <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-11">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-8">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and null as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-10">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a> is not null, then:</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a>.</p>
+         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-42">active worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-13">Terminate</a> <var>redundantWorker</var>.</p>
-        <li data-md="">
-         <p>The user agent <em>may</em> abort in-flight requests triggered by <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-12">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-9">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and null as the arguments.</p>
         <li data-md="">
@@ -5953,11 +6014,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-67">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-68">service worker registration</a></p>
       <dd data-md="">
        <p><var>target</var>, a string (one of "<code>installing</code>", "<code>waiting</code>", and "<code>active</code>")</p>
       <dd data-md="">
-       <p><var>source</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> or null</p>
+       <p><var>source</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a> or null</p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5994,12 +6055,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Else if <var>target</var> is "<code>active</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-43">active worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-3">active</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-27">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-3">active</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-27">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-44">active worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-45">active worker</a> is null.</p>
          </ol>
        </ol>
        <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <em>must</em> use <var>registrationObject</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>.</p>
@@ -6011,9 +6072,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a></p>
+       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-102">service worker</a></p>
       <dd data-md="">
-       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-102">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-12">state</a></p>
+       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-12">state</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -6037,27 +6098,27 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
              <p><em>installing</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installing" id="ref-for-dom-serviceworkerstate-installing-1">"installing"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> is not active until all of the core caches are populated.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a> is not active until all of the core caches are populated.</p>
             <dt data-md="">
              <p><em>installed</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installed" id="ref-for-dom-serviceworkerstate-installed-1">"installed"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a>.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a>.</p>
             <dt data-md="">
              <p><em>activating</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activating" id="ref-for-dom-serviceworkerstate-activating-1">"activating"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-42">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-9">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-43">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-12">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-46">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-9">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-47">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-12">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
             <dt data-md="">
              <p><em>activated</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activated" id="ref-for-dom-serviceworkerstate-activated-1">"activated"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-44">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-13">functional events</a>.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-48">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-13">functional events</a>.</p>
             <dt data-md="">
              <p><em>redundant</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-redundant" id="ref-for-dom-serviceworkerstate-redundant-2">"redundant"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> A new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a> is replacing the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-109">service worker</a>, or the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-110">service worker</a> is being discarded due to an install failure.</p>
+             <p class="note" role="note"><span>Note:</span> A new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-109">service worker</a> is replacing the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-110">service worker</a>, or the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-111">service worker</a> is being discarded due to an install failure.</p>
            </dl>
           <li data-md="">
            <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <code>statechange</code> at <var>workerObject</var>.</p>
@@ -6096,7 +6157,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-68">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-69">service worker registration</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -6132,7 +6193,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-111">service worker</a></p>
+       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-112">service worker</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -6142,7 +6203,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var> is null, return null.</p>
       <li data-md="">
-       <p>Let <var>worker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-45">active worker</a>.</p>
+       <p>Let <var>worker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-49">active worker</a>.</p>
       <li data-md="">
        <p>If <var>worker</var> is null, return null.</p>
       <li data-md="">
@@ -6169,7 +6230,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-69">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-70">service worker registration</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -6196,11 +6257,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-70">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-71">service worker registration</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>newestWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-112">service worker</a></p>
+       <p><var>newestWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-113">service worker</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -6212,9 +6273,36 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-21">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-22">waiting worker</a>.</p>
       <li data-md="">
-       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-46">active worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-47">active worker</a>.</p>
+       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-50">active worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-51">active worker</a>.</p>
       <li data-md="">
        <p>Return <var>newestWorker</var>.</p>
+     </ol>
+    </section>
+    <section class="algorithm" data-algorithm="Service Worker Has No Pending Events">
+     <h3 class="heading settled" id="service-worker-has-no-pending-events-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="service-worker-has-no-pending-events">Service Worker Has No Pending Events</dfn></span><a class="self-link" href="#service-worker-has-no-pending-events-algorithm"></a></h3>
+     <dl>
+      <dt data-md="">
+       <p>Input</p>
+      <dd data-md="">
+       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-114">service worker</a></p>
+      <dt data-md="">
+       <p>Output</p>
+      <dd data-md="">
+       <p>True or false, a boolean</p>
+     </dl>
+     <ol>
+      <li data-md="">
+       <p>Let <var>sum</var> be zero.</p>
+      <li data-md="">
+       <p>For each <var>item</var> of <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-4">set of extended events</a>:</p>
+       <ol>
+        <li data-md="">
+         <p>Add <var>item</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-16">pending promises count</a> to <var>sum</var>.</p>
+       </ol>
+      <li data-md="">
+       <p>If <var>sum</var> is zero, return true.</p>
+      <li data-md="">
+       <p>Else, return false.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Create Client">
@@ -6495,18 +6583,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <h2 class="heading settled" id="extended-http-headers"><span class="content">Appendix B: Extended HTTP headers</span><a class="self-link" href="#extended-http-headers"></a></h2>
     <section>
      <h3 class="heading settled" id="service-worker-script-request"><span class="content">Service Worker Script Request</span><a class="self-link" href="#service-worker-script-request"></a></h3>
-     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-113">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-115">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker"><code>Service-Worker</code><a class="self-link" href="#service-worker"></a></dfn>`</p>
       <dd data-md="">
-       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-114">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request.</p>
+       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-116">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request.</p>
        <p class="note" role="note"><span>Note:</span> This header helps administrators log the requests and detect threats.</p>
      </dl>
     </section>
     <section>
      <h3 class="heading settled" id="service-worker-script-response"><span class="content">Service Worker Script Response</span><a class="self-link" href="#service-worker-script-response"></a></h3>
-     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-115">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-117">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker-allowed"><code>Service-Worker-Allowed</code><a class="self-link" href="#service-worker-allowed"></a></dfn>`</p>
@@ -6553,7 +6641,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" id="syntax"><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
-     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-116">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-17">script resource</a> requests and responses:</p>
+     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-118">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-17">script resource</a> requests and responses:</p>
 <pre>Service-Worker = %x73.63.72.69.70.74 ; "script", case-sensitive
 </pre>
      <p class="note" role="note"><span>Note:</span> The validation of the Service-Worker-Allowed header’s values is done by URL parsing algorithm (in Update algorithm) instead of using ABNF.</p>
@@ -6978,6 +7066,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </ul>
    <li><a href="#serviceworkercontainer">ServiceWorkerContainer</a><span>, in §3.4</span>
    <li><a href="#serviceworkerglobalscope">ServiceWorkerGlobalScope</a><span>, in §4.1</span>
+   <li><a href="#service-worker-has-no-pending-events">Service Worker Has No Pending Events</a><span>, in §Unnumbered section</span>
    <li><a href="#dfn-serviceworker-link">serviceworker link</a><span>, in §5</span>
    <li><a href="#dfn-link-type-serviceworker">serviceworker link type</a><span>, in §5</span>
    <li><a href="#serviceworkerregistration">ServiceWorkerRegistration</a><span>, in §3.2</span>
@@ -6990,6 +7079,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#enumdef-serviceworkerstate">ServiceWorkerState</a><span>, in §3.1</span>
    <li><a href="#dom-navigationpreloadmanager-setheadervalue">setHeaderValue(value)</a><span>, in §3.6.3</span>
    <li><a href="#dfn-set-of-event-types-to-handle">set of event types to handle</a><span>, in §2.1</span>
+   <li><a href="#dfn-set-of-extended-events">set of extended events</a><span>, in §2.1</span>
    <li><a href="#set-registration">Set Registration</a><span>, in §Unnumbered section</span>
    <li><a href="#dom-clienttype-sharedworker">sharedworker</a><span>, in §4.3</span>
    <li><a href="#dom-clienttype-sharedworker">"sharedworker"</a><span>, in §4.3</span>
@@ -7020,6 +7110,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </ul>
    <li><a href="#dfn-service-worker-registration-task-queue">task queues</a><span>, in §2.2</span>
    <li><a href="#terminate-service-worker">Terminate Service Worker</a><span>, in §Unnumbered section</span>
+   <li><a href="#try-activate">Try Activate</a><span>, in §Unnumbered section</span>
    <li>
     type
     <ul>
@@ -7036,6 +7127,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#update">Update</a><span>, in §Unnumbered section</span>
    <li><a href="#service-worker-registration-updatefound-event">updatefound</a><span>, in §3.5</span>
    <li><a href="#update-registration-state">Update Registration State</a><span>, in §Unnumbered section</span>
+   <li><a href="#update-service-worker-extended-events-set">Update Service Worker Extended Events Set</a><span>, in §Unnumbered section</span>
    <li><a href="#update-worker-state">Update Worker State</a><span>, in §Unnumbered section</span>
    <li><a href="#dom-client-url">url</a><span>, in §4.2.1</span>
    <li>
@@ -7323,7 +7415,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://infra.spec.whatwg.org/#list-item">item</a>
      <li><a href="https://infra.spec.whatwg.org/#ordered-map">ordered map</a>
      <li><a href="https://infra.spec.whatwg.org/#ordered-set">ordered set</a>
-     <li><a href="https://infra.spec.whatwg.org/#map-remove">remove</a>
+     <li><a href="https://infra.spec.whatwg.org/#list-remove">remove <small>(for list)</small></a>
+     <li><a href="https://infra.spec.whatwg.org/#map-remove">remove <small>(for map)</small></a>
      <li><a href="https://infra.spec.whatwg.org/#map-set">set</a>
     </ul>
    <li>
@@ -7730,22 +7823,22 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dfn-service-worker">#dfn-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-1">1. Motivations</a> <a href="#ref-for-dfn-service-worker-2">(2)</a> <a href="#ref-for-dfn-service-worker-3">(3)</a> <a href="#ref-for-dfn-service-worker-4">(4)</a> <a href="#ref-for-dfn-service-worker-5">(5)</a> <a href="#ref-for-dfn-service-worker-6">(6)</a> <a href="#ref-for-dfn-service-worker-7">(7)</a> <a href="#ref-for-dfn-service-worker-8">(8)</a> <a href="#ref-for-dfn-service-worker-9">(9)</a> <a href="#ref-for-dfn-service-worker-10">(10)</a> <a href="#ref-for-dfn-service-worker-11">(11)</a> <a href="#ref-for-dfn-service-worker-12">(12)</a> <a href="#ref-for-dfn-service-worker-13">(13)</a> <a href="#ref-for-dfn-service-worker-14">(14)</a>
-    <li><a href="#ref-for-dfn-service-worker-15">2.1. Service Worker</a> <a href="#ref-for-dfn-service-worker-16">(2)</a> <a href="#ref-for-dfn-service-worker-17">(3)</a> <a href="#ref-for-dfn-service-worker-18">(4)</a> <a href="#ref-for-dfn-service-worker-19">(5)</a> <a href="#ref-for-dfn-service-worker-20">(6)</a> <a href="#ref-for-dfn-service-worker-21">(7)</a> <a href="#ref-for-dfn-service-worker-22">(8)</a> <a href="#ref-for-dfn-service-worker-23">(9)</a> <a href="#ref-for-dfn-service-worker-24">(10)</a> <a href="#ref-for-dfn-service-worker-25">(11)</a> <a href="#ref-for-dfn-service-worker-26">(12)</a> <a href="#ref-for-dfn-service-worker-27">(13)</a> <a href="#ref-for-dfn-service-worker-28">(14)</a> <a href="#ref-for-dfn-service-worker-29">(15)</a>
-    <li><a href="#ref-for-dfn-service-worker-30">2.1.1. Lifetime</a> <a href="#ref-for-dfn-service-worker-31">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-32">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-service-worker-33">(2)</a> <a href="#ref-for-dfn-service-worker-34">(3)</a> <a href="#ref-for-dfn-service-worker-35">(4)</a>
-    <li><a href="#ref-for-dfn-service-worker-36">2.5. Task Sources</a> <a href="#ref-for-dfn-service-worker-37">(2)</a> <a href="#ref-for-dfn-service-worker-38">(3)</a>
-    <li><a href="#ref-for-dfn-service-worker-39">2.6. User Agent Shutdown</a>
-    <li><a href="#ref-for-dfn-service-worker-40">3.1. ServiceWorker</a> <a href="#ref-for-dfn-service-worker-41">(2)</a> <a href="#ref-for-dfn-service-worker-42">(3)</a> <a href="#ref-for-dfn-service-worker-43">(4)</a>
-    <li><a href="#ref-for-dfn-service-worker-44">3.1.1. scriptURL</a>
-    <li><a href="#ref-for-dfn-service-worker-45">3.1.3. postMessage(message, transfer)</a>
-    <li><a href="#ref-for-dfn-service-worker-46">3.2.1. installing</a>
-    <li><a href="#ref-for-dfn-service-worker-47">3.2.2. waiting</a>
-    <li><a href="#ref-for-dfn-service-worker-48">3.2.3. active</a>
-    <li><a href="#ref-for-dfn-service-worker-49">3.4. ServiceWorkerContainer</a>
-    <li><a href="#ref-for-dfn-service-worker-50">3.4.1. controller</a>
-    <li><a href="#ref-for-dfn-service-worker-51">3.5. Events</a> <a href="#ref-for-dfn-service-worker-52">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-53">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-dfn-service-worker-54">(2)</a> <a href="#ref-for-dfn-service-worker-55">(3)</a> <a href="#ref-for-dfn-service-worker-56">(4)</a>
-    <li><a href="#ref-for-dfn-service-worker-57">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-service-worker-58">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-15">2.1. Service Worker</a> <a href="#ref-for-dfn-service-worker-16">(2)</a> <a href="#ref-for-dfn-service-worker-17">(3)</a> <a href="#ref-for-dfn-service-worker-18">(4)</a> <a href="#ref-for-dfn-service-worker-19">(5)</a> <a href="#ref-for-dfn-service-worker-20">(6)</a> <a href="#ref-for-dfn-service-worker-21">(7)</a> <a href="#ref-for-dfn-service-worker-22">(8)</a> <a href="#ref-for-dfn-service-worker-23">(9)</a> <a href="#ref-for-dfn-service-worker-24">(10)</a> <a href="#ref-for-dfn-service-worker-25">(11)</a> <a href="#ref-for-dfn-service-worker-26">(12)</a> <a href="#ref-for-dfn-service-worker-27">(13)</a> <a href="#ref-for-dfn-service-worker-28">(14)</a> <a href="#ref-for-dfn-service-worker-29">(15)</a> <a href="#ref-for-dfn-service-worker-30">(16)</a>
+    <li><a href="#ref-for-dfn-service-worker-31">2.1.1. Lifetime</a> <a href="#ref-for-dfn-service-worker-32">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-33">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-service-worker-34">(2)</a> <a href="#ref-for-dfn-service-worker-35">(3)</a> <a href="#ref-for-dfn-service-worker-36">(4)</a>
+    <li><a href="#ref-for-dfn-service-worker-37">2.5. Task Sources</a> <a href="#ref-for-dfn-service-worker-38">(2)</a> <a href="#ref-for-dfn-service-worker-39">(3)</a>
+    <li><a href="#ref-for-dfn-service-worker-40">2.6. User Agent Shutdown</a>
+    <li><a href="#ref-for-dfn-service-worker-41">3.1. ServiceWorker</a> <a href="#ref-for-dfn-service-worker-42">(2)</a> <a href="#ref-for-dfn-service-worker-43">(3)</a> <a href="#ref-for-dfn-service-worker-44">(4)</a>
+    <li><a href="#ref-for-dfn-service-worker-45">3.1.1. scriptURL</a>
+    <li><a href="#ref-for-dfn-service-worker-46">3.1.3. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-dfn-service-worker-47">3.2.1. installing</a>
+    <li><a href="#ref-for-dfn-service-worker-48">3.2.2. waiting</a>
+    <li><a href="#ref-for-dfn-service-worker-49">3.2.3. active</a>
+    <li><a href="#ref-for-dfn-service-worker-50">3.4. ServiceWorkerContainer</a>
+    <li><a href="#ref-for-dfn-service-worker-51">3.4.1. controller</a>
+    <li><a href="#ref-for-dfn-service-worker-52">3.5. Events</a> <a href="#ref-for-dfn-service-worker-53">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-54">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-dfn-service-worker-55">(2)</a> <a href="#ref-for-dfn-service-worker-56">(3)</a> <a href="#ref-for-dfn-service-worker-57">(4)</a>
+    <li><a href="#ref-for-dfn-service-worker-58">4.1.3. skipWaiting()</a>
     <li><a href="#ref-for-dfn-service-worker-59">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-service-worker-60">(2)</a> <a href="#ref-for-dfn-service-worker-61">(3)</a> <a href="#ref-for-dfn-service-worker-62">(4)</a> <a href="#ref-for-dfn-service-worker-63">(5)</a> <a href="#ref-for-dfn-service-worker-64">(6)</a>
     <li><a href="#ref-for-dfn-service-worker-65">4.4.1. event.waitUntil(f)</a>
     <li><a href="#ref-for-dfn-service-worker-66">4.5.1. event.registerForeignFetch(options)</a> <a href="#ref-for-dfn-service-worker-67">(2)</a>
@@ -7767,13 +7860,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-97">Terminate Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-98">Handle Fetch</a>
     <li><a href="#ref-for-dfn-service-worker-99">Handle Foreign Fetch</a>
-    <li><a href="#ref-for-dfn-service-worker-100">Update Registration State</a>
-    <li><a href="#ref-for-dfn-service-worker-101">Update Worker State</a> <a href="#ref-for-dfn-service-worker-102">(2)</a> <a href="#ref-for-dfn-service-worker-103">(3)</a> <a href="#ref-for-dfn-service-worker-104">(4)</a> <a href="#ref-for-dfn-service-worker-105">(5)</a> <a href="#ref-for-dfn-service-worker-106">(6)</a> <a href="#ref-for-dfn-service-worker-107">(7)</a> <a href="#ref-for-dfn-service-worker-108">(8)</a> <a href="#ref-for-dfn-service-worker-109">(9)</a> <a href="#ref-for-dfn-service-worker-110">(10)</a>
-    <li><a href="#ref-for-dfn-service-worker-111">Match Service Worker for Foreign Fetch</a>
-    <li><a href="#ref-for-dfn-service-worker-112">Get Newest Worker</a>
-    <li><a href="#ref-for-dfn-service-worker-113">Service Worker Script Request</a> <a href="#ref-for-dfn-service-worker-114">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-115">Service Worker Script Response</a>
-    <li><a href="#ref-for-dfn-service-worker-116">Syntax</a>
+    <li><a href="#ref-for-dfn-service-worker-100">Update Service Worker Extended Events Set</a>
+    <li><a href="#ref-for-dfn-service-worker-101">Update Registration State</a>
+    <li><a href="#ref-for-dfn-service-worker-102">Update Worker State</a> <a href="#ref-for-dfn-service-worker-103">(2)</a> <a href="#ref-for-dfn-service-worker-104">(3)</a> <a href="#ref-for-dfn-service-worker-105">(4)</a> <a href="#ref-for-dfn-service-worker-106">(5)</a> <a href="#ref-for-dfn-service-worker-107">(6)</a> <a href="#ref-for-dfn-service-worker-108">(7)</a> <a href="#ref-for-dfn-service-worker-109">(8)</a> <a href="#ref-for-dfn-service-worker-110">(9)</a> <a href="#ref-for-dfn-service-worker-111">(10)</a>
+    <li><a href="#ref-for-dfn-service-worker-112">Match Service Worker for Foreign Fetch</a>
+    <li><a href="#ref-for-dfn-service-worker-113">Get Newest Worker</a>
+    <li><a href="#ref-for-dfn-service-worker-114">Service Worker Has No Pending Events</a>
+    <li><a href="#ref-for-dfn-service-worker-115">Service Worker Script Request</a> <a href="#ref-for-dfn-service-worker-116">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-117">Service Worker Script Response</a>
+    <li><a href="#ref-for-dfn-service-worker-118">Syntax</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-state">
@@ -7815,15 +7910,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-containing-service-worker-registration-2">2.4. Selection and Use</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-3">3.2.8. unregister()</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-4">4.1.2. registration</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-5">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-containing-service-worker-registration-6">(2)</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-7">4.3.4. claim()</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-8">4.5.1. event.registerForeignFetch(options)</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-9">4.9. Events</a> <a href="#ref-for-dfn-containing-service-worker-registration-10">(2)</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-11">7.3.2. importScripts(urls)</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-12">Install</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-13">Run Service Worker</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-14">Terminate Service Worker</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-15">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration-16">(2)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-5">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-containing-service-worker-registration-6">(2)</a> <a href="#ref-for-dfn-containing-service-worker-registration-7">(3)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-8">4.3.4. claim()</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-9">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-10">4.5.1. event.registerForeignFetch(options)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-11">4.6.7. event.respondWith(r)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-12">4.7.3. event.respondWith(r)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-13">4.9. Events</a> <a href="#ref-for-dfn-containing-service-worker-registration-14">(2)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-15">7.3.2. importScripts(urls)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-16">Install</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-17">Run Service Worker</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-18">Terminate Service Worker</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-19">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration-20">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-service-worker-id">
@@ -7909,7 +8007,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-skip-waiting-flag-1">3.5. Events</a>
     <li><a href="#ref-for-dfn-skip-waiting-flag-2">4.1.3. skipWaiting()</a>
-    <li><a href="#ref-for-dfn-skip-waiting-flag-3">Install</a>
+    <li><a href="#ref-for-dfn-skip-waiting-flag-3">Try Activate</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-imported-scripts-updated-flag">
@@ -7925,6 +8023,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle-1">Run Service Worker</a>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle-2">Handle Fetch</a> <a href="#ref-for-dfn-set-of-event-types-to-handle-3">(2)</a> <a href="#ref-for-dfn-set-of-event-types-to-handle-4">(3)</a>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle-5">Handle Functional Event</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-set-of-extended-events">
+   <b><a href="#dfn-set-of-extended-events">#dfn-set-of-extended-events</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-set-of-extended-events-1">Update Service Worker Extended Events Set</a> <a href="#ref-for-dfn-set-of-extended-events-2">(2)</a> <a href="#ref-for-dfn-set-of-extended-events-3">(3)</a>
+    <li><a href="#ref-for-dfn-set-of-extended-events-4">Service Worker Has No Pending Events</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-foreign-fetch-scopes">
@@ -7968,14 +8073,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-registration-59">Soft Update</a>
     <li><a href="#ref-for-dfn-service-worker-registration-60">Install</a>
     <li><a href="#ref-for-dfn-service-worker-registration-61">Activate</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-62">Handle Functional Event</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-63">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-64">Set Registration</a> <a href="#ref-for-dfn-service-worker-registration-65">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-66">Clear Registration</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-67">Update Registration State</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-68">Match Service Worker Registration</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-69">Get Registration</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-70">Get Newest Worker</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-62">Try Activate</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-63">Handle Functional Event</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-64">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-65">Set Registration</a> <a href="#ref-for-dfn-service-worker-registration-66">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-67">Clear Registration</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-68">Update Registration State</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-69">Match Service Worker Registration</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-70">Get Registration</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-71">Get Newest Worker</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-scope-url">
@@ -8023,8 +8129,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-waiting-worker-2">2.6. User Agent Shutdown</a>
     <li><a href="#ref-for-dfn-waiting-worker-3">4.1.3. skipWaiting()</a>
     <li><a href="#ref-for-dfn-waiting-worker-4">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-waiting-worker-5">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-6">Install</a> <a href="#ref-for-dfn-waiting-worker-7">(2)</a> <a href="#ref-for-dfn-waiting-worker-8">(3)</a> <a href="#ref-for-dfn-waiting-worker-9">(4)</a> <a href="#ref-for-dfn-waiting-worker-10">(5)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-11">Activate</a> <a href="#ref-for-dfn-waiting-worker-12">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-6">Install</a> <a href="#ref-for-dfn-waiting-worker-7">(2)</a> <a href="#ref-for-dfn-waiting-worker-8">(3)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-9">Activate</a> <a href="#ref-for-dfn-waiting-worker-10">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-11">Try Activate</a> <a href="#ref-for-dfn-waiting-worker-12">(2)</a>
     <li><a href="#ref-for-dfn-waiting-worker-13">Handle Service Worker Client Unload</a>
     <li><a href="#ref-for-dfn-waiting-worker-14">Handle User Agent Shutdown</a>
     <li><a href="#ref-for-dfn-waiting-worker-15">Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-16">(2)</a>
@@ -8048,15 +8155,17 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-active-worker-19">4.3.4. claim()</a>
     <li><a href="#ref-for-dfn-active-worker-20">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dfn-active-worker-21">4.9. Events</a>
-    <li><a href="#ref-for-dfn-active-worker-22">Activate</a> <a href="#ref-for-dfn-active-worker-23">(2)</a> <a href="#ref-for-dfn-active-worker-24">(3)</a> <a href="#ref-for-dfn-active-worker-25">(4)</a> <a href="#ref-for-dfn-active-worker-26">(5)</a> <a href="#ref-for-dfn-active-worker-27">(6)</a> <a href="#ref-for-dfn-active-worker-28">(7)</a>
-    <li><a href="#ref-for-dfn-active-worker-29">Run Service Worker</a>
-    <li><a href="#ref-for-dfn-active-worker-30">Handle Fetch</a> <a href="#ref-for-dfn-active-worker-31">(2)</a> <a href="#ref-for-dfn-active-worker-32">(3)</a> <a href="#ref-for-dfn-active-worker-33">(4)</a> <a href="#ref-for-dfn-active-worker-34">(5)</a>
-    <li><a href="#ref-for-dfn-active-worker-35">Handle Functional Event</a> <a href="#ref-for-dfn-active-worker-36">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-37">Clear Registration</a> <a href="#ref-for-dfn-active-worker-38">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-39">Update Registration State</a> <a href="#ref-for-dfn-active-worker-40">(2)</a> <a href="#ref-for-dfn-active-worker-41">(3)</a>
-    <li><a href="#ref-for-dfn-active-worker-42">Update Worker State</a> <a href="#ref-for-dfn-active-worker-43">(2)</a> <a href="#ref-for-dfn-active-worker-44">(3)</a>
-    <li><a href="#ref-for-dfn-active-worker-45">Match Service Worker for Foreign Fetch</a>
-    <li><a href="#ref-for-dfn-active-worker-46">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker-47">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-22">Install</a> <a href="#ref-for-dfn-active-worker-23">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-24">Activate</a> <a href="#ref-for-dfn-active-worker-25">(2)</a> <a href="#ref-for-dfn-active-worker-26">(3)</a> <a href="#ref-for-dfn-active-worker-27">(4)</a> <a href="#ref-for-dfn-active-worker-28">(5)</a> <a href="#ref-for-dfn-active-worker-29">(6)</a> <a href="#ref-for-dfn-active-worker-30">(7)</a>
+    <li><a href="#ref-for-dfn-active-worker-31">Try Activate</a> <a href="#ref-for-dfn-active-worker-32">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-33">Run Service Worker</a>
+    <li><a href="#ref-for-dfn-active-worker-34">Handle Fetch</a> <a href="#ref-for-dfn-active-worker-35">(2)</a> <a href="#ref-for-dfn-active-worker-36">(3)</a> <a href="#ref-for-dfn-active-worker-37">(4)</a> <a href="#ref-for-dfn-active-worker-38">(5)</a>
+    <li><a href="#ref-for-dfn-active-worker-39">Handle Functional Event</a> <a href="#ref-for-dfn-active-worker-40">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-41">Clear Registration</a> <a href="#ref-for-dfn-active-worker-42">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-43">Update Registration State</a> <a href="#ref-for-dfn-active-worker-44">(2)</a> <a href="#ref-for-dfn-active-worker-45">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-46">Update Worker State</a> <a href="#ref-for-dfn-active-worker-47">(2)</a> <a href="#ref-for-dfn-active-worker-48">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-49">Match Service Worker for Foreign Fetch</a>
+    <li><a href="#ref-for-dfn-active-worker-50">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker-51">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-last-update-check-time">
@@ -8137,8 +8246,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-client-36">Appendix A: Algorithms</a>
     <li><a href="#ref-for-dfn-service-worker-client-37">Create Job</a>
     <li><a href="#ref-for-dfn-service-worker-client-38">Start Register</a>
-    <li><a href="#ref-for-dfn-service-worker-client-39">Install</a> <a href="#ref-for-dfn-service-worker-client-40">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-client-41">Activate</a> <a href="#ref-for-dfn-service-worker-client-42">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-client-39">Install</a>
+    <li><a href="#ref-for-dfn-service-worker-client-40">Activate</a> <a href="#ref-for-dfn-service-worker-client-41">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-client-42">Try Activate</a>
     <li><a href="#ref-for-dfn-service-worker-client-43">Run Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-client-44">Handle Fetch</a>
     <li><a href="#ref-for-dfn-service-worker-client-45">Handle Service Worker Client Unload</a> <a href="#ref-for-dfn-service-worker-client-46">(2)</a> <a href="#ref-for-dfn-service-worker-client-47">(3)</a>
@@ -8211,8 +8321,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-use-1">2.4. Selection and Use</a>
     <li><a href="#ref-for-dfn-use-2">3.5. Events</a>
     <li><a href="#ref-for-dfn-use-3">4.1.3. skipWaiting()</a>
-    <li><a href="#ref-for-dfn-use-4">Install</a>
-    <li><a href="#ref-for-dfn-use-5">Activate</a>
+    <li><a href="#ref-for-dfn-use-4">Activate</a>
+    <li><a href="#ref-for-dfn-use-5">Try Activate</a>
     <li><a href="#ref-for-dfn-use-6">Handle Fetch</a>
     <li><a href="#ref-for-dfn-use-7">Handle Service Worker Client Unload</a> <a href="#ref-for-dfn-use-8">(2)</a>
     <li><a href="#ref-for-dfn-use-9">Unregister</a>
@@ -8644,16 +8754,20 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-1">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-2">3.2.7. update()</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-3">4.1.2. registration</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-4">4.2.5. postMessage(message, transfer)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-5">4.2.10. navigate(url)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-6">(2)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-7">4.3.1. get(id)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-8">4.3.2. matchAll(options)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-9">(2)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-10">4.3.3. openWindow(url)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-11">4.3.4. claim()</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-12">(2)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-13">(3)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-14">(4)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-15">(5)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-16">4.5.1. event.registerForeignFetch(options)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-17">4.9. Events</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-18">(2)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-19">(3)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-20">(4)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-21">7.3.2. importScripts(urls)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-22">Run Service Worker</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-4">4.1.3. skipWaiting()</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-5">(2)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-6">4.2.5. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-7">4.2.10. navigate(url)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-8">(2)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-9">4.3.1. get(id)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-10">4.3.2. matchAll(options)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-11">(2)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-12">4.3.3. openWindow(url)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-13">4.3.4. claim()</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-14">(2)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-15">(3)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-16">(4)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-17">(5)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-18">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-19">4.5.1. event.registerForeignFetch(options)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-20">4.6.7. event.respondWith(r)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-21">4.7.3. event.respondWith(r)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-22">4.9. Events</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-23">(2)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-24">(3)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-25">(4)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-26">7.3.2. importScripts(urls)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-27">Run Service Worker</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">
@@ -8682,6 +8796,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting-1">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting-2">4.1.3. skipWaiting()</a> <a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting-3">(2)</a>
+    <li><a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting-4">Install</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-oninstall">
@@ -8982,7 +9097,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-8">4.4.1. event.waitUntil(f)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-9">4.6.7. event.respondWith(r)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-10">4.7.3. event.respondWith(r)</a>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-11">Install</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-11">Install</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-12">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="extendableevent-pending-promises-count">
@@ -8993,6 +9108,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-extendableevent-pending-promises-count-9">4.7.3. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-10">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count-11">(3)</a>
     <li><a href="#ref-for-extendableevent-pending-promises-count-12">Install</a>
     <li><a href="#ref-for-extendableevent-pending-promises-count-13">Activate</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-14">Update Service Worker Extended Events Set</a> <a href="#ref-for-extendableevent-pending-promises-count-15">(2)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-16">Service Worker Has No Pending Events</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-extendableevent-waituntil">
@@ -9860,9 +9977,20 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-activate-2">3.5. Events</a> <a href="#ref-for-activate-3">(2)</a>
     <li><a href="#ref-for-activate-4">4.4. ExtendableEvent</a> <a href="#ref-for-activate-5">(2)</a>
     <li><a href="#ref-for-activate-6">4.9. Events</a>
-    <li><a href="#ref-for-activate-7">Install</a>
-    <li><a href="#ref-for-activate-8">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-activate-9">Handle User Agent Shutdown</a>
+    <li><a href="#ref-for-activate-7">Install</a> <a href="#ref-for-activate-8">(2)</a>
+    <li><a href="#ref-for-activate-9">Try Activate</a>
+    <li><a href="#ref-for-activate-10">Handle User Agent Shutdown</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="try-activate">
+   <b><a href="#try-activate">#try-activate</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-try-activate-1">4.1.3. skipWaiting()</a>
+    <li><a href="#ref-for-try-activate-2">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-try-activate-3">4.6.7. event.respondWith(r)</a>
+    <li><a href="#ref-for-try-activate-4">4.7.3. event.respondWith(r)</a>
+    <li><a href="#ref-for-try-activate-5">Install</a> <a href="#ref-for-try-activate-6">(2)</a>
+    <li><a href="#ref-for-try-activate-7">Handle Service Worker Client Unload</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="run-service-worker">
@@ -9885,11 +10013,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-terminate-service-worker-2">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-terminate-service-worker-3">4.4.1. event.waitUntil(f)</a>
     <li><a href="#ref-for-terminate-service-worker-4">Install</a> <a href="#ref-for-terminate-service-worker-5">(2)</a>
-    <li><a href="#ref-for-terminate-service-worker-6">Activate</a> <a href="#ref-for-terminate-service-worker-7">(2)</a>
-    <li><a href="#ref-for-terminate-service-worker-8">Handle Fetch</a>
-    <li><a href="#ref-for-terminate-service-worker-9">Handle Foreign Fetch</a>
-    <li><a href="#ref-for-terminate-service-worker-10">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-terminate-service-worker-11">Clear Registration</a> <a href="#ref-for-terminate-service-worker-12">(2)</a> <a href="#ref-for-terminate-service-worker-13">(3)</a>
+    <li><a href="#ref-for-terminate-service-worker-6">Activate</a>
+    <li><a href="#ref-for-terminate-service-worker-7">Handle Fetch</a>
+    <li><a href="#ref-for-terminate-service-worker-8">Handle Foreign Fetch</a>
+    <li><a href="#ref-for-terminate-service-worker-9">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-terminate-service-worker-10">Clear Registration</a> <a href="#ref-for-terminate-service-worker-11">(2)</a> <a href="#ref-for-terminate-service-worker-12">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-fetch">
@@ -9920,12 +10048,22 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#handle-service-worker-client-unload">#handle-service-worker-client-unload</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-service-worker-client-unload-1">4.3.4. claim()</a>
+    <li><a href="#ref-for-handle-service-worker-client-unload-2">Install</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-user-agent-shutdown">
    <b><a href="#handle-user-agent-shutdown">#handle-user-agent-shutdown</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-user-agent-shutdown-1">2.6. User Agent Shutdown</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="update-service-worker-extended-events-set">
+   <b><a href="#update-service-worker-extended-events-set">#update-service-worker-extended-events-set</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-update-service-worker-extended-events-set-1">3.1.3. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-update-service-worker-extended-events-set-2">Handle Fetch</a>
+    <li><a href="#ref-for-update-service-worker-extended-events-set-3">Handle Foreign Fetch</a>
+    <li><a href="#ref-for-update-service-worker-extended-events-set-4">Handle Functional Event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="unregister">
@@ -10012,6 +10150,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-get-newest-worker-4">Soft Update</a>
     <li><a href="#ref-for-get-newest-worker-5">Install</a>
     <li><a href="#ref-for-get-newest-worker-6">Handle User Agent Shutdown</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="service-worker-has-no-pending-events">
+   <b><a href="#service-worker-has-no-pending-events">#service-worker-has-no-pending-events</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-service-worker-has-no-pending-events-1">Try Activate</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="create-client">

--- a/docs/index.html
+++ b/docs/index.html
@@ -419,7 +419,7 @@
 	[data-algorithm]:not(.heading) {
 	  padding: .5em;
 	  border: thin solid #ddd; border-radius: .5em;
-	  margin: .5em 0;
+	  margin: .5em calc(-0.5em - 1px);
 	}
 	[data-algorithm]:not(.heading) > :first-child {
 	  margin-top: 0;
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 90eb18a0d2a7680cdd94ecc3b342163de5a3fd43" name="generator">
+  <meta content="Bikeshed version 2de6f41e63a9bd84932e1a28745f8d452d3b0e46" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-03">3 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-08">8 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1773,7 +1773,7 @@ pre.idl.highlight { color: #708090; }
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-25">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-skip-waiting-flag">skip waiting flag</dfn>. Unless stated otherwise it is unset.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-26">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-imported-scripts-updated-flag">imported scripts updated flag</dfn>. It is initially unset.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-27">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-set-of-event-types-to-handle">set of event types to handle</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a>) whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item">item</a> is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-listener">event listener</a>’s event type. It is initially an empty set.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-28">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-set-of-extended-events">set of extended events</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a>) whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item">item</a> is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event">event</a>. It is initially an empty set.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-28">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-set-of-extended-events">set of extended events</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a>) whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item">item</a> is an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-1">ExtendableEvent</a></code>. It is initially an empty set.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-29">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-foreign-fetch-scopes">list of foreign fetch scopes</dfn> whose element type is a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>. It is initially empty.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-30">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-foreign-fetch-origins">list of foreign fetch origins</dfn> whose element type is a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>. It is initially empty.</p>
      <section>
@@ -3033,7 +3033,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </section>
     </section>
     <section>
-     <h3 class="heading settled" data-level="4.4" id="extendableevent-interface"><span class="secno">4.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-1">ExtendableEvent</a></code></span><a class="self-link" href="#extendableevent-interface"></a></h3>
+     <h3 class="heading settled" data-level="4.4" id="extendableevent-interface"><span class="secno">4.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-2">ExtendableEvent</a></code></span><a class="self-link" href="#extendableevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="ExtendableEvent" data-dfn-type="constructor" data-export="" data-lt="ExtendableEvent(type, eventInitDict)|ExtendableEvent(type)" id="dom-extendableevent-extendableevent">Constructor<a class="self-link" href="#dom-extendableevent-extendableevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="ExtendableEvent/ExtendableEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendableevent-extendableevent-type-eventinitdict-type">type<a class="self-link" href="#dom-extendableevent-extendableevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-extendableeventinit" id="ref-for-dictdef-extendableeventinit-1">ExtendableEventInit</a> <dfn class="nv idl-code" data-dfn-for="ExtendableEvent/ExtendableEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendableevent-extendableevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-extendableevent-extendableevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="extendableevent">ExtendableEvent</dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event">Event</a> {
   <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-1">waitUntil</a>(<span class="kt">Promise</span>&lt;<span class="kt">any</span>> <dfn class="nv idl-code" data-dfn-for="ExtendableEvent/waitUntil(f)" data-dfn-type="argument" data-export="" id="dom-extendableevent-waituntil-f-f">f<a class="self-link" href="#dom-extendableevent-waituntil-f-f"></a></dfn>);
@@ -3043,10 +3043,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   // Defined for the forward compatibility across the derived events
 };
 </pre>
-     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-2">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-extend-lifetime-promises">extend lifetime promises</dfn> (an array of <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a>). It is initially an empty array.</p>
-     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-3">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-pending-promises-count">pending promises count</dfn> (the number of pending promises in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-1">extend lifetime promises</a>). It is initially set to zero.</p>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-59">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-60">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
-     <p><a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> also use or extend the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-5">ExtendableEvent</a></code> interface.</p>
+     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-3">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-extend-lifetime-promises">extend lifetime promises</dfn> (an array of <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a>). It is initially an empty array.</p>
+     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-pending-promises-count">pending promises count</dfn> (the number of pending promises in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-1">extend lifetime promises</a>). It is initially set to zero.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-59">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-60">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-5">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
+     <p><a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> also use or extend the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a></code> interface.</p>
      <section class="algorithm" data-algorithm="wait-until-method">
       <h4 class="heading settled" data-level="4.4.1" id="wait-until-method"><span class="secno">4.4.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-2">event.waitUntil(f)</a></code></span><a class="self-link" href="#wait-until-method"></a></h4>
       <p><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-3">waitUntil()</a></code> method extends the lifetime of the event.</p>
@@ -3089,7 +3089,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.5" id="installevent-interface"><span class="secno">4.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#installevent" id="ref-for-installevent-1">InstallEvent</a></code></span><a class="self-link" href="#installevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="InstallEvent" data-dfn-type="constructor" data-export="" data-lt="InstallEvent(type, eventInitDict)|InstallEvent(type)" id="dom-installevent-installevent">Constructor<a class="self-link" href="#dom-installevent-installevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="InstallEvent/InstallEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-installevent-installevent-type-eventinitdict-type">type<a class="self-link" href="#dom-installevent-installevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-extendableeventinit" id="ref-for-dictdef-extendableeventinit-2">ExtendableEventInit</a> <dfn class="nv idl-code" data-dfn-for="InstallEvent/InstallEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-installevent-installevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-installevent-installevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="installevent">InstallEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="installevent">InstallEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-7">ExtendableEvent</a> {
   <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-installevent-registerforeignfetch" id="ref-for-dom-installevent-registerforeignfetch-1">registerForeignFetch</a>(<a class="n" data-link-type="idl-name" href="#dictdef-foreignfetchoptions" id="ref-for-dictdef-foreignfetchoptions-1">ForeignFetchOptions</a> <dfn class="nv idl-code" data-dfn-for="InstallEvent/registerForeignFetch(options)" data-dfn-type="argument" data-export="" id="dom-installevent-registerforeignfetch-options-options">options<a class="self-link" href="#dom-installevent-registerforeignfetch-options-options"></a></dfn>);
 };
 
@@ -3157,7 +3157,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.6" id="fetchevent-interface"><span class="secno">4.6. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-1">FetchEvent</a></code></span><a class="self-link" href="#fetchevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="FetchEvent" data-dfn-type="constructor" data-export="" data-lt="FetchEvent(type, eventInitDict)" id="dom-fetchevent-fetchevent">Constructor<a class="self-link" href="#dom-fetchevent-fetchevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="FetchEvent/FetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-fetchevent-fetchevent-type-eventinitdict-type">type<a class="self-link" href="#dom-fetchevent-fetchevent-type-eventinitdict-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-fetcheventinit" id="ref-for-dictdef-fetcheventinit-1">FetchEventInit</a> <dfn class="nv idl-code" data-dfn-for="FetchEvent/FetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-fetchevent-fetchevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-fetchevent-fetchevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="fetchevent">FetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-7">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="fetchevent">FetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-8">ExtendableEvent</a> {
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#request">Request</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Request" href="#dom-fetchevent-request" id="ref-for-dom-fetchevent-request-1">request</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">Promise</span>&lt;<span class="kt">any</span>> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Promise<any>" href="#dom-fetchevent-preloadresponse" id="ref-for-dom-fetchevent-preloadresponse-1">preloadResponse</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-fetchevent-clientid" id="ref-for-dom-fetchevent-clientid-1">clientId</a>;
@@ -3177,7 +3177,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="FetchEventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-fetcheventinit-isreload">isReload<a class="self-link" href="#dom-fetcheventinit-isreload"></a></dfn> = <span class="kt">false</span>;
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-68">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-69">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-8">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-68">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-69">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-9">ExtendableEvent</a></code> interface.</p>
      <p>Each event using <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-3">FetchEvent</a></code> interface has an associated <dfn class="dfn-paneled" data-dfn-for="FetchEvent" data-dfn-type="dfn" data-noexport="" id="fetchevent-potential-response">potential response</dfn> (a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>), initially set to null, and the following associated flags that are initially unset:</p>
      <ul>
       <li data-md="">
@@ -3357,7 +3357,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.7" id="foreignfetchevent-interface"><span class="secno">4.7. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#foreignfetchevent" id="ref-for-foreignfetchevent-1">ForeignFetchEvent</a></code></span><a class="self-link" href="#foreignfetchevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="ForeignFetchEvent" data-dfn-type="constructor" data-export="" data-lt="ForeignFetchEvent(type, eventInitDict)" id="dom-foreignfetchevent-foreignfetchevent">Constructor<a class="self-link" href="#dom-foreignfetchevent-foreignfetchevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="ForeignFetchEvent/ForeignFetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-foreignfetchevent-foreignfetchevent-type-eventinitdict-type">type<a class="self-link" href="#dom-foreignfetchevent-foreignfetchevent-type-eventinitdict-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-foreignfetcheventinit" id="ref-for-dictdef-foreignfetcheventinit-1">ForeignFetchEventInit</a> <dfn class="nv idl-code" data-dfn-for="ForeignFetchEvent/ForeignFetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-foreignfetchevent-foreignfetchevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-foreignfetchevent-foreignfetchevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="foreignfetchevent">ForeignFetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-9">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="foreignfetchevent">ForeignFetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-10">ExtendableEvent</a> {
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#request">Request</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Request" href="#dom-foreignfetchevent-request" id="ref-for-dom-foreignfetchevent-request-1">request</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-foreignfetchevent-origin" id="ref-for-dom-foreignfetchevent-origin-1">origin</a>;
 
@@ -3375,7 +3375,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">sequence</span>&lt;<span class="kt">ByteString</span>> <dfn class="nv dfn-paneled idl-code" data-dfn-for="ForeignFetchResponse" data-dfn-type="dict-member" data-export="" data-type="sequence<ByteString> " id="dom-foreignfetchresponse-headers">headers</dfn>;
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-70">Service workers</a> have a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-4">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-2">foreignfetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-3">foreignfetch</a></code> events, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-71">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#foreignfetchevent" id="ref-for-foreignfetchevent-2">ForeignFetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-10">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-70">Service workers</a> have a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-4">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-2">foreignfetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-foreignfetch-event" id="ref-for-service-worker-global-scope-foreignfetch-event-3">foreignfetch</a></code> events, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-71">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#foreignfetchevent" id="ref-for-foreignfetchevent-2">ForeignFetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a></code> interface.</p>
      <p>Each event using <code class="idl"><a data-link-type="idl" href="#foreignfetchevent" id="ref-for-foreignfetchevent-3">ForeignFetchEvent</a></code> interface has an associated <dfn class="dfn-paneled" data-dfn-for="ForeignFetchEvent" data-dfn-type="dfn" data-noexport="" id="foreignfetchevent-potential-response">potential response</dfn> (a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>), initially set to null, an associated <dfn class="dfn-paneled" data-dfn-for="ForeignFetchEvent" data-dfn-type="dfn" data-noexport="" id="foreignfetchevent-origin">origin</dfn> (a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-USVString">USVString</a></code> or null), initially set to null, an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="list-of-exposed-headers">list of exposed headers</dfn> (whose element type is a byte string), initially set to an empty list, and the following associated flags that are initially unset:</p>
      <ul>
       <li data-md="">
@@ -3543,7 +3543,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.8" id="extendablemessageevent-interface"><span class="secno">4.8. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-2">ExtendableMessageEvent</a></code></span><a class="self-link" href="#extendablemessageevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent" data-dfn-type="constructor" data-export="" data-lt="ExtendableMessageEvent(type, eventInitDict)|ExtendableMessageEvent(type)" id="dom-extendablemessageevent-extendablemessageevent">Constructor<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent/ExtendableMessageEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-type">type<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-extendablemessageeventinit" id="ref-for-dictdef-extendablemessageeventinit-1">ExtendableMessageEventInit</a> <dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent/ExtendableMessageEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="extendablemessageevent">ExtendableMessageEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="extendablemessageevent">ExtendableMessageEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-12">ExtendableEvent</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">any</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="any" href="#dom-extendablemessageevent-data" id="ref-for-dom-extendablemessageevent-data-2">data</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-extendablemessageevent-origin" id="ref-for-dom-extendablemessageevent-origin-2">origin</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-extendablemessageevent-lasteventid" id="ref-for-dom-extendablemessageevent-lasteventid-1">lastEventId</a>;
@@ -3559,7 +3559,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/comms.html#messageport">MessagePort</a>> <dfn class="nv idl-code" data-default="None" data-dfn-for="ExtendableMessageEventInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MessagePort> " id="dom-extendablemessageeventinit-ports">ports<a class="self-link" href="#dom-extendablemessageeventinit-ports"></a></dfn> = [];
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-72">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-73">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-12">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-72">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-73">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-13">ExtendableEvent</a></code> interface.</p>
      <section>
       <h4 class="heading settled" data-level="4.8.1" id="extendablemessage-event-data"><span class="secno">4.8.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendablemessageevent-data" id="ref-for-dom-extendablemessageevent-data-3">event.data</a></code></span><a class="self-link" href="#extendablemessage-event-data"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ExtendableMessageEvent" data-dfn-type="attribute" data-export="" id="dom-extendablemessageevent-data">data</dfn> attribute <em>must</em> return the value it was initialized to. When the object is created, this attribute <em>must</em> be initialized to null. It represents the message being sent.</p>
@@ -3597,7 +3597,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-2">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-22">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-13">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-6">installing worker</a> changes. (See step 11.2 of the <a data-link-type="dfn" href="#install" id="ref-for-install-4">Install</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-activate-event"><code>activate</code></dfn>
-        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-13">ExtendableEvent</a></code>
+        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-14">ExtendableEvent</a></code>
         <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-3">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-23">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-21">active worker</a> changes. (See step 12.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-6">Activate</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-fetch-event"><code>fetch</code></dfn>
@@ -4518,7 +4518,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="8.2" id="extension-to-extendable-event"><span class="secno">8.2. </span><span class="content">Define Functional Event</span><a class="self-link" href="#extension-to-extendable-event"></a></h3>
-     <p>Specifications <em>may</em> define a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-7">functional event</a> by extending <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-14">ExtendableEvent</a></code> interface:</p>
+     <p>Specifications <em>may</em> define a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-7">functional event</a> by extending <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-15">ExtendableEvent</a></code> interface:</p>
 <pre class="example idl highlight def" data-no-idl="" id="example-3de376f0"><a class="self-link" href="#example-3de376f0"></a>// e.g. define FunctionalEvent interface
 <span class="kt">interface</span> <span class="nv">FunctionalEvent</span> : <span class="n">ExtendableEvent</span> {
   // add a functional event’s own attributes and methods
@@ -5085,8 +5085,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>newestWorker</var> be the result of running <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-5">Get Newest Worker</a> algorithm passing <var>registration</var> as its argument.</p>
       <li data-md="">
-       <p>Let <var>redundantWorker</var> be null.</p>
-      <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-1">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and <var>worker</var> as the arguments.</p>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-1">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-7">installing worker</a> and <em>installing</em> as the arguments.</p>
@@ -5127,11 +5125,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>installFailed</var> is true, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-9">installing worker</a>.</p>
+         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-2">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-9">installing worker</a> and <em>redundant</em> as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-2">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and null as the arguments.</p>
-        <li data-md="">
-         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-2">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
         <li data-md="">
          <p>If <var>newestWorker</var> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-3">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
         <li data-md="">
@@ -5143,18 +5139,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-6">waiting worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-7">waiting worker</a>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-5">Terminate</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-7">waiting worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-5">Terminate</a> <var>redundantWorker</var>.</p>
+         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-3">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-8">waiting worker</a> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-3">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-11">installing worker</a> as the arguments.</p>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-4">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and null as the arguments.</p>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-3">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-8">waiting worker</a> and <em>installed</em> as the arguments.</p>
-      <li data-md="">
-       <p>If <var>redundantWorker</var> is not null, run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-4">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-4">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-9">waiting worker</a> and <em>installed</em> as the arguments.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-11">Finish Job</a> with <var>job</var>.</p>
       <li data-md="">
@@ -5178,20 +5172,22 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-9">waiting worker</a> is null, abort these steps.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-10">waiting worker</a> is null, abort these steps.</p>
       <li data-md="">
-       <p>Let <var>redundantWorker</var> be null.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-24">active worker</a> is not null, then:</p>
+       <ol>
+        <li data-md="">
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-6">Terminate</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-25">active worker</a>.</p>
+        <li data-md="">
+         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-6">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a> and <em>redundant</em> as the arguments.</p>
+       </ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-24">active worker</a> is not null, <var>redundantWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-25">active worker</a>.</p>
-      <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-5">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-10">waiting worker</a> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-5">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-11">waiting worker</a> as the arguments.</p>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-6">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and null as the arguments.</p>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-6">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a> and <em>activating</em> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-7">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-27">active worker</a> and <em>activating</em> as the arguments.</p>
        <p class="note" role="note"><span>Note:</span> Once an active worker is activating, neither a runtime script error nor a force termination of the active worker prevents the active worker from getting activated.</p>
-      <li data-md="">
-       <p>If <var>redundantWorker</var> is not null, run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-7">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
       <li data-md="">
        <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-40">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-9">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-18">scope url</a>:</p>
        <ol>
@@ -5205,19 +5201,19 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-41">service worker client</a> <var>client</var> who is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-4">using</a> <var>registration</var>:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>client</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-27">active worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-28">active worker</a>.</p>
+         <p>Set <var>client</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-28">active worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-29">active worker</a>.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#notify-controller-change" id="ref-for-notify-controller-change-2">Notify Controller Change</a> algorithm with <var>client</var> as the argument.</p>
        </ol>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-29">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-5">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-15">ExtendableEvent</a></code>.</p>
+         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code>.</p>
         <li data-md="">
          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> attribute to <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-5">activate</a></code>.</p>
         <li data-md="">
@@ -5226,11 +5222,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><em>WaitForAsynchronousExtensions</em>: Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-13">pending promises count</a> is zero.</p>
        </ol>
       <li data-md="">
-       <p>Wait for <var>task</var> to have executed or been discarded, or the script to have been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-6">termination</a> of <var>activeWorker</var>.</p>
+       <p>Wait for <var>task</var> to have executed or been discarded, or the script to have been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">termination</a> of <var>activeWorker</var>.</p>
       <li data-md="">
        <p>Wait for the step labeled <em>WaitForAsynchronousExtensions</em> to complete.</p>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-8">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a> and <em>activated</em> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-8">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-31">active worker</a> and <em>activated</em> as the arguments.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Try Activate">
@@ -5247,9 +5243,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-11">waiting worker</a> is not null.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a> is null, return.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-31">active worker</a> is null, or if the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-1">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-32">active worker</a> is true, and no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-42">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-5">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set, then invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-9">Activate</a> with <var>registration</var>.</p>
+       <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-9">Activate</a> with <var>registration</var> if either of the following is true:</p>
+       <ul>
+        <li data-md="">
+         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-32">active worker</a> is null.</p>
+        <li data-md="">
+         <p>The result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-1">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-33">active worker</a> is true, and no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-42">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-5">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set.</p>
+       </ul>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Run Service Worker">
@@ -5340,7 +5342,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Create a new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">WorkerLocation</a></code> object and associate it with <var>workerGlobalScope</var>.</p>
       <li data-md="">
-       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-33">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-17">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
+       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-34">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-17">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
       <li data-md="">
        <p>If <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>, then <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">run the classic script</a> <var>script</var>. Otherwise, it is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">module script</a>; <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">run the module script</a> <var>script</var>.</p>
        <p class="note" role="note"><span>Note:</span> In addition to the usual possibilities of returning a value or failing due to an exception, this could be prematurely aborted by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">kill a worker</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">terminate a worker</a> algorithms.</p>
@@ -5384,6 +5386,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Let <var>serviceWorkerGlobalScope</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-4">global object</a>.</p>
       <li data-md="">
        <p>Set <var>serviceWorkerGlobalScope</var>’s closing flag to true.</p>
+      <li data-md="">
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove">Remove</a> all the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item">items</a> from <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-1">set of extended events</a>.</p>
       <li data-md="">
        <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-18">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
        <p class="note" role="note"><span>Note:</span> This effectively means that the fetch events and the other functional events such as push events are backed up by the registration’s task queues while the other tasks including message events are discarded.</p>
@@ -5456,12 +5460,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>registration</var> to the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-10">Match Service Worker Registration</a> algorithm passing <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url">url</a> as the argument.</p>
         <li data-md="">
-         <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-34">active worker</a> is null, return null.</p>
+         <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-35">active worker</a> is null, return null.</p>
         <li data-md="">
-         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-35">active worker</a>.</p>
+         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-36">active worker</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request">navigation request</a>, <var>registration</var>’s <a data-link-type="dfn" href="#service-worker-registration-navigation-preload-enabled-flag" id="ref-for-service-worker-registration-navigation-preload-enabled-flag-4">navigation preload enabled flag</a> is set, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method">method</a> is `<code>GET</code>`, and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-36">active worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-2">set of event types to handle</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contains</a> <code>fetch</code>, then:</p>
-         <p class="note" role="note"><span>Note:</span> If the above is true except <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-3">set of event types to handle</a> <strong>does not</strong> contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer’s intent isn’t clear.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request">navigation request</a>, <var>registration</var>’s <a data-link-type="dfn" href="#service-worker-registration-navigation-preload-enabled-flag" id="ref-for-service-worker-registration-navigation-preload-enabled-flag-4">navigation preload enabled flag</a> is set, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method">method</a> is `<code>GET</code>`, and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-2">set of event types to handle</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contains</a> <code>fetch</code>, then:</p>
+         <p class="note" role="note"><span>Note:</span> If the above is true except <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-3">set of event types to handle</a> <strong>does not</strong> contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer’s intent isn’t clear.</p>
          <ol>
           <li data-md="">
            <p>Let <var>preloadRequest</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-clone">cloning</a> the request <var>request</var>.</p>
@@ -5502,7 +5506,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Else, return null.</p>
        </ol>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a>.</p>
       <li data-md="">
        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-4">set of event types to handle</a> does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> <code>fetch</code>, then:</p>
        <ol>
@@ -5558,7 +5562,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>If <var>e</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#canceled-flag">canceled flag</a> is set, set <var>eventCanceled</var> to true.</p>
        </ol>
-       <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">termination</a> of <var>activeWorker</var>, set <var>handleFetchFailed</var> to true.</p>
+       <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-8">termination</a> of <var>activeWorker</var>, set <var>handleFetchFailed</var> to true.</p>
        <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-4">handle fetch task source</a>.</p>
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded.</p>
@@ -5704,7 +5708,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>If <var>e</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#canceled-flag">canceled flag</a> is set, set <var>eventCanceled</var> to true.</p>
         </ol>
-        <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-8">termination</a> of <var>activeWorker</var>, set <var>handleFetchFailed</var> to true.</p>
+        <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-9">termination</a> of <var>activeWorker</var>, set <var>handleFetchFailed</var> to true.</p>
         <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-5">handle fetch task source</a>.</p>
        <li data-md="">
         <p>Wait for <var>task</var> to have executed or been discarded.</p>
@@ -5745,7 +5749,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code> object</p>
+       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-17">ExtendableEvent</a></code> object</p>
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-63">service worker registration</a></p>
       <dd data-md="">
@@ -5759,9 +5763,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p class="assertion">Assert: <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-7">scope to registration map</a> contains a value equal to <var>registration</var>.</p>
       <li data-md="">
-       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a> is not null.</p>
+       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a> is not null.</p>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a>.</p>
       <li data-md="">
        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-5">set of event types to handle</a> does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> <var>event</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code>, then:</p>
        <ol>
@@ -5794,7 +5798,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section class="algorithm" data-algorithm="Handle Service Worker Client Unload">
      <h3 class="heading settled" id="on-client-unload-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="handle-service-worker-client-unload">Handle Service Worker Client Unload</dfn></span><a class="self-link" href="#on-client-unload-algorithm"></a></h3>
-     <p>The user agent <em>must</em> run these steps when a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-45">service worker client</a> unloads by <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unload-a-document">unloading</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">being killed</a>, or <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-9">terminating</a>.</p>
+     <p>The user agent <em>must</em> run these steps when a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-45">service worker client</a> unloads by <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unload-a-document">unloading</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">being killed</a>, or <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-10">terminating</a>.</p>
      <dl>
       <dt data-md="">
        <p>Input</p>
@@ -5817,7 +5821,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-4">uninstalling flag</a> is set, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-4">Clear Registration</a> algorithm passing <var>registration</var> as its argument and abort these steps.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a> is not null, invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-7">Try Activate</a> with <var>registration</var>.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-14">waiting worker</a> is not null, invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-7">Try Activate</a> with <var>registration</var>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle User Agent Shutdown">
@@ -5845,7 +5849,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <p>Else, set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-13">installing worker</a> to null.</p>
          </ol>
         <li data-md="">
-         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-14">waiting worker</a> is not null, run the following substep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-15">waiting worker</a> is not null, run the following substep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
          <ol>
           <li data-md="">
            <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-10">Activate</a> with <var>registration</var>.</p>
@@ -5871,13 +5875,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p class="assertion">Assert: <var>event</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is unset.</p>
       <li data-md="">
-       <p>For each <var>item</var> of <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-1">set of extended events</a>:</p>
+       <p>For each <var>item</var> of <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-2">set of extended events</a>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>item</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-14">pending promises count</a> is zero, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove">remove</a> <var>item</var> from <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-2">set of extended events</a>.</p>
+         <p>If <var>item</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-14">pending promises count</a> is zero, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove">remove</a> <var>item</var> from <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-3">set of extended events</a>.</p>
        </ol>
       <li data-md="">
-       <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-15">pending promises count</a> is not zero, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append">append</a> <var>event</var> to <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-3">set of extended events</a>.</p>
+       <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-15">pending promises count</a> is not zero, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append">append</a> <var>event</var> to <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-4">set of extended events</a>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Unregister">
@@ -5972,31 +5976,31 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-15">installing worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-10">Terminate</a> <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-11">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-7">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and null as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-9">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-15">waiting worker</a> is not null, then:</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-16">waiting worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-16">waiting worker</a>.</p>
+         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-17">waiting worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-11">Terminate</a> <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-12">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-8">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and null as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-10">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a> is not null, then:</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-42">active worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-42">active worker</a>.</p>
+         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-43">active worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-12">Terminate</a> <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-13">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-9">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and null as the arguments.</p>
         <li data-md="">
@@ -6043,24 +6047,24 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Else if <var>target</var> is "<code>waiting</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-17">waiting worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-18">waiting worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-waiting" id="ref-for-dom-serviceworkerregistration-waiting-3">waiting</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-26">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-18">waiting worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-19">waiting worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-waiting" id="ref-for-dom-serviceworkerregistration-waiting-3">waiting</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-26">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-19">waiting worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a> is null.</p>
          </ol>
        </ol>
       <li data-md="">
        <p>Else if <var>target</var> is "<code>active</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-43">active worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-44">active worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-3">active</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-27">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-44">active worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-45">active worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-3">active</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-27">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-45">active worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-46">active worker</a> is null.</p>
          </ol>
        </ol>
        <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <em>must</em> use <var>registrationObject</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>.</p>
@@ -6103,17 +6107,17 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
              <p><em>installed</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installed" id="ref-for-dom-serviceworkerstate-installed-1">"installed"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a>.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-21">waiting worker</a>.</p>
             <dt data-md="">
              <p><em>activating</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activating" id="ref-for-dom-serviceworkerstate-activating-1">"activating"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-46">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-9">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-47">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-12">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-47">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-9">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-48">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-12">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
             <dt data-md="">
              <p><em>activated</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activated" id="ref-for-dom-serviceworkerstate-activated-1">"activated"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-48">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-13">functional events</a>.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-49">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-13">functional events</a>.</p>
             <dt data-md="">
              <p><em>redundant</em></p>
             <dd data-md="">
@@ -6203,7 +6207,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var> is null, return null.</p>
       <li data-md="">
-       <p>Let <var>worker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-49">active worker</a>.</p>
+       <p>Let <var>worker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-50">active worker</a>.</p>
       <li data-md="">
        <p>If <var>worker</var> is null, return null.</p>
       <li data-md="">
@@ -6271,9 +6275,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-21">installing worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-22">installing worker</a>.</p>
       <li data-md="">
-       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-21">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-22">waiting worker</a>.</p>
+       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-22">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-23">waiting worker</a>.</p>
       <li data-md="">
-       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-50">active worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-51">active worker</a>.</p>
+       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-51">active worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-52">active worker</a>.</p>
       <li data-md="">
        <p>Return <var>newestWorker</var>.</p>
      </ol>
@@ -6294,7 +6298,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>sum</var> be zero.</p>
       <li data-md="">
-       <p>For each <var>item</var> of <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-4">set of extended events</a>:</p>
+       <p>For each <var>item</var> of <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-5">set of extended events</a>:</p>
        <ol>
         <li data-md="">
          <p>Add <var>item</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-16">pending promises count</a> to <var>sum</var>.</p>
@@ -8028,8 +8032,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-set-of-extended-events">
    <b><a href="#dfn-set-of-extended-events">#dfn-set-of-extended-events</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-set-of-extended-events-1">Update Service Worker Extended Events Set</a> <a href="#ref-for-dfn-set-of-extended-events-2">(2)</a> <a href="#ref-for-dfn-set-of-extended-events-3">(3)</a>
-    <li><a href="#ref-for-dfn-set-of-extended-events-4">Service Worker Has No Pending Events</a>
+    <li><a href="#ref-for-dfn-set-of-extended-events-1">Terminate Service Worker</a>
+    <li><a href="#ref-for-dfn-set-of-extended-events-2">Update Service Worker Extended Events Set</a> <a href="#ref-for-dfn-set-of-extended-events-3">(2)</a> <a href="#ref-for-dfn-set-of-extended-events-4">(3)</a>
+    <li><a href="#ref-for-dfn-set-of-extended-events-5">Service Worker Has No Pending Events</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-foreign-fetch-scopes">
@@ -8129,15 +8134,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-waiting-worker-2">2.6. User Agent Shutdown</a>
     <li><a href="#ref-for-dfn-waiting-worker-3">4.1.3. skipWaiting()</a>
     <li><a href="#ref-for-dfn-waiting-worker-4">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-waiting-worker-5">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-6">Install</a> <a href="#ref-for-dfn-waiting-worker-7">(2)</a> <a href="#ref-for-dfn-waiting-worker-8">(3)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-9">Activate</a> <a href="#ref-for-dfn-waiting-worker-10">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-11">Try Activate</a> <a href="#ref-for-dfn-waiting-worker-12">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-13">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-dfn-waiting-worker-14">Handle User Agent Shutdown</a>
-    <li><a href="#ref-for-dfn-waiting-worker-15">Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-16">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-17">Update Registration State</a> <a href="#ref-for-dfn-waiting-worker-18">(2)</a> <a href="#ref-for-dfn-waiting-worker-19">(3)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-20">Update Worker State</a>
-    <li><a href="#ref-for-dfn-waiting-worker-21">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker-22">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-6">Install</a> <a href="#ref-for-dfn-waiting-worker-7">(2)</a> <a href="#ref-for-dfn-waiting-worker-8">(3)</a> <a href="#ref-for-dfn-waiting-worker-9">(4)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-10">Activate</a> <a href="#ref-for-dfn-waiting-worker-11">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-12">Try Activate</a> <a href="#ref-for-dfn-waiting-worker-13">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-14">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-dfn-waiting-worker-15">Handle User Agent Shutdown</a>
+    <li><a href="#ref-for-dfn-waiting-worker-16">Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-17">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-18">Update Registration State</a> <a href="#ref-for-dfn-waiting-worker-19">(2)</a> <a href="#ref-for-dfn-waiting-worker-20">(3)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-21">Update Worker State</a>
+    <li><a href="#ref-for-dfn-waiting-worker-22">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker-23">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-active-worker">
@@ -8156,16 +8161,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-active-worker-20">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dfn-active-worker-21">4.9. Events</a>
     <li><a href="#ref-for-dfn-active-worker-22">Install</a> <a href="#ref-for-dfn-active-worker-23">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-24">Activate</a> <a href="#ref-for-dfn-active-worker-25">(2)</a> <a href="#ref-for-dfn-active-worker-26">(3)</a> <a href="#ref-for-dfn-active-worker-27">(4)</a> <a href="#ref-for-dfn-active-worker-28">(5)</a> <a href="#ref-for-dfn-active-worker-29">(6)</a> <a href="#ref-for-dfn-active-worker-30">(7)</a>
-    <li><a href="#ref-for-dfn-active-worker-31">Try Activate</a> <a href="#ref-for-dfn-active-worker-32">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-33">Run Service Worker</a>
-    <li><a href="#ref-for-dfn-active-worker-34">Handle Fetch</a> <a href="#ref-for-dfn-active-worker-35">(2)</a> <a href="#ref-for-dfn-active-worker-36">(3)</a> <a href="#ref-for-dfn-active-worker-37">(4)</a> <a href="#ref-for-dfn-active-worker-38">(5)</a>
-    <li><a href="#ref-for-dfn-active-worker-39">Handle Functional Event</a> <a href="#ref-for-dfn-active-worker-40">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-41">Clear Registration</a> <a href="#ref-for-dfn-active-worker-42">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-43">Update Registration State</a> <a href="#ref-for-dfn-active-worker-44">(2)</a> <a href="#ref-for-dfn-active-worker-45">(3)</a>
-    <li><a href="#ref-for-dfn-active-worker-46">Update Worker State</a> <a href="#ref-for-dfn-active-worker-47">(2)</a> <a href="#ref-for-dfn-active-worker-48">(3)</a>
-    <li><a href="#ref-for-dfn-active-worker-49">Match Service Worker for Foreign Fetch</a>
-    <li><a href="#ref-for-dfn-active-worker-50">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker-51">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-24">Activate</a> <a href="#ref-for-dfn-active-worker-25">(2)</a> <a href="#ref-for-dfn-active-worker-26">(3)</a> <a href="#ref-for-dfn-active-worker-27">(4)</a> <a href="#ref-for-dfn-active-worker-28">(5)</a> <a href="#ref-for-dfn-active-worker-29">(6)</a> <a href="#ref-for-dfn-active-worker-30">(7)</a> <a href="#ref-for-dfn-active-worker-31">(8)</a>
+    <li><a href="#ref-for-dfn-active-worker-32">Try Activate</a> <a href="#ref-for-dfn-active-worker-33">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-34">Run Service Worker</a>
+    <li><a href="#ref-for-dfn-active-worker-35">Handle Fetch</a> <a href="#ref-for-dfn-active-worker-36">(2)</a> <a href="#ref-for-dfn-active-worker-37">(3)</a> <a href="#ref-for-dfn-active-worker-38">(4)</a> <a href="#ref-for-dfn-active-worker-39">(5)</a>
+    <li><a href="#ref-for-dfn-active-worker-40">Handle Functional Event</a> <a href="#ref-for-dfn-active-worker-41">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-42">Clear Registration</a> <a href="#ref-for-dfn-active-worker-43">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-44">Update Registration State</a> <a href="#ref-for-dfn-active-worker-45">(2)</a> <a href="#ref-for-dfn-active-worker-46">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-47">Update Worker State</a> <a href="#ref-for-dfn-active-worker-48">(2)</a> <a href="#ref-for-dfn-active-worker-49">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-50">Match Service Worker for Foreign Fetch</a>
+    <li><a href="#ref-for-dfn-active-worker-51">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker-52">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-last-update-check-time">
@@ -9069,15 +9074,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="extendableevent">
    <b><a href="#extendableevent">#extendableevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendableevent-1">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-2">(2)</a> <a href="#ref-for-extendableevent-3">(3)</a> <a href="#ref-for-extendableevent-4">(4)</a> <a href="#ref-for-extendableevent-5">(5)</a>
-    <li><a href="#ref-for-extendableevent-6">4.5. InstallEvent</a>
-    <li><a href="#ref-for-extendableevent-7">4.6. FetchEvent</a> <a href="#ref-for-extendableevent-8">(2)</a>
-    <li><a href="#ref-for-extendableevent-9">4.7. ForeignFetchEvent</a> <a href="#ref-for-extendableevent-10">(2)</a>
-    <li><a href="#ref-for-extendableevent-11">4.8. ExtendableMessageEvent</a> <a href="#ref-for-extendableevent-12">(2)</a>
-    <li><a href="#ref-for-extendableevent-13">4.9. Events</a>
-    <li><a href="#ref-for-extendableevent-14">8.2. Define Functional Event</a>
-    <li><a href="#ref-for-extendableevent-15">Activate</a>
-    <li><a href="#ref-for-extendableevent-16">Handle Functional Event</a>
+    <li><a href="#ref-for-extendableevent-1">2.1. Service Worker</a>
+    <li><a href="#ref-for-extendableevent-2">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-3">(2)</a> <a href="#ref-for-extendableevent-4">(3)</a> <a href="#ref-for-extendableevent-5">(4)</a> <a href="#ref-for-extendableevent-6">(5)</a>
+    <li><a href="#ref-for-extendableevent-7">4.5. InstallEvent</a>
+    <li><a href="#ref-for-extendableevent-8">4.6. FetchEvent</a> <a href="#ref-for-extendableevent-9">(2)</a>
+    <li><a href="#ref-for-extendableevent-10">4.7. ForeignFetchEvent</a> <a href="#ref-for-extendableevent-11">(2)</a>
+    <li><a href="#ref-for-extendableevent-12">4.8. ExtendableMessageEvent</a> <a href="#ref-for-extendableevent-13">(2)</a>
+    <li><a href="#ref-for-extendableevent-14">4.9. Events</a>
+    <li><a href="#ref-for-extendableevent-15">8.2. Define Functional Event</a>
+    <li><a href="#ref-for-extendableevent-16">Activate</a>
+    <li><a href="#ref-for-extendableevent-17">Handle Functional Event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-extendableeventinit">
@@ -10013,11 +10019,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-terminate-service-worker-2">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-terminate-service-worker-3">4.4.1. event.waitUntil(f)</a>
     <li><a href="#ref-for-terminate-service-worker-4">Install</a> <a href="#ref-for-terminate-service-worker-5">(2)</a>
-    <li><a href="#ref-for-terminate-service-worker-6">Activate</a>
-    <li><a href="#ref-for-terminate-service-worker-7">Handle Fetch</a>
-    <li><a href="#ref-for-terminate-service-worker-8">Handle Foreign Fetch</a>
-    <li><a href="#ref-for-terminate-service-worker-9">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-terminate-service-worker-10">Clear Registration</a> <a href="#ref-for-terminate-service-worker-11">(2)</a> <a href="#ref-for-terminate-service-worker-12">(3)</a>
+    <li><a href="#ref-for-terminate-service-worker-6">Activate</a> <a href="#ref-for-terminate-service-worker-7">(2)</a>
+    <li><a href="#ref-for-terminate-service-worker-8">Handle Fetch</a>
+    <li><a href="#ref-for-terminate-service-worker-9">Handle Foreign Fetch</a>
+    <li><a href="#ref-for-terminate-service-worker-10">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-terminate-service-worker-11">Clear Registration</a> <a href="#ref-for-terminate-service-worker-12">(2)</a> <a href="#ref-for-terminate-service-worker-13">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-fetch">

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -161,6 +161,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A [=/service worker=] has an associated <dfn export id="dfn-set-of-event-types-to-handle">set of event types to handle</dfn> (a [=ordered set|set=]) whose [=item=] is an <a>event listener</a>'s event type. It is initially an empty set.
 
+    A [=/service worker=] has an associated <dfn export id="dfn-set-of-extended-events">set of extended events</dfn> (a [=ordered set|set=]) whose [=item=] is an [=event=]. It is initially an empty set.
+
     <section>
       <h4 id="service-worker-lifetime">Lifetime</h4>
 
@@ -347,6 +349,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             1. Else, let it be initialized to a new {{Client}} object that represents the worker associated with |incumbentGlobal|.
             1. Let the {{ExtendableMessageEvent/ports}} attribute of |e| be initialized to |newPorts|.
             1. <a>Dispatch</a> |e| at |destination|.
+            1. Invoke [=Update Service Worker Extended Events Set=] with |serviceWorker| and |e|.
 
             The <a>task</a> *must* use the <a>DOM manipulation task source</a>.
     </section>
@@ -826,7 +829,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
         1. Let |promise| be a new <a>promise</a>.
         1. Run the following substeps <a>in parallel</a>:
-            1. Set [=/service worker=]'s <a>skip waiting flag</a>.
+            1. Set [=ServiceWorkerGlobalScope/service worker=]'s <a>skip waiting flag</a>.
+            1. Invoke [=Try Activate=] with [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
             1. Resolve |promise| with undefined.
         1. Return |promise|.
     </section>
@@ -1232,11 +1236,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             Note: If no lifetime extension promise has been added in the task that called the event handlers), calling {{ExtendableEvent/waitUntil()}} in subsequent asynchronous tasks will throw.
 
         1. Add |f| to the [=ExtendableEvent/extend lifetime promises=].
-        1. Increase the [=ExtendableEvent/pending promises count=] by one.
+        1. Increment the [=ExtendableEvent/pending promises count=] by one.
 
-            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done in the microtask queued by the reaction to the promise.
+            Note: The [=ExtendableEvent/pending promises count=] is incremented even if the given promise has already been settled. The corresponding count decrement is done in the microtask queued by the reaction to the promise.
 
-        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |f|, [=queue a microtask=] to decrease the [=ExtendableEvent/pending promises count=] by one.
+        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |f|, [=queue a microtask=] to run these substeps:
+            1. Decrement the [=ExtendableEvent/pending promises count=] by one.
+            1. Invoke [=Try Activate=] with the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
 
         The user agent *should not* <a lt="terminate service worker">terminate</a> the [=/service worker=] associated with |event|'s <a>relevant settings object</a>'s [=environment settings object/global object=] when |event|'s [=dispatch flag=] is set or |event|'s [=ExtendableEvent/pending promises count=] is not zero. However, the user agent *may* impose a time limit to this lifetime extension.
     </section>
@@ -1328,11 +1334,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             1. <a>Throw</a> an "{{InvalidStateError}}" exception.
             1. Abort these steps.
         1. Add |r| to the <a>extend lifetime promises</a>.
-        1. Increase the [=ExtendableEvent/pending promises count=] by one.
+        1. Increment the [=ExtendableEvent/pending promises count=] by one.
 
-            Note: The [=ExtendableEvent/pending promises count=] is increased even if the given promise has already been settled. The corresponding count decrease is done in the microtask queued by the reaction to the promise.
+            Note: The [=ExtendableEvent/pending promises count=] is incremented even if the given promise has already been settled. The corresponding count decrement is done in the microtask queued by the reaction to the promise.
 
-        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |r|, [=queue a microtask=] to decrease the [=ExtendableEvent/pending promises count=] by one.
+        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |r|, [=queue a microtask=] to run these substeps:
+            1. Decrement the [=ExtendableEvent/pending promises count=] by one.
+            1. Invoke [=Try Activate=] with the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
 
             Note: {{FetchEvent/respondWith(r)|event.respondWith(r)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(r)}} is called.
 
@@ -2347,15 +2355,15 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If |registration|'s <a>waiting worker</a> is not null, then:
           1. Set |redundantWorker| to |registration|'s <a>waiting worker</a>.
           1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
-          1. The user agent *may* abort in-flight requests triggered by |redundantWorker|.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>waiting</code>" and |registration|'s <a>installing worker</a> as the arguments.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and null as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>waiting worker</a> and *installed* as the arguments.
       1. If |redundantWorker| is not null, run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. Invoke <a>Finish Job</a> with |job|.
       1. Wait for all the <a>tasks</a> <a lt="queue a task">queued</a> by <a>Update Worker State</a> invoked in this algorithm have executed.
-      1. Wait until no [=/service worker client=] is <a>using</a> |registration| or |registration|'s <a>waiting worker</a>'s <a>skip waiting flag</a> is set.
-      1. If |registration|'s <a>waiting worker</a> is not null, invoke <a>Activate</a> algorithm with |registration| as its argument.
+      1. Invoke [=Try Activate=] with |registration|.
+
+          Note: If [=Try Activate=] does not trigger [=Activate=] here, [=Activate=] is tried again when the last client controlled by the existing [=active worker=] is [=Handle Service Worker Client Unload|unloaded=], {{ServiceWorkerGlobalScope/skipWaiting()}} is asynchronously called, and the [=extend lifetime promises=] for the existing [=active worker=] settle.
   </section>
 
   <section algorithm>
@@ -2368,10 +2376,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       1. If |registration|'s <a>waiting worker</a> is null, abort these steps.
       1. Let |redundantWorker| be null.
-      1. If |registration|'s <a>active worker</a> is not null, then:
-          1. Set |redundantWorker| to |registration|'s <a>active worker</a>.
-          1. Wait for |redundantWorker| to finish handling any in-progress requests.
-          1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
+      1. If |registration|'s [=active worker=] is not null, |redundantWorker| be |registration|'s [=active worker=].
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>active</code>" and |registration|'s <a>waiting worker</a> as the arguments.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>waiting</code>" and null as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>active worker</a> and *activating* as the arguments.
@@ -2398,6 +2403,18 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Wait for |task| to have executed or been discarded, or the script to have been aborted by the <a lt="terminate service worker">termination</a> of |activeWorker|.
       1. Wait for the step labeled *WaitForAsynchronousExtensions* to complete.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>active worker</a> and *activated* as the arguments.
+  </section>
+
+  <section algorithm>
+    <h3 id="try-activate-algorithm"><dfn>Try Activate</dfn></h3>
+
+      : Input
+      :: |registration|, a [=/service worker registration=]
+      : Output
+      :: None
+
+      1. Assert: |registration|'s [=waiting worker=] is not null.
+      1. If |registration|'s [=active worker=] is null, or if the result of running [=Service Worker Has No Pending Events=] with |registration|'s [=active worker=] is true, and no [=/service worker client=] is [=using=] |registration| or |registration|’s [=waiting worker=]'s [=skip waiting flag=] is set, then invoke [=Activate=] with |registration|.
   </section>
 
   <section algorithm>
@@ -2540,6 +2557,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. If |request| is a <a>navigation request</a>, initialize |e|'s {{FetchEvent/targetClientId}} attribute to |request|'s [=request/target client id=], and to the empty string otherwise.
           1. Let the {{FetchEvent/isReload}} attribute of |e| be initialized to <code>true</code> if |request|'s [=request/client=] is a <a>window client</a> and the event was dispatched with the user's intention for the page reload, and <code>false</code> otherwise.
           1. <a>Dispatch</a> |e| at |activeWorker|'s [=service worker/global object=].
+          1. Invoke [=Update Service Worker Extended Events Set=] with |activeWorker| and |e|.
           1. If |e|'s [=FetchEvent/respond-with entered flag=] is set, set |respondWithEntered| to true.
           1. If |e|'s [=FetchEvent/wait to respond flag=] is set, then:
               1. Wait until |e|'s [=FetchEvent/wait to respond flag=] is unset.
@@ -2589,6 +2607,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Invoke <a>Run Service Worker</a> algorithm with |activeWorker| as the argument.
       1. <a>Queue a task</a> |task| to run these substeps:
           1. Invoke |callbackSteps| with |activeWorker|'s [=service worker/global object=] as its argument.
+          1. Invoke [=Update Service Worker Extended Events Set=] with |activeWorker| and |event|.
 
           The |task| *must* use |activeWorker|'s <a>event loop</a> and the <a>handle functional event task source</a>.
 
@@ -2611,7 +2630,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If |registration| is null, abort these steps.
       1. If any other [=/service worker client=] is <a>using</a> |registration|, abort these steps.
       1. If |registration|'s <a>uninstalling flag</a> is set, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument and abort these steps.
-      1. If |registration|'s <a>waiting worker</a> is not null, run <a>Activate</a> algorithm with |registration| as the argument.
+      1. If |registration|'s <a>waiting worker</a> is not null, invoke [=Try Activate=] with |registration|.
   </section>
 
   <section algorithm>
@@ -2628,6 +2647,21 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. Else, set |registration|'s <a>installing worker</a> to null.
           1. If |registration|'s <a>waiting worker</a> is not null, run the following substep <a>in parallel</a>:
               1. Invoke <a>Activate</a> with |registration|.
+  </section>
+
+  <section algorithm>
+    <h3 id="update-service-worker-extended-events-set-algorithm"><dfn>Update Service Worker Extended Events Set</dfn></h3>
+
+      : Input
+      :: |worker|, a [=/service worker=]
+      :: |event|, an [=event=]
+      : Output
+      :: None
+
+      1. Assert: |event|'s [=dispatch flag=] is unset.
+      1. For each |item| of |worker|'s [=set of extended events=]:
+          1. If |item|'s [=pending promises count=] is zero, [=set/remove=] |item| from |worker|'s [=set of extended events=].
+      1. If |event|'s [=pending promises count=] is not zero, [=set/append=] |event| to |worker|'s [=set of extended events=].
   </section>
 
   <section algorithm>
@@ -2683,19 +2717,16 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If |registration|'s <a>installing worker</a> is not null, then:
           1. Set |redundantWorker| to |registration|'s <a>installing worker</a>.
           1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
-          1. The user agent *may* abort in-flight requests triggered by |redundantWorker|.
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and null as the arguments.
           1. Run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. If |registration|'s <a>waiting worker</a> is not null, then:
           1. Set |redundantWorker| to |registration|'s <a>waiting worker</a>.
           1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
-          1. The user agent *may* abort in-flight requests triggered by |redundantWorker|.
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>waiting</code>" and null as the arguments.
           1. Run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. If |registration|'s <a>active worker</a> is not null, then:
           1. Set |redundantWorker| to |registration|'s <a>active worker</a>.
           1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
-          1. The user agent *may* abort in-flight requests triggered by |redundantWorker|.
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>active</code>" and null as the arguments.
           1. Run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. Let |scopeString| be <a lt="URL serializer">serialized</a> |registration|'s [=service worker registration/scope url=] with the *exclude fragment flag* set.
@@ -2841,6 +2872,21 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Else if |registration|'s <a>waiting worker</a> is not null, set |newestWorker| to |registration|'s <a>waiting worker</a>.
       1. Else if |registration|'s <a>active worker</a> is not null, set |newestWorker| to |registration|'s <a>active worker</a>.
       1. Return |newestWorker|.
+  </section>
+
+  <section algorithm>
+    <h3 id="service-worker-has-no-pending-events-algorithm"><dfn>Service Worker Has No Pending Events</dfn></h3>
+
+      : Input
+      :: |worker|, a [=/service worker=]
+      : Output
+      :: True or false, a boolean
+
+      1. Let |sum| be zero.
+      1. For each |item| of |worker|'s [=set of extended events=]:
+          1. Add |item|'s [=pending promises count=] to |sum|.
+      1. If |sum| is zero, return true.
+      1. Else, return false.
   </section>
 
   <section algorithm>

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -161,7 +161,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A [=/service worker=] has an associated <dfn export id="dfn-set-of-event-types-to-handle">set of event types to handle</dfn> (a [=ordered set|set=]) whose [=item=] is an <a>event listener</a>'s event type. It is initially an empty set.
 
-    A [=/service worker=] has an associated <dfn export id="dfn-set-of-extended-events">set of extended events</dfn> (a [=ordered set|set=]) whose [=item=] is an [=event=]. It is initially an empty set.
+    A [=/service worker=] has an associated <dfn export id="dfn-set-of-extended-events">set of extended events</dfn> (a [=ordered set|set=]) whose [=item=] is an {{ExtendableEvent}}. It is initially an empty set.
 
     <section>
       <h4 id="service-worker-lifetime">Lifetime</h4>
@@ -2325,7 +2325,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       1. Let |installFailed| be false.
       1. Let |newestWorker| be the result of running <a>Get Newest Worker</a> algorithm passing |registration| as its argument.
-      1. Let |redundantWorker| be null.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and |worker| as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>installing worker</a> and *installing* as the arguments.
       1. Assert: |job|'s [=job/job promise=] is not null.
@@ -2346,19 +2345,17 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Wait for |task| to have executed or been discarded.
       1. Wait for the step labeled *WaitForAsynchronousExtensions* to complete.
       1. If |installFailed| is true, then:
-          1. Set |redundantWorker| to |registration|'s <a>installing worker</a>.
+          1. Run the <a>Update Worker State</a> algorithm passing |registration|'s [=installing worker=] and *redundant* as the arguments.
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and null as the arguments.
-          1. Run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
           1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Set |registration|'s <a>installing worker</a>'s <a>imported scripts updated flag</a>.
       1. If |registration|'s <a>waiting worker</a> is not null, then:
-          1. Set |redundantWorker| to |registration|'s <a>waiting worker</a>.
-          1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
+          1. [=Terminate Service Worker|Terminate=] |registration|'s [=waiting worker=].
+          1. Run the [=Update Worker State=] algorithm passing |registration|'s [=waiting worker=] and *redundant* as the arguments.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>waiting</code>" and |registration|'s <a>installing worker</a> as the arguments.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and null as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>waiting worker</a> and *installed* as the arguments.
-      1. If |redundantWorker| is not null, run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. Invoke <a>Finish Job</a> with |job|.
       1. Wait for all the <a>tasks</a> <a lt="queue a task">queued</a> by <a>Update Worker State</a> invoked in this algorithm have executed.
       1. Invoke [=Try Activate=] with |registration|.
@@ -2375,15 +2372,15 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: None
 
       1. If |registration|'s <a>waiting worker</a> is null, abort these steps.
-      1. Let |redundantWorker| be null.
-      1. If |registration|'s [=active worker=] is not null, |redundantWorker| be |registration|'s [=active worker=].
+      1. If |registration|'s [=active worker=] is not null, then:
+          1. [=Terminate Service Worker|Terminate=] |registration|'s [=active worker=].
+          1. Run the [=Update Worker State=] algorithm passing |registration|'s [=active worker=] and *redundant* as the arguments.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>active</code>" and |registration|'s <a>waiting worker</a> as the arguments.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>waiting</code>" and null as the arguments.
       1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>active worker</a> and *activating* as the arguments.
 
           Note: Once an active worker is activating, neither a runtime script error nor a force termination of the active worker prevents the active worker from getting activated.
 
-      1. If |redundantWorker| is not null, run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. For each [=/service worker client=] |client| whose <a>creation URL</a> <a lt="Match Service Worker Registration">matches</a> |registration|'s [=service worker registration/scope url=]:
           1. If |client| is a <a>window client</a>, unassociate |client|'s <a>responsible document</a> from its <a>application cache</a>, if it has one.
           1. Else if |client| is a <a>shared worker client</a>, unassociate |client|'s [=environment settings object/global object=] from its <a>application cache</a>, if it has one.
@@ -2413,8 +2410,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: None
 
-      1. Assert: |registration|'s [=waiting worker=] is not null.
-      1. If |registration|'s [=active worker=] is null, or if the result of running [=Service Worker Has No Pending Events=] with |registration|'s [=active worker=] is true, and no [=/service worker client=] is [=using=] |registration| or |registration|’s [=waiting worker=]'s [=skip waiting flag=] is set, then invoke [=Activate=] with |registration|.
+      1. If |registration|'s [=waiting worker=] is null, return.
+      1. Invoke [=Activate=] with |registration| if either of the following is true:
+        * |registration|'s [=active worker=] is null.
+        * The result of running [=Service Worker Has No Pending Events=] with |registration|’s [=active worker=] is true, and no [=/service worker client=] is [=using=] |registration| or |registration|’s [=waiting worker=]'s [=skip waiting flag=] is set.
   </section>
 
   <section algorithm>
@@ -2489,6 +2488,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If |serviceWorker| is not running, abort these steps.
       1. Let |serviceWorkerGlobalScope| be |serviceWorker|'s [=service worker/global object=].
       1. Set |serviceWorkerGlobalScope|'s closing flag to true.
+      1. [=set/Remove=] all the [=items=] from |serviceWorker|'s [=set of extended events=].
       1. If there are any <a>tasks</a>, whose <a>task source</a> is either the <a>handle fetch task source</a> or the <a>handle functional event task source</a>, queued in |serviceWorkerGlobalScope|'s <a>event loop</a>'s [=/task queues=], <a lt="queue a task">queue</a> them to |serviceWorker|'s <a>containing service worker registration</a>'s corresponding [=service worker registration/task queues=] in the same order using their original <a>task sources</a>, and discard all the <a>tasks</a> (including <a>tasks</a> whose <a>task source</a> is neither the <a>handle fetch task source</a> nor the <a>handle functional event task source</a>) from |serviceWorkerGlobalScope|'s <a>event loop</a>'s [=/task queues=] without processing them.
 
           Note: This effectively means that the fetch events and the other functional events such as push events are backed up by the registration's task queues while the other tasks including message events are discarded.

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 2de6f41e63a9bd84932e1a28745f8d452d3b0e46" name="generator">
+  <meta content="Bikeshed version 70f542b3eb403344eee83c57e6631f734b1c4427" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-08">8 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-16">16 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -4401,7 +4401,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          </ul>
          <p class="note" role="note"><span>Note:</span> Even if the cache mode is not set to "<code>no-cache</code>", the user agent obeys Cache-Control header’s max-age value in the network layer to determine if it should bypass the browser cache.</p>
         <li data-md="">
-         <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#skip-service-worker-flag">skip-service-worker flag</a>.</p>
+         <p>Set <var>request</var>’s <a data-link-type="dfn">skip-service-worker flag</a>.</p>
         <li data-md="">
          <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-is-top-level">is top-level</a> flag is unset, then return the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetching</a> <var>request</var>.</p>
         <li data-md="">
@@ -6450,7 +6450,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-reserved-client">reserved client</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-response">response</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-response-response">response <small>(for Response)</small></a>
-     <li><a href="https://fetch.spec.whatwg.org/#skip-service-worker-flag">skip-service-worker flag</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-response-status">status</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-body-stream">stream</a>
      <li><a href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a>
@@ -6625,7 +6624,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li>
     <a data-link-type="biblio">[WHATWG-URL]</a> defines the following terms:
     <ul>
-     <li><a href="https://url.spec.whatwg.org/#concept-url-equals">equals</a>
+     <li><a href="https://url.spec.whatwg.org/#concept-url-equals">equal</a>
      <li><a href="https://url.spec.whatwg.org/#is-local">is local</a>
      <li><a href="https://url.spec.whatwg.org/#concept-url-origin">origin</a>
      <li><a href="https://url.spec.whatwg.org/#concept-url-path">path</a>

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -419,7 +419,7 @@
 	[data-algorithm]:not(.heading) {
 	  padding: .5em;
 	  border: thin solid #ddd; border-radius: .5em;
-	  margin: .5em 0;
+	  margin: .5em calc(-0.5em - 1px);
 	}
 	[data-algorithm]:not(.heading) > :first-child {
 	  margin-top: 0;
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 90eb18a0d2a7680cdd94ecc3b342163de5a3fd43" name="generator">
+  <meta content="Bikeshed version 2de6f41e63a9bd84932e1a28745f8d452d3b0e46" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-03">3 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-08">8 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1741,7 +1741,7 @@ pre.idl.highlight { color: #708090; }
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-25">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-skip-waiting-flag">skip waiting flag</dfn>. Unless stated otherwise it is unset.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-26">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-imported-scripts-updated-flag">imported scripts updated flag</dfn>. It is initially unset.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-27">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-set-of-event-types-to-handle">set of event types to handle</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a>) whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item">item</a> is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-listener">event listener</a>’s event type. It is initially an empty set.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-28">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-set-of-extended-events">set of extended events</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a>) whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item">item</a> is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event">event</a>. It is initially an empty set.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-28">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-set-of-extended-events">set of extended events</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a>) whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item">item</a> is an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-1">ExtendableEvent</a></code>. It is initially an empty set.</p>
      <section>
       <h4 class="heading settled" data-level="2.1.1" id="service-worker-lifetime"><span class="secno">2.1.1. </span><span class="content">Lifetime</span><a class="self-link" href="#service-worker-lifetime"></a></h4>
       <p>The lifetime of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-29">service worker</a> is tied to the execution lifetime of events and not references held by <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-2">service worker clients</a> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-1">ServiceWorker</a></code> object.</p>
@@ -2934,7 +2934,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </section>
     </section>
     <section>
-     <h3 class="heading settled" data-level="4.4" id="extendableevent-interface"><span class="secno">4.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-1">ExtendableEvent</a></code></span><a class="self-link" href="#extendableevent-interface"></a></h3>
+     <h3 class="heading settled" data-level="4.4" id="extendableevent-interface"><span class="secno">4.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-2">ExtendableEvent</a></code></span><a class="self-link" href="#extendableevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="ExtendableEvent" data-dfn-type="constructor" data-export="" data-lt="ExtendableEvent(type, eventInitDict)|ExtendableEvent(type)" id="dom-extendableevent-extendableevent">Constructor<a class="self-link" href="#dom-extendableevent-extendableevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="ExtendableEvent/ExtendableEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendableevent-extendableevent-type-eventinitdict-type">type<a class="self-link" href="#dom-extendableevent-extendableevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-extendableeventinit" id="ref-for-dictdef-extendableeventinit-1">ExtendableEventInit</a> <dfn class="nv idl-code" data-dfn-for="ExtendableEvent/ExtendableEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendableevent-extendableevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-extendableevent-extendableevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="extendableevent">ExtendableEvent</dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event">Event</a> {
   <span class="kt">void</span> <a class="nv idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-1">waitUntil</a>(<span class="kt">Promise</span>&lt;<span class="kt">any</span>> <dfn class="nv idl-code" data-dfn-for="ExtendableEvent/waitUntil(f)" data-dfn-type="argument" data-export="" id="dom-extendableevent-waituntil-f-f">f<a class="self-link" href="#dom-extendableevent-waituntil-f-f"></a></dfn>);
@@ -2944,10 +2944,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   // Defined for the forward compatibility across the derived events
 };
 </pre>
-     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-2">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-extend-lifetime-promises">extend lifetime promises</dfn> (an array of <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a>). It is initially an empty array.</p>
-     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-3">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-pending-promises-count">pending promises count</dfn> (the number of pending promises in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-1">extend lifetime promises</a>). It is initially set to zero.</p>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-57">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-58">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
-     <p><a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> also use or extend the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-5">ExtendableEvent</a></code> interface.</p>
+     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-3">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-extend-lifetime-promises">extend lifetime promises</dfn> (an array of <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promises</a>). It is initially an empty array.</p>
+     <p>An <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-4">ExtendableEvent</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ExtendableEvent" data-dfn-type="dfn" data-noexport="" id="extendableevent-pending-promises-count">pending promises count</dfn> (the number of pending promises in the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-1">extend lifetime promises</a>). It is initially set to zero.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-57">Service workers</a> have two <a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-1">lifecycle events</a>, <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-3">install</a></code> and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-3">activate</a></code>. <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-58">Service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-5">ExtendableEvent</a></code> interface for <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-4">activate</a></code> event and <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-4">install</a></code> event.</p>
+     <p><a href="#extensibility">Service worker extensions</a> that <a href="#extension-to-service-worker-global-scope">define event handlers</a> <em>may</em> also use or extend the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a></code> interface.</p>
      <section class="algorithm" data-algorithm="wait-until-method">
       <h4 class="heading settled" data-level="4.4.1" id="wait-until-method"><span class="secno">4.4.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-2">event.waitUntil(f)</a></code></span><a class="self-link" href="#wait-until-method"></a></h4>
       <p><code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-3">waitUntil()</a></code> method extends the lifetime of the event.</p>
@@ -2990,7 +2990,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.5" id="fetchevent-interface"><span class="secno">4.5. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-1">FetchEvent</a></code></span><a class="self-link" href="#fetchevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="FetchEvent" data-dfn-type="constructor" data-export="" data-lt="FetchEvent(type, eventInitDict)" id="dom-fetchevent-fetchevent">Constructor<a class="self-link" href="#dom-fetchevent-fetchevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="FetchEvent/FetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-fetchevent-fetchevent-type-eventinitdict-type">type<a class="self-link" href="#dom-fetchevent-fetchevent-type-eventinitdict-type"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-fetcheventinit" id="ref-for-dictdef-fetcheventinit-1">FetchEventInit</a> <dfn class="nv idl-code" data-dfn-for="FetchEvent/FetchEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-fetchevent-fetchevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-fetchevent-fetchevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="fetchevent">FetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-6">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="fetchevent">FetchEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-7">ExtendableEvent</a> {
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject">SameObject</a>] <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://fetch.spec.whatwg.org/#request">Request</a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Request" href="#dom-fetchevent-request" id="ref-for-dom-fetchevent-request-1">request</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-fetchevent-clientid" id="ref-for-dom-fetchevent-clientid-1">clientId</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-fetchevent-reservedclientid" id="ref-for-dom-fetchevent-reservedclientid-1">reservedClientId</a>;
@@ -3008,7 +3008,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="FetchEventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-fetcheventinit-isreload">isReload<a class="self-link" href="#dom-fetcheventinit-isreload"></a></dfn> = <span class="kt">false</span>;
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-64">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-7">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-64">Service workers</a> have an essential <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-3">functional event</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-4">fetch</a></code>. For <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-5">fetch</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-2">FetchEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-8">ExtendableEvent</a></code> interface.</p>
      <p>Each event using <code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-3">FetchEvent</a></code> interface has an associated <dfn class="dfn-paneled" data-dfn-for="FetchEvent" data-dfn-type="dfn" data-noexport="" id="fetchevent-potential-response">potential response</dfn> (a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>), initially set to null, and the following associated flags that are initially unset:</p>
      <ul>
       <li data-md="">
@@ -3184,7 +3184,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section>
      <h3 class="heading settled" data-level="4.6" id="extendablemessageevent-interface"><span class="secno">4.6. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-2">ExtendableMessageEvent</a></code></span><a class="self-link" href="#extendablemessageevent-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent" data-dfn-type="constructor" data-export="" data-lt="ExtendableMessageEvent(type, eventInitDict)|ExtendableMessageEvent(type)" id="dom-extendablemessageevent-extendablemessageevent">Constructor<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent/ExtendableMessageEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-type">type<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-extendablemessageeventinit" id="ref-for-dictdef-extendablemessageeventinit-1">ExtendableMessageEventInit</a> <dfn class="nv idl-code" data-dfn-for="ExtendableMessageEvent/ExtendableMessageEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-extendablemessageevent-extendablemessageevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed">Exposed</a>=<span class="n">ServiceWorker</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="extendablemessageevent">ExtendableMessageEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-8">ExtendableEvent</a> {
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="extendablemessageevent">ExtendableMessageEvent</dfn> : <a class="n" data-link-type="idl-name" href="#extendableevent" id="ref-for-extendableevent-9">ExtendableEvent</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">any</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="any" href="#dom-extendablemessageevent-data" id="ref-for-dom-extendablemessageevent-data-2">data</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">USVString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="USVString" href="#dom-extendablemessageevent-origin" id="ref-for-dom-extendablemessageevent-origin-2">origin</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-extendablemessageevent-lasteventid" id="ref-for-dom-extendablemessageevent-lasteventid-1">lastEventId</a>;
@@ -3200,7 +3200,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/comms.html#messageport">MessagePort</a>> <dfn class="nv idl-code" data-default="None" data-dfn-for="ExtendableMessageEventInit" data-dfn-type="dict-member" data-export="" data-type="sequence<MessagePort> " id="dom-extendablemessageeventinit-ports">ports<a class="self-link" href="#dom-extendablemessageeventinit-ports"></a></dfn> = [];
 };
 </pre>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-66">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-67">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-9">ExtendableEvent</a></code> interface.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-66">Service workers</a> define the <a class="idl-code" data-link-type="method" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">extendable</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-3">message</a></code> event to allow extending the lifetime of the event. For the <code class="idl"><a class="idl-code" data-link-type="event" href="#eventdef-serviceworkerglobalscope-message" id="ref-for-eventdef-serviceworkerglobalscope-message-4">message</a></code> event, <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-67">service workers</a> use the <code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-3">ExtendableMessageEvent</a></code> interface which extends the <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-10">ExtendableEvent</a></code> interface.</p>
      <section>
       <h4 class="heading settled" data-level="4.6.1" id="extendablemessage-event-data"><span class="secno">4.6.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-extendablemessageevent-data" id="ref-for-dom-extendablemessageevent-data-3">event.data</a></code></span><a class="self-link" href="#extendablemessage-event-data"></a></h4>
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ExtendableMessageEvent" data-dfn-type="attribute" data-export="" id="dom-extendablemessageevent-data">data</dfn> attribute <em>must</em> return the value it was initialized to. When the object is created, this attribute <em>must</em> be initialized to null. It represents the message being sent.</p>
@@ -3234,11 +3234,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <tbody>
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-install-event"><code>install</code></dfn>
-        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-10">ExtendableEvent</a></code>
+        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a></code>
         <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-2">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-20">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-11">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-6">installing worker</a> changes. (See step 11.2 of the <a data-link-type="dfn" href="#install" id="ref-for-install-4">Install</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-activate-event"><code>activate</code></dfn>
-        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a></code>
+        <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-12">ExtendableEvent</a></code>
         <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-3">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-21">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-12">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-18">active worker</a> changes. (See step 12.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-6">Activate</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-fetch-event"><code>fetch</code></dfn>
@@ -4058,7 +4058,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="7.2" id="extension-to-extendable-event"><span class="secno">7.2. </span><span class="content">Define Functional Event</span><a class="self-link" href="#extension-to-extendable-event"></a></h3>
-     <p>Specifications <em>may</em> define a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-5">functional event</a> by extending <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-12">ExtendableEvent</a></code> interface:</p>
+     <p>Specifications <em>may</em> define a <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-5">functional event</a> by extending <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-13">ExtendableEvent</a></code> interface:</p>
 <pre class="example idl highlight def" data-no-idl="" id="example-3de376f0"><a class="self-link" href="#example-3de376f0"></a>// e.g. define FunctionalEvent interface
 <span class="kt">interface</span> <span class="nv">FunctionalEvent</span> : <span class="n">ExtendableEvent</span> {
   // add a functional event’s own attributes and methods
@@ -4570,8 +4570,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>newestWorker</var> be the result of running <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-5">Get Newest Worker</a> algorithm passing <var>registration</var> as its argument.</p>
       <li data-md="">
-       <p>Let <var>redundantWorker</var> be null.</p>
-      <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-1">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and <var>worker</var> as the arguments.</p>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-1">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-7">installing worker</a> and <em>installing</em> as the arguments.</p>
@@ -4589,7 +4587,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-13">ExtendableEvent</a></code>.</p>
+         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-14">ExtendableEvent</a></code>.</p>
         <li data-md="">
          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> attribute to <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-5">install</a></code>.</p>
         <li data-md="">
@@ -4612,11 +4610,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>installFailed</var> is true, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-9">installing worker</a>.</p>
+         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-2">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-9">installing worker</a> and <em>redundant</em> as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-2">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and null as the arguments.</p>
-        <li data-md="">
-         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-2">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
         <li data-md="">
          <p>If <var>newestWorker</var> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-3">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
         <li data-md="">
@@ -4628,18 +4624,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-6">waiting worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-7">waiting worker</a>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-5">Terminate</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-7">waiting worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-5">Terminate</a> <var>redundantWorker</var>.</p>
+         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-3">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-8">waiting worker</a> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-3">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-11">installing worker</a> as the arguments.</p>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-4">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and null as the arguments.</p>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-3">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-8">waiting worker</a> and <em>installed</em> as the arguments.</p>
-      <li data-md="">
-       <p>If <var>redundantWorker</var> is not null, run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-4">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-4">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-9">waiting worker</a> and <em>installed</em> as the arguments.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-11">Finish Job</a> with <var>job</var>.</p>
       <li data-md="">
@@ -4663,20 +4657,22 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-9">waiting worker</a> is null, abort these steps.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-10">waiting worker</a> is null, abort these steps.</p>
       <li data-md="">
-       <p>Let <var>redundantWorker</var> be null.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-21">active worker</a> is not null, then:</p>
+       <ol>
+        <li data-md="">
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-6">Terminate</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-22">active worker</a>.</p>
+        <li data-md="">
+         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-6">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-23">active worker</a> and <em>redundant</em> as the arguments.</p>
+       </ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-21">active worker</a> is not null, <var>redundantWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-22">active worker</a>.</p>
-      <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-5">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-10">waiting worker</a> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-5">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-11">waiting worker</a> as the arguments.</p>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-6">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and null as the arguments.</p>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-6">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-23">active worker</a> and <em>activating</em> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-7">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-24">active worker</a> and <em>activating</em> as the arguments.</p>
        <p class="note" role="note"><span>Note:</span> Once an active worker is activating, neither a runtime script error nor a force termination of the active worker prevents the active worker from getting activated.</p>
-      <li data-md="">
-       <p>If <var>redundantWorker</var> is not null, run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-7">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
       <li data-md="">
        <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-39">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-9">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-16">scope url</a>:</p>
        <ol>
@@ -4690,19 +4686,19 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-40">service worker client</a> <var>client</var> who is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-4">using</a> <var>registration</var>:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>client</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-24">active worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-25">active worker</a>.</p>
+         <p>Set <var>client</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-25">active worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a>.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#notify-controller-change" id="ref-for-notify-controller-change-2">Notify Controller Change</a> algorithm with <var>client</var> as the argument.</p>
        </ol>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-27">active worker</a>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-5">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-14">ExtendableEvent</a></code>.</p>
+         <p>Let <var>e</var> be the result of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-create">creating an event</a> with <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-15">ExtendableEvent</a></code>.</p>
         <li data-md="">
          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> attribute to <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-5">activate</a></code>.</p>
         <li data-md="">
@@ -4711,11 +4707,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><em>WaitForAsynchronousExtensions</em>: Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-10">pending promises count</a> is zero.</p>
        </ol>
       <li data-md="">
-       <p>Wait for <var>task</var> to have executed or been discarded, or the script to have been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-6">termination</a> of <var>activeWorker</var>.</p>
+       <p>Wait for <var>task</var> to have executed or been discarded, or the script to have been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">termination</a> of <var>activeWorker</var>.</p>
       <li data-md="">
        <p>Wait for the step labeled <em>WaitForAsynchronousExtensions</em> to complete.</p>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-8">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-27">active worker</a> and <em>activated</em> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-8">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-28">active worker</a> and <em>activated</em> as the arguments.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Try Activate">
@@ -4732,9 +4728,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-11">waiting worker</a> is not null.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a> is null, return.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-28">active worker</a> is null, or if the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-1">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-29">active worker</a> is true, and no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-41">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-5">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set, then invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-9">Activate</a> with <var>registration</var>.</p>
+       <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-9">Activate</a> with <var>registration</var> if either of the following is true:</p>
+       <ul>
+        <li data-md="">
+         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-29">active worker</a> is null.</p>
+        <li data-md="">
+         <p>The result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-1">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a> is true, and no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-41">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-5">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set.</p>
+       </ul>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Run Service Worker">
@@ -4825,7 +4827,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Create a new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">WorkerLocation</a></code> object and associate it with <var>workerGlobalScope</var>.</p>
       <li data-md="">
-       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-15">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
+       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-31">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-15">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
       <li data-md="">
        <p>If <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>, then <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">run the classic script</a> <var>script</var>. Otherwise, it is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">module script</a>; <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">run the module script</a> <var>script</var>.</p>
        <p class="note" role="note"><span>Note:</span> In addition to the usual possibilities of returning a value or failing due to an exception, this could be prematurely aborted by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">kill a worker</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">terminate a worker</a> algorithms.</p>
@@ -4869,6 +4871,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Let <var>serviceWorkerGlobalScope</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-4">global object</a>.</p>
       <li data-md="">
        <p>Set <var>serviceWorkerGlobalScope</var>’s closing flag to true.</p>
+      <li data-md="">
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove">Remove</a> all the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item">items</a> from <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-1">set of extended events</a>.</p>
       <li data-md="">
        <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-16">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
        <p class="note" role="note"><span>Note:</span> This effectively means that the fetch events and the other functional events such as push events are backed up by the registration’s task queues while the other tasks including message events are discarded.</p>
@@ -4939,9 +4943,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>registration</var> to the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-10">Match Service Worker Registration</a> algorithm passing <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url">url</a> as the argument.</p>
         <li data-md="">
-         <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-31">active worker</a> is null, return null.</p>
+         <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-32">active worker</a> is null, return null.</p>
         <li data-md="">
-         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-32">active worker</a>.</p>
+         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-33">active worker</a>.</p>
        </ol>
        <p class="note" role="note"><span>Note:</span> From this point, the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-43">service worker client</a> starts to <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-6">use</a> its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-17">containing service worker registration</a>.</p>
       <li data-md="">
@@ -4953,7 +4957,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Else, return null.</p>
        </ol>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-33">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-34">active worker</a>.</p>
       <li data-md="">
        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-2">set of event types to handle</a> does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> <code>fetch</code>, then:</p>
        <ol>
@@ -5007,7 +5011,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>If <var>e</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#canceled-flag">canceled flag</a> is set, set <var>eventCanceled</var> to true.</p>
        </ol>
-       <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">termination</a> of <var>activeWorker</var>, set <var>handleFetchFailed</var> to true.</p>
+       <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-8">termination</a> of <var>activeWorker</var>, set <var>handleFetchFailed</var> to true.</p>
        <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-4">handle fetch task source</a>.</p>
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded.</p>
@@ -5047,7 +5051,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-15">ExtendableEvent</a></code> object</p>
+       <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code> object</p>
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-55">service worker registration</a></p>
       <dd data-md="">
@@ -5061,9 +5065,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p class="assertion">Assert: <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-7">scope to registration map</a> contains a value equal to <var>registration</var>.</p>
       <li data-md="">
-       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-34">active worker</a> is not null.</p>
+       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-35">active worker</a> is not null.</p>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-35">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-36">active worker</a>.</p>
       <li data-md="">
        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-3">set of event types to handle</a> does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> <var>event</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code>, then:</p>
        <ol>
@@ -5096,7 +5100,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section class="algorithm" data-algorithm="Handle Service Worker Client Unload">
      <h3 class="heading settled" id="on-client-unload-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="handle-service-worker-client-unload">Handle Service Worker Client Unload</dfn></span><a class="self-link" href="#on-client-unload-algorithm"></a></h3>
-     <p>The user agent <em>must</em> run these steps when a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-44">service worker client</a> unloads by <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unload-a-document">unloading</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">being killed</a>, or <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-8">terminating</a>.</p>
+     <p>The user agent <em>must</em> run these steps when a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-44">service worker client</a> unloads by <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unload-a-document">unloading</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">being killed</a>, or <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-9">terminating</a>.</p>
      <dl>
       <dt data-md="">
        <p>Input</p>
@@ -5119,7 +5123,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-4">uninstalling flag</a> is set, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-4">Clear Registration</a> algorithm passing <var>registration</var> as its argument and abort these steps.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a> is not null, invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-6">Try Activate</a> with <var>registration</var>.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-14">waiting worker</a> is not null, invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-6">Try Activate</a> with <var>registration</var>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle User Agent Shutdown">
@@ -5147,7 +5151,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <p>Else, set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-13">installing worker</a> to null.</p>
          </ol>
         <li data-md="">
-         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-14">waiting worker</a> is not null, run the following substep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-15">waiting worker</a> is not null, run the following substep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
          <ol>
           <li data-md="">
            <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-10">Activate</a> with <var>registration</var>.</p>
@@ -5173,13 +5177,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p class="assertion">Assert: <var>event</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is unset.</p>
       <li data-md="">
-       <p>For each <var>item</var> of <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-1">set of extended events</a>:</p>
+       <p>For each <var>item</var> of <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-2">set of extended events</a>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>item</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-11">pending promises count</a> is zero, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove">remove</a> <var>item</var> from <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-2">set of extended events</a>.</p>
+         <p>If <var>item</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-11">pending promises count</a> is zero, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove">remove</a> <var>item</var> from <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-3">set of extended events</a>.</p>
        </ol>
       <li data-md="">
-       <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-12">pending promises count</a> is not zero, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append">append</a> <var>event</var> to <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-3">set of extended events</a>.</p>
+       <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-12">pending promises count</a> is not zero, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append">append</a> <var>event</var> to <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-4">set of extended events</a>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Unregister">
@@ -5274,31 +5278,31 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-15">installing worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-9">Terminate</a> <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-10">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-7">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and null as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-9">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-15">waiting worker</a> is not null, then:</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-16">waiting worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-16">waiting worker</a>.</p>
+         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-17">waiting worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-10">Terminate</a> <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-11">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-8">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and null as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-10">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-36">active worker</a> is not null, then:</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a>.</p>
+         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-11">Terminate</a> <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-12">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-9">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and null as the arguments.</p>
         <li data-md="">
@@ -5345,24 +5349,24 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Else if <var>target</var> is "<code>waiting</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-17">waiting worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-18">waiting worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-waiting" id="ref-for-dom-serviceworkerregistration-waiting-3">waiting</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-26">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-18">waiting worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-19">waiting worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-waiting" id="ref-for-dom-serviceworkerregistration-waiting-3">waiting</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-26">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-19">waiting worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a> is null.</p>
          </ol>
        </ol>
       <li data-md="">
        <p>Else if <var>target</var> is "<code>active</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-3">active</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-27">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-3">active</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-27">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a> is null.</p>
          </ol>
        </ol>
        <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <em>must</em> use <var>registrationObject</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>.</p>
@@ -5405,17 +5409,17 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
              <p><em>installed</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installed" id="ref-for-dom-serviceworkerstate-installed-1">"installed"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-99">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a>.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-99">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-21">waiting worker</a>.</p>
             <dt data-md="">
              <p><em>activating</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activating" id="ref-for-dom-serviceworkerstate-activating-1">"activating"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-42">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-42">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-43">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
             <dt data-md="">
              <p><em>activated</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activated" id="ref-for-dom-serviceworkerstate-activated-1">"activated"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-43">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-44">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>.</p>
             <dt data-md="">
              <p><em>redundant</em></p>
             <dd data-md="">
@@ -5536,9 +5540,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-21">installing worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-22">installing worker</a>.</p>
       <li data-md="">
-       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-21">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-22">waiting worker</a>.</p>
+       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-22">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-23">waiting worker</a>.</p>
       <li data-md="">
-       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-44">active worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-45">active worker</a>.</p>
+       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-45">active worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-46">active worker</a>.</p>
       <li data-md="">
        <p>Return <var>newestWorker</var>.</p>
      </ol>
@@ -5559,7 +5563,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>sum</var> be zero.</p>
       <li data-md="">
-       <p>For each <var>item</var> of <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-4">set of extended events</a>:</p>
+       <p>For each <var>item</var> of <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-5">set of extended events</a>:</p>
        <ol>
         <li data-md="">
          <p>Add <var>item</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-13">pending promises count</a> to <var>sum</var>.</p>
@@ -7111,8 +7115,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-set-of-extended-events">
    <b><a href="#dfn-set-of-extended-events">#dfn-set-of-extended-events</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-set-of-extended-events-1">Update Service Worker Extended Events Set</a> <a href="#ref-for-dfn-set-of-extended-events-2">(2)</a> <a href="#ref-for-dfn-set-of-extended-events-3">(3)</a>
-    <li><a href="#ref-for-dfn-set-of-extended-events-4">Service Worker Has No Pending Events</a>
+    <li><a href="#ref-for-dfn-set-of-extended-events-1">Terminate Service Worker</a>
+    <li><a href="#ref-for-dfn-set-of-extended-events-2">Update Service Worker Extended Events Set</a> <a href="#ref-for-dfn-set-of-extended-events-3">(2)</a> <a href="#ref-for-dfn-set-of-extended-events-4">(3)</a>
+    <li><a href="#ref-for-dfn-set-of-extended-events-5">Service Worker Has No Pending Events</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-service-worker-registration">
@@ -7191,15 +7196,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-waiting-worker-2">2.6. User Agent Shutdown</a>
     <li><a href="#ref-for-dfn-waiting-worker-3">4.1.3. skipWaiting()</a>
     <li><a href="#ref-for-dfn-waiting-worker-4">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-waiting-worker-5">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-6">Install</a> <a href="#ref-for-dfn-waiting-worker-7">(2)</a> <a href="#ref-for-dfn-waiting-worker-8">(3)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-9">Activate</a> <a href="#ref-for-dfn-waiting-worker-10">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-11">Try Activate</a> <a href="#ref-for-dfn-waiting-worker-12">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-13">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-dfn-waiting-worker-14">Handle User Agent Shutdown</a>
-    <li><a href="#ref-for-dfn-waiting-worker-15">Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-16">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-17">Update Registration State</a> <a href="#ref-for-dfn-waiting-worker-18">(2)</a> <a href="#ref-for-dfn-waiting-worker-19">(3)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-20">Update Worker State</a>
-    <li><a href="#ref-for-dfn-waiting-worker-21">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker-22">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-6">Install</a> <a href="#ref-for-dfn-waiting-worker-7">(2)</a> <a href="#ref-for-dfn-waiting-worker-8">(3)</a> <a href="#ref-for-dfn-waiting-worker-9">(4)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-10">Activate</a> <a href="#ref-for-dfn-waiting-worker-11">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-12">Try Activate</a> <a href="#ref-for-dfn-waiting-worker-13">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-14">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-dfn-waiting-worker-15">Handle User Agent Shutdown</a>
+    <li><a href="#ref-for-dfn-waiting-worker-16">Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-17">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-18">Update Registration State</a> <a href="#ref-for-dfn-waiting-worker-19">(2)</a> <a href="#ref-for-dfn-waiting-worker-20">(3)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-21">Update Worker State</a>
+    <li><a href="#ref-for-dfn-waiting-worker-22">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker-23">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-active-worker">
@@ -7215,15 +7220,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-active-worker-17">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dfn-active-worker-18">4.7. Events</a>
     <li><a href="#ref-for-dfn-active-worker-19">Install</a> <a href="#ref-for-dfn-active-worker-20">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-21">Activate</a> <a href="#ref-for-dfn-active-worker-22">(2)</a> <a href="#ref-for-dfn-active-worker-23">(3)</a> <a href="#ref-for-dfn-active-worker-24">(4)</a> <a href="#ref-for-dfn-active-worker-25">(5)</a> <a href="#ref-for-dfn-active-worker-26">(6)</a> <a href="#ref-for-dfn-active-worker-27">(7)</a>
-    <li><a href="#ref-for-dfn-active-worker-28">Try Activate</a> <a href="#ref-for-dfn-active-worker-29">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-30">Run Service Worker</a>
-    <li><a href="#ref-for-dfn-active-worker-31">Handle Fetch</a> <a href="#ref-for-dfn-active-worker-32">(2)</a> <a href="#ref-for-dfn-active-worker-33">(3)</a>
-    <li><a href="#ref-for-dfn-active-worker-34">Handle Functional Event</a> <a href="#ref-for-dfn-active-worker-35">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-36">Clear Registration</a> <a href="#ref-for-dfn-active-worker-37">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-38">Update Registration State</a> <a href="#ref-for-dfn-active-worker-39">(2)</a> <a href="#ref-for-dfn-active-worker-40">(3)</a>
-    <li><a href="#ref-for-dfn-active-worker-41">Update Worker State</a> <a href="#ref-for-dfn-active-worker-42">(2)</a> <a href="#ref-for-dfn-active-worker-43">(3)</a>
-    <li><a href="#ref-for-dfn-active-worker-44">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker-45">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-21">Activate</a> <a href="#ref-for-dfn-active-worker-22">(2)</a> <a href="#ref-for-dfn-active-worker-23">(3)</a> <a href="#ref-for-dfn-active-worker-24">(4)</a> <a href="#ref-for-dfn-active-worker-25">(5)</a> <a href="#ref-for-dfn-active-worker-26">(6)</a> <a href="#ref-for-dfn-active-worker-27">(7)</a> <a href="#ref-for-dfn-active-worker-28">(8)</a>
+    <li><a href="#ref-for-dfn-active-worker-29">Try Activate</a> <a href="#ref-for-dfn-active-worker-30">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-31">Run Service Worker</a>
+    <li><a href="#ref-for-dfn-active-worker-32">Handle Fetch</a> <a href="#ref-for-dfn-active-worker-33">(2)</a> <a href="#ref-for-dfn-active-worker-34">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-35">Handle Functional Event</a> <a href="#ref-for-dfn-active-worker-36">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-37">Clear Registration</a> <a href="#ref-for-dfn-active-worker-38">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-39">Update Registration State</a> <a href="#ref-for-dfn-active-worker-40">(2)</a> <a href="#ref-for-dfn-active-worker-41">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-42">Update Worker State</a> <a href="#ref-for-dfn-active-worker-43">(2)</a> <a href="#ref-for-dfn-active-worker-44">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-45">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker-46">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-last-update-check-time">
@@ -8035,14 +8040,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="extendableevent">
    <b><a href="#extendableevent">#extendableevent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-extendableevent-1">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-2">(2)</a> <a href="#ref-for-extendableevent-3">(3)</a> <a href="#ref-for-extendableevent-4">(4)</a> <a href="#ref-for-extendableevent-5">(5)</a>
-    <li><a href="#ref-for-extendableevent-6">4.5. FetchEvent</a> <a href="#ref-for-extendableevent-7">(2)</a>
-    <li><a href="#ref-for-extendableevent-8">4.6. ExtendableMessageEvent</a> <a href="#ref-for-extendableevent-9">(2)</a>
-    <li><a href="#ref-for-extendableevent-10">4.7. Events</a> <a href="#ref-for-extendableevent-11">(2)</a>
-    <li><a href="#ref-for-extendableevent-12">7.2. Define Functional Event</a>
-    <li><a href="#ref-for-extendableevent-13">Install</a>
-    <li><a href="#ref-for-extendableevent-14">Activate</a>
-    <li><a href="#ref-for-extendableevent-15">Handle Functional Event</a>
+    <li><a href="#ref-for-extendableevent-1">2.1. Service Worker</a>
+    <li><a href="#ref-for-extendableevent-2">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-3">(2)</a> <a href="#ref-for-extendableevent-4">(3)</a> <a href="#ref-for-extendableevent-5">(4)</a> <a href="#ref-for-extendableevent-6">(5)</a>
+    <li><a href="#ref-for-extendableevent-7">4.5. FetchEvent</a> <a href="#ref-for-extendableevent-8">(2)</a>
+    <li><a href="#ref-for-extendableevent-9">4.6. ExtendableMessageEvent</a> <a href="#ref-for-extendableevent-10">(2)</a>
+    <li><a href="#ref-for-extendableevent-11">4.7. Events</a> <a href="#ref-for-extendableevent-12">(2)</a>
+    <li><a href="#ref-for-extendableevent-13">7.2. Define Functional Event</a>
+    <li><a href="#ref-for-extendableevent-14">Install</a>
+    <li><a href="#ref-for-extendableevent-15">Activate</a>
+    <li><a href="#ref-for-extendableevent-16">Handle Functional Event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-extendableeventinit">
@@ -8763,10 +8769,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-terminate-service-worker-2">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-terminate-service-worker-3">4.4.1. event.waitUntil(f)</a>
     <li><a href="#ref-for-terminate-service-worker-4">Install</a> <a href="#ref-for-terminate-service-worker-5">(2)</a>
-    <li><a href="#ref-for-terminate-service-worker-6">Activate</a>
-    <li><a href="#ref-for-terminate-service-worker-7">Handle Fetch</a>
-    <li><a href="#ref-for-terminate-service-worker-8">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-terminate-service-worker-9">Clear Registration</a> <a href="#ref-for-terminate-service-worker-10">(2)</a> <a href="#ref-for-terminate-service-worker-11">(3)</a>
+    <li><a href="#ref-for-terminate-service-worker-6">Activate</a> <a href="#ref-for-terminate-service-worker-7">(2)</a>
+    <li><a href="#ref-for-terminate-service-worker-8">Handle Fetch</a>
+    <li><a href="#ref-for-terminate-service-worker-9">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-terminate-service-worker-10">Clear Registration</a> <a href="#ref-for-terminate-service-worker-11">(2)</a> <a href="#ref-for-terminate-service-worker-12">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-fetch">

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 6ef2009a74468c39cdee1058d2c325259bdcb4fa" name="generator">
+  <meta content="Bikeshed version 90eb18a0d2a7680cdd94ecc3b342163de5a3fd43" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-02">2 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-03">3 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1657,12 +1657,14 @@ pre.idl.highlight { color: #708090; }
       <li><a href="#soft-update-algorithm"><span class="secno"></span> <span class="content"><span>Soft Update</span></span></a>
       <li><a href="#installation-algorithm"><span class="secno"></span> <span class="content"><span>Install</span></span></a>
       <li><a href="#activation-algorithm"><span class="secno"></span> <span class="content"><span>Activate</span></span></a>
+      <li><a href="#try-activate-algorithm"><span class="secno"></span> <span class="content"><span>Try Activate</span></span></a>
       <li><a href="#run-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Run Service Worker</span></span></a>
       <li><a href="#terminate-service-worker-algorithm"><span class="secno"></span> <span class="content"><span>Terminate Service Worker</span></span></a>
       <li><a href="#on-fetch-request-algorithm"><span class="secno"></span> <span class="content"><span>Handle Fetch</span></span></a>
       <li><a href="#handle-functional-event-algorithm"><span class="secno"></span> <span class="content"><span>Handle Functional Event</span></span></a>
       <li><a href="#on-client-unload-algorithm"><span class="secno"></span> <span class="content"><span>Handle Service Worker Client Unload</span></span></a>
       <li><a href="#on-user-agent-shutdown-algorithm"><span class="secno"></span> <span class="content"><span>Handle User Agent Shutdown</span></span></a>
+      <li><a href="#update-service-worker-extended-events-set-algorithm"><span class="secno"></span> <span class="content"><span>Update Service Worker Extended Events Set</span></span></a>
       <li><a href="#unregister-algorithm"><span class="secno"></span> <span class="content"><span>Unregister</span></span></a>
       <li><a href="#set-registration-algorithm"><span class="secno"></span> <span class="content"><span>Set Registration</span></span></a>
       <li><a href="#clear-registration-algorithm"><span class="secno"></span> <span class="content"><span>Clear Registration</span></span></a>
@@ -1672,6 +1674,7 @@ pre.idl.highlight { color: #708090; }
       <li><a href="#scope-match-algorithm"><span class="secno"></span> <span class="content"><span>Match Service Worker Registration</span></span></a>
       <li><a href="#get-registration-algorithm"><span class="secno"></span> <span class="content"><span>Get Registration</span></span></a>
       <li><a href="#get-newest-worker-algorithm"><span class="secno"></span> <span class="content"><span>Get Newest Worker</span></span></a>
+      <li><a href="#service-worker-has-no-pending-events-algorithm"><span class="secno"></span> <span class="content"><span>Service Worker Has No Pending Events</span></span></a>
       <li><a href="#create-client-algorithm"><span class="secno"></span> <span class="content"><span>Create Client</span></span></a>
       <li><a href="#create-windowclient-algorithm"><span class="secno"></span> <span class="content"><span>Create Window Client</span></span></a>
       <li><a href="#query-cache-algorithm"><span class="secno"></span> <span class="content"><span>Query Cache</span></span></a>
@@ -1738,10 +1741,11 @@ pre.idl.highlight { color: #708090; }
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-25">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-skip-waiting-flag">skip waiting flag</dfn>. Unless stated otherwise it is unset.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-26">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-imported-scripts-updated-flag">imported scripts updated flag</dfn>. It is initially unset.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-27">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-set-of-event-types-to-handle">set of event types to handle</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a>) whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item">item</a> is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-listener">event listener</a>’s event type. It is initially an empty set.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-28">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-set-of-extended-events">set of extended events</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set">set</a>) whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item">item</a> is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event">event</a>. It is initially an empty set.</p>
      <section>
       <h4 class="heading settled" data-level="2.1.1" id="service-worker-lifetime"><span class="secno">2.1.1. </span><span class="content">Lifetime</span><a class="self-link" href="#service-worker-lifetime"></a></h4>
-      <p>The lifetime of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-28">service worker</a> is tied to the execution lifetime of events and not references held by <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-2">service worker clients</a> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-1">ServiceWorker</a></code> object.</p>
-      <p>A user agent <em>may</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-1">terminate</a> <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-29">service workers</a> at any time it:</p>
+      <p>The lifetime of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-29">service worker</a> is tied to the execution lifetime of events and not references held by <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-2">service worker clients</a> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-1">ServiceWorker</a></code> object.</p>
+      <p>A user agent <em>may</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-1">terminate</a> <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-30">service workers</a> at any time it:</p>
       <ul>
        <li data-md="">
         <p>Has no event to handle.</p>
@@ -1752,11 +1756,11 @@ pre.idl.highlight { color: #708090; }
     </section>
     <section>
      <h3 class="heading settled" data-level="2.2" id="service-worker-registration-concept"><span class="secno">2.2. </span><span class="content">Service Worker Registration</span><a class="self-link" href="#service-worker-registration-concept"></a></h3>
-     <p>A <dfn class="dfn-paneled" data-dfn-for="" data-dfn-type="dfn" data-export="" id="dfn-service-worker-registration">service worker registration</dfn> is a tuple of a <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-1">scope url</a> and a set of <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-30">service workers</a>, an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-1">installing worker</a>, a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-1">waiting worker</a>, and an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-1">active worker</a>. A user agent <em>may</em> enable many <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-2">service worker registrations</a> at a single origin so long as the <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-2">scope url</a> of the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-3">service worker registration</a> differs. A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-4">service worker registration</a> of an identical <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-3">scope url</a> when one already exists in the user agent causes the existing <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-5">service worker registration</a> to be replaced.</p>
+     <p>A <dfn class="dfn-paneled" data-dfn-for="" data-dfn-type="dfn" data-export="" id="dfn-service-worker-registration">service worker registration</dfn> is a tuple of a <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-1">scope url</a> and a set of <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-31">service workers</a>, an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-1">installing worker</a>, a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-1">waiting worker</a>, and an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-1">active worker</a>. A user agent <em>may</em> enable many <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-2">service worker registrations</a> at a single origin so long as the <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-2">scope url</a> of the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-3">service worker registration</a> differs. A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-4">service worker registration</a> of an identical <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-3">scope url</a> when one already exists in the user agent causes the existing <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-5">service worker registration</a> to be replaced.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-6">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-scope-url">scope url</dfn> (a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a>).</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-7">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-installing-worker">installing worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-31">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-1">state</a> is <em>installing</em>. It is initially set to null.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-8">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-waiting-worker">waiting worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-32">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-2">state</a> is <em>installed</em>. It is initially set to null.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-9">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-active-worker">active worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-33">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-3">state</a> is either <em>activating</em> or <em>activated</em>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-7">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-installing-worker">installing worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-32">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-1">state</a> is <em>installing</em>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-8">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-waiting-worker">waiting worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-33">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-2">state</a> is <em>installed</em>. It is initially set to null.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-9">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-active-worker">active worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-34">service worker</a> or null) whose <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-3">state</a> is either <em>activating</em> or <em>activated</em>. It is initially set to null.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-10">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-last-update-check-time">last update check time</dfn>. It is initially set to null.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-11">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-use-cache">use cache</dfn> (a boolean). It is initially set to false.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-12">service worker registration</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker registration" data-dfn-type="dfn" data-export="" id="dfn-uninstalling-flag">uninstalling flag</dfn>. It is initially unset.</p>
@@ -1784,16 +1788,16 @@ pre.idl.highlight { color: #708090; }
     </section>
     <section>
      <h3 class="heading settled" data-level="2.5" id="task-sources"><span class="secno">2.5. </span><span class="content">Task Sources</span><a class="self-link" href="#task-sources"></a></h3>
-     <p>The following additional <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a> are used by <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-34">service workers</a>.</p>
+     <p>The following additional <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a> are used by <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-35">service workers</a>.</p>
      <dl>
       <dt data-md="">
        <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-handle-fetch-task-source">handle fetch task source</dfn></p>
       <dd data-md="">
-       <p>This <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is used for <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-2">fetch</a></code> events to <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-35">service workers</a>.</p>
+       <p>This <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is used for <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-2">fetch</a></code> events to <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-36">service workers</a>.</p>
       <dt data-md="">
        <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-handle-functional-event-task-source">handle functional event task source</dfn></p>
       <dd data-md="">
-       <p>This <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is used for features that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> other <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-1">functional events</a>, e.g. <code class="idl"><a class="idl-code" data-link-type="event" href="https://w3c.github.io/push-api/#h-the-push-event">push</a></code> events, to <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-36">service workers</a>.</p>
+       <p>This <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is used for features that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> other <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-1">functional events</a>, e.g. <code class="idl"><a class="idl-code" data-link-type="event" href="https://w3c.github.io/push-api/#h-the-push-event">push</a></code> events, to <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-37">service workers</a>.</p>
        <p class="note" role="note"><span>Note:</span> A user agent may use a separate task source for each functional event type in order to avoid a head-of-line blocking phenomenon for certain functional events.</p>
      </dl>
     </section>
@@ -1802,7 +1806,7 @@ pre.idl.highlight { color: #708090; }
      <p>A user agent <em>must</em> maintain the state of its stored <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-28">service worker registrations</a> across restarts with the following rules:</p>
      <ul>
       <li data-md="">
-       <p>An <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-2">installing worker</a> does not persist but discarded. If the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-3">installing worker</a> was the only <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-37">service worker</a> for the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-29">service worker registration</a>, the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-30">service worker registration</a> is discarded.</p>
+       <p>An <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-2">installing worker</a> does not persist but discarded. If the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-3">installing worker</a> was the only <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-38">service worker</a> for the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-29">service worker registration</a>, the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-30">service worker registration</a> is discarded.</p>
       <li data-md="">
        <p>A <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-2">waiting worker</a> promotes to an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-10">active worker</a>.</p>
      </ul>
@@ -1846,11 +1850,11 @@ pre.idl.highlight { color: #708090; }
   <dfn class="s dfn-paneled idl-code" data-dfn-for="ServiceWorkerState" data-dfn-type="enum-value" data-export="" data-lt="&quot;redundant&quot;|redundant" id="dom-serviceworkerstate-redundant">"redundant"</dfn>
 };
 </pre>
-     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-4">ServiceWorker</a></code> object represents a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-38">service worker</a>. Each <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-5">ServiceWorker</a></code> object is associated with a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-39">service worker</a>. Multiple separate objects implementing the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-6">ServiceWorker</a></code> interface across documents and workers can all be associated with the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-40">service worker</a> simultaneously.</p>
-     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-7">ServiceWorker</a></code> object has an associated <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate-2">ServiceWorkerState</a></code> object which is itself associated with <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-41">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-4">state</a>.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-4">ServiceWorker</a></code> object represents a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-39">service worker</a>. Each <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-5">ServiceWorker</a></code> object is associated with a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-40">service worker</a>. Multiple separate objects implementing the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-6">ServiceWorker</a></code> interface across documents and workers can all be associated with the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-41">service worker</a> simultaneously.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-7">ServiceWorker</a></code> object has an associated <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate-2">ServiceWorkerState</a></code> object which is itself associated with <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-42">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-4">state</a>.</p>
      <section>
       <h4 class="heading settled" data-level="3.1.1" id="service-worker-url"><span class="secno">3.1.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworker-scripturl" id="ref-for-dom-serviceworker-scripturl-2">scriptURL</a></code></span><a class="self-link" href="#service-worker-url"></a></h4>
-      <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorker" data-dfn-type="attribute" data-export="" id="dom-serviceworker-scripturl"><code>scriptURL</code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-42">service worker</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-1">script url</a>.</p>
+      <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorker" data-dfn-type="attribute" data-export="" id="dom-serviceworker-scripturl"><code>scriptURL</code></dfn> attribute <em>must</em> return the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-43">service worker</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-1">script url</a>.</p>
       <div class="example" id="example-3ff1f346">
        <a class="self-link" href="#example-3ff1f346"></a> For example, consider a document created by a navigation to <code>https://example.com/app.html</code> which <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-4">matches</a> via the following registration call which has been previously executed: 
 <pre class="highlight"><span class="c1">// Script on the page https://example.com/app.html
@@ -1870,7 +1874,7 @@ pre.idl.highlight { color: #708090; }
        <li data-md="">
         <p>If the <code class="idl"><a data-link-type="idl" href="#dom-serviceworker-state" id="ref-for-dom-serviceworker-state-3">state</a></code> attribute value of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> is <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-redundant" id="ref-for-dom-serviceworkerstate-redundant-1">"redundant"</a></code>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" exception and abort these steps.</p>
        <li data-md="">
-        <p>Let <var>serviceWorker</var> be the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-43">service worker</a> represented by the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
+        <p>Let <var>serviceWorker</var> be the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-44">service worker</a> represented by the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
        <li data-md="">
         <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-1">Run Service Worker</a> algorithm with <var>serviceWorker</var> as the argument.</p>
        <li data-md="">
@@ -1904,6 +1908,8 @@ pre.idl.highlight { color: #708090; }
           <p>Let the <code class="idl"><a data-link-type="idl" href="#dom-extendablemessageevent-ports" id="ref-for-dom-extendablemessageevent-ports-1">ports</a></code> attribute of <var>e</var> be initialized to <var>newPorts</var>.</p>
          <li data-md="">
           <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>destination</var>.</p>
+         <li data-md="">
+          <p>Invoke <a data-link-type="dfn" href="#update-service-worker-extended-events-set" id="ref-for-update-service-worker-extended-events-set-1">Update Service Worker Extended Events Set</a> with <var>serviceWorker</var> and <var>e</var>.</p>
         </ol>
         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <em>must</em> use the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>.</p>
       </ol>
@@ -1945,17 +1951,17 @@ pre.idl.highlight { color: #708090; }
      <section class="algorithm" data-algorithm="navigator-service-worker-installing">
       <h4 class="heading settled" data-level="3.2.1" id="navigator-service-worker-installing"><span class="secno">3.2.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-installing" id="ref-for-dom-serviceworkerregistration-installing-2">installing</a></code></span><a class="self-link" href="#navigator-service-worker-installing"></a></h4>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export="" id="dom-serviceworkerregistration-installing"><code>installing</code></dfn> attribute <em>must</em> return the value to which it was last set.</p>
-      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-13">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-44">service worker</a> are the same objects.</p>
+      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-13">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-45">service worker</a> are the same objects.</p>
      </section>
      <section class="algorithm" data-algorithm="navigator-service-worker-waiting">
       <h4 class="heading settled" data-level="3.2.2" id="navigator-service-worker-waiting"><span class="secno">3.2.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-waiting" id="ref-for-dom-serviceworkerregistration-waiting-2">waiting</a></code></span><a class="self-link" href="#navigator-service-worker-waiting"></a></h4>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export="" id="dom-serviceworkerregistration-waiting"><code>waiting</code></dfn> attribute <em>must</em> return the value to which it was last set.</p>
-      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-14">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-45">service worker</a> are the same objects.</p>
+      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-14">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-46">service worker</a> are the same objects.</p>
      </section>
      <section class="algorithm" data-algorithm="navigator-service-worker-active">
       <h4 class="heading settled" data-level="3.2.3" id="navigator-service-worker-active"><span class="secno">3.2.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-2">active</a></code></span><a class="self-link" href="#navigator-service-worker-active"></a></h4>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerRegistration" data-dfn-type="attribute" data-export="" id="dom-serviceworkerregistration-active"><code>active</code></dfn> attribute <em>must</em> return the value to which it was last set.</p>
-      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-15">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-46">service worker</a> are the same objects.</p>
+      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-15">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-47">service worker</a> are the same objects.</p>
      </section>
      <section class="algorithm" data-algorithm="service-worker-registration-scope">
       <h4 class="heading settled" data-level="3.2.4" id="service-worker-registration-scope"><span class="secno">3.2.4. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-scope" id="ref-for-dom-serviceworkerregistration-scope-2">scope</a></code></span><a class="self-link" href="#service-worker-registration-scope"></a></h4>
@@ -2059,7 +2065,7 @@ pre.idl.highlight { color: #708090; }
 };
 </pre>
      <p>The user agent <em>must</em> create a <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-5">ServiceWorkerContainer</a></code> object when a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#navigator">Navigator</a></code> object or a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">WorkerNavigator</a></code> object is created and associate it with that object.</p>
-     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-6">ServiceWorkerContainer</a></code> provides capabilities to register, unregister, and update the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-36">service worker registrations</a>, and provides access to the state of the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-37">service worker registrations</a> and their associated <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-47">service workers</a>.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-6">ServiceWorkerContainer</a></code> provides capabilities to register, unregister, and update the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-36">service worker registrations</a>, and provides access to the state of the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-37">service worker registrations</a> and their associated <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-48">service workers</a>.</p>
      <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-7">ServiceWorkerContainer</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerContainer" data-dfn-type="dfn" data-noexport="" id="serviceworkercontainer-service-worker-client">service worker client</dfn>, which is a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-22">service worker client</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> is associated with the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#navigator">Navigator</a></code> object or the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">WorkerNavigator</a></code> object that the <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-8">ServiceWorkerContainer</a></code> is retrieved from.</p>
      <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-9">ServiceWorkerContainer</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerContainer" data-dfn-type="dfn" data-noexport="" id="serviceworkercontainer-ready-promise">ready promise</dfn> (a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>). It is initially set to a new <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>.</p>
      <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-10">ServiceWorkerContainer</a></code> object has a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> called the <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerContainer" data-dfn-type="dfn" data-export="" id="dfn-client-message-queue">client message queue</dfn>, initially empty. A <a data-link-type="dfn" href="#dfn-client-message-queue" id="ref-for-dfn-client-message-queue-1">client message queue</a> can be enabled or disabled, and is initially disabled. When a <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-11">ServiceWorkerContainer</a></code> object’s <a data-link-type="dfn" href="#dfn-client-message-queue" id="ref-for-dfn-client-message-queue-2">client message queue</a> is enabled, the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> <em>must</em> use it as one of its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>. When the <code class="idl"><a data-link-type="idl" href="#serviceworkercontainer" id="ref-for-serviceworkercontainer-12">ServiceWorkerContainer</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object, all <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> on its <a data-link-type="dfn" href="#dfn-client-message-queue" id="ref-for-dfn-client-message-queue-3">client message queue</a> <em>must</em> be associated with its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a>.</p>
@@ -2072,7 +2078,7 @@ pre.idl.highlight { color: #708090; }
        <li data-md="">
         <p>Return the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-17">ServiceWorker</a></code> object that represents <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>.</p>
       </ol>
-      <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="#dom-serviceworkercontainer-controller" id="ref-for-dom-serviceworkercontainer-controller-3">navigator.serviceWorker.controller</a></code> returns <code>null</code> if the request is a force refresh (shift+refresh). The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-18">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-48">service worker</a> are the same objects.</p>
+      <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="#dom-serviceworkercontainer-controller" id="ref-for-dom-serviceworkercontainer-controller-3">navigator.serviceWorker.controller</a></code> returns <code>null</code> if the request is a force refresh (shift+refresh). The <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-18">ServiceWorker</a></code> objects returned from this attribute getter that represent the same <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-49">service worker</a> are the same objects.</p>
      </section>
      <section class="algorithm" data-algorithm="navigator-service-worker-ready">
       <h4 class="heading settled" data-level="3.4.2" id="navigator-service-worker-ready"><span class="secno">3.4.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkercontainer-ready" id="ref-for-dom-serviceworkercontainer-ready-2">ready</a></code></span><a class="self-link" href="#navigator-service-worker-ready"></a></h4>
@@ -2280,7 +2286,7 @@ pre.idl.highlight { color: #708090; }
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerContainer" data-dfn-type="event" data-export="" id="service-worker-container-controllerchange-event"><code>controllerchange</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code>
-        <td>The <a data-link-type="dfn" href="#serviceworkercontainer-service-worker-client" id="ref-for-serviceworkercontainer-service-worker-client-6">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> changes. (See step 9.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-2">Activate</a> algorithm. The <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-1">skip waiting flag</a> of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-49">service worker</a> causes <a data-link-type="dfn" href="#activate" id="ref-for-activate-3">activation</a> of the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-41">service worker registration</a> to occur while <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-23">service worker clients</a> are <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-2">using</a> the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-42">service worker registration</a>, <code class="idl"><a data-link-type="idl" href="#dom-serviceworkercontainer-controller" id="ref-for-dom-serviceworkercontainer-controller-4">navigator.serviceWorker.controller</a></code> immediately reflects the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-14">active worker</a> as the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-50">service worker</a> that <a data-link-type="dfn" href="#dfn-control" id="ref-for-dfn-control-3">controls</a> the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-24">service worker client</a>.)
+        <td>The <a data-link-type="dfn" href="#serviceworkercontainer-service-worker-client" id="ref-for-serviceworkercontainer-service-worker-client-6">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> changes. (See step 9.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-2">Activate</a> algorithm. The <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-1">skip waiting flag</a> of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-50">service worker</a> causes <a data-link-type="dfn" href="#activate" id="ref-for-activate-3">activation</a> of the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-41">service worker registration</a> to occur while <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-23">service worker clients</a> are <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-2">using</a> the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-42">service worker registration</a>, <code class="idl"><a data-link-type="idl" href="#dom-serviceworkercontainer-controller" id="ref-for-dom-serviceworkercontainer-controller-4">navigator.serviceWorker.controller</a></code> immediately reflects the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-14">active worker</a> as the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-51">service worker</a> that <a data-link-type="dfn" href="#dfn-control" id="ref-for-dfn-control-3">controls</a> the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-24">service worker client</a>.)
      </table>
     </section>
    </section>
@@ -2341,8 +2347,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <a class="nv idl-code" data-link-type="attribute" data-type="EventHandler" href="#dom-serviceworkerglobalscope-onmessage" id="ref-for-dom-serviceworkerglobalscope-onmessage-1">onmessage</a>; // event.source of the message events is Client object
 };
 </pre>
-     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-6">ServiceWorkerGlobalScope</a></code> object represents the global execution context of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-51">service worker</a>. A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-7">ServiceWorkerGlobalScope</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="dfn" data-noexport="" id="serviceworkerglobalscope-service-worker">service worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-52">service worker</a>). A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-8">ServiceWorkerGlobalScope</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="dfn" data-noexport="" id="serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">force bypass cache for importscripts flag</dfn>. It is initially unset.</p>
-     <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-9">ServiceWorkerGlobalScope</a></code> object provides generic, event-driven, time-limited script execution contexts that run at an origin. Once successfully <a data-link-type="dfn" href="#register" id="ref-for-register-2">registered</a>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-53">service worker</a> is started, kept alive and killed by their relationship to events, not <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-25">service worker clients</a>. Any type of synchronous requests must not be initiated inside of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-54">service worker</a>.</p>
+     <p>A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-6">ServiceWorkerGlobalScope</a></code> object represents the global execution context of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-52">service worker</a>. A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-7">ServiceWorkerGlobalScope</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="dfn" data-noexport="" id="serviceworkerglobalscope-service-worker">service worker</dfn> (a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-53">service worker</a>). A <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-8">ServiceWorkerGlobalScope</a></code> object has an associated <dfn class="dfn-paneled" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="dfn" data-noexport="" id="serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">force bypass cache for importscripts flag</dfn>. It is initially unset.</p>
+     <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-9">ServiceWorkerGlobalScope</a></code> object provides generic, event-driven, time-limited script execution contexts that run at an origin. Once successfully <a data-link-type="dfn" href="#register" id="ref-for-register-2">registered</a>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-54">service worker</a> is started, kept alive and killed by their relationship to events, not <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-25">service worker clients</a>. Any type of synchronous requests must not be initiated inside of a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-55">service worker</a>.</p>
      <section>
       <h4 class="heading settled" data-level="4.1.1" id="service-worker-global-scope-clients"><span class="secno">4.1.1. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-clients" id="ref-for-dom-serviceworkerglobalscope-clients-2">clients</a></code></span><a class="self-link" href="#service-worker-global-scope-clients"></a></h4>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="attribute" data-export="" id="dom-serviceworkerglobalscope-clients"><code>clients</code></dfn> attribute <em>must</em> return the <code class="idl"><a data-link-type="idl" href="#clients" id="ref-for-clients-2">Clients</a></code> object that is associated with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>.</p>
@@ -2353,7 +2359,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </section>
      <section class="algorithm" data-algorithm="service-worker-global-scope-skipwaiting">
       <h4 class="heading settled" data-level="4.1.3" id="service-worker-global-scope-skipwaiting"><span class="secno">4.1.3. </span><span class="content"><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-skipwaiting" id="ref-for-dom-serviceworkerglobalscope-skipwaiting-2">skipWaiting()</a></code></span><a class="self-link" href="#service-worker-global-scope-skipwaiting"></a></h4>
-      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-skipwaiting" id="ref-for-dom-serviceworkerglobalscope-skipwaiting-3">skipWaiting()</a></code> method allows this <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-55">service worker</a> to progress from the <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-5">registration</a>'s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-3">waiting</a> position to <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-15">active</a> even while <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-26">service worker clients</a> are <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-3">using</a> the <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-6">registration</a>.</p>
+      <p class="note" role="note"><span>Note:</span> The <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-skipwaiting" id="ref-for-dom-serviceworkerglobalscope-skipwaiting-3">skipWaiting()</a></code> method allows this <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-56">service worker</a> to progress from the <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-5">registration</a>'s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-3">waiting</a> position to <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-15">active</a> even while <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-26">service worker clients</a> are <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-3">using</a> the <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-6">registration</a>.</p>
       <p><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="method" data-export="" id="dom-serviceworkerglobalscope-skipwaiting"><code>skipWaiting()</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
@@ -2362,7 +2368,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
         <ol>
          <li data-md="">
-          <p>Set <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-56">service worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-2">skip waiting flag</a>.</p>
+          <p>Set <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-4">service worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-2">skip waiting flag</a>.</p>
+         <li data-md="">
+          <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-1">Try Activate</a> with <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-5">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-7">containing service worker registration</a>.</p>
          <li data-md="">
           <p>Resolve <var>promise</var> with undefined.</p>
         </ol>
@@ -2471,7 +2479,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Let the <a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin">origin</a> attribute of <var>e</var> be initialized to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin">Unicode serialization</a> of <var>sourceSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
          <li data-md="">
-          <p>Let the <a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source">source</a> attribute of <var>e</var> be initialized to a <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-22">ServiceWorker</a></code> object, which represents the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-4">service worker</a> associated with <var>sourceSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>.</p>
+          <p>Let the <a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source">source</a> attribute of <var>e</var> be initialized to a <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-22">ServiceWorker</a></code> object, which represents the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-6">service worker</a> associated with <var>sourceSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>.</p>
          <li data-md="">
           <p>Let the <a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports">ports</a> attribute of <var>e</var> be initialized to <var>newPorts</var>.</p>
          <li data-md="">
@@ -2546,7 +2554,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>If <var>url</var> is <code>about:blank</code>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with a <code>TypeError</code>.</p>
        <li data-md="">
-        <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-11">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-5">service worker</a>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with a <code>TypeError</code>.</p>
+        <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s associated <a data-link-type="dfn" href="#client-service-worker-client" id="ref-for-client-service-worker-client-11">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-7">service worker</a>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with a <code>TypeError</code>.</p>
        <li data-md="">
         <p>Let <var>promise</var> be a new <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>.</p>
        <li data-md="">
@@ -2583,7 +2591,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>If <var>navigateFailed</var> is true, reject <var>promise</var> with a <code>TypeError</code> and abort these steps.</p>
          <li data-md="">
-          <p>If <var>browsingContext</var>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin</a> is not the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-6">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+          <p>If <var>browsingContext</var>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-origin">origin</a> is not the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-8">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
           <ol>
            <li data-md="">
             <p>Resolve <var>promise</var> with null.</p>
@@ -2635,7 +2643,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>Run these substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
         <ol>
          <li data-md="">
-          <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-28">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="#service-worker-client-origin" id="ref-for-service-worker-client-origin-1">origin</a> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-7">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>:</p>
+          <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-28">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="#service-worker-client-origin" id="ref-for-service-worker-client-origin-1">origin</a> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-9">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>:</p>
           <ol>
            <li data-md="">
             <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id">id</a> is not <var>id</var>, continue to the next iteration of the loop.</p>
@@ -2711,7 +2719,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Let <var>targetClients</var> be an empty array.</p>
          <li data-md="">
-          <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-29">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="#service-worker-client-origin" id="ref-for-service-worker-client-origin-2">origin</a> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-8">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>:</p>
+          <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-29">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="#service-worker-client-origin" id="ref-for-service-worker-client-origin-2">origin</a> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-10">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>:</p>
           <ol>
            <li data-md="">
             <p>If <var>client</var> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a>, then:</p>
@@ -2729,7 +2737,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
             <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-includeuncontrolled" id="ref-for-dom-clientqueryoptions-includeuncontrolled-1">includeUncontrolled</a></code> is false, then:</p>
             <ol>
              <li data-md="">
-              <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-9">service worker</a>, continue to the next iteration of the loop.</p>
+              <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-11">service worker</a>, continue to the next iteration of the loop.</p>
             </ol>
            <li data-md="">
             <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-clientqueryoptions-includereserved" id="ref-for-dom-clientqueryoptions-includereserved-1">includeReserved</a></code> is false, then:</p>
@@ -2860,7 +2868,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>If <var>openWindowFailed</var> is true, reject <var>promise</var> with a <code>TypeError</code> and abort these steps.</p>
          <li data-md="">
-          <p>If <var>newContext</var>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> is not the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-10">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
+          <p>If <var>newContext</var>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> is not the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-12">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>, then:</p>
           <ol>
            <li data-md="">
             <p>Resolve <var>promise</var> with null.</p>
@@ -2881,14 +2889,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="Clients" data-dfn-type="method" data-export="" id="dom-clients-claim"><code>claim()</code></dfn> method <em>must</em> run these steps:</p>
       <ol>
        <li data-md="">
-        <p>If the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-11">service worker</a> is not an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-16">active worker</a>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" exception.</p>
+        <p>If the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-13">service worker</a> is not an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-16">active worker</a>, return a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> rejected with an "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>" exception.</p>
        <li data-md="">
         <p>Let <var>promise</var> be a new <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a>.</p>
        <li data-md="">
         <p>Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
         <ol>
          <li data-md="">
-          <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-31">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="#service-worker-client-origin" id="ref-for-service-worker-client-origin-3">origin</a> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-12">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>:</p>
+          <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-31">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="#service-worker-client-origin" id="ref-for-service-worker-client-origin-3">origin</a> is the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same</a> as the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-14">service worker</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>:</p>
           <ol>
            <li data-md="">
             <p>If <var>client</var> is a type of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">environment</a>, then:</p>
@@ -2905,14 +2913,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <li data-md="">
             <p>Let <var>registration</var> be the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-7">Match Service Worker Registration</a> algorithm passing <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> as the argument.</p>
            <li data-md="">
-            <p>If <var>registration</var> is not the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-13">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-7">containing service worker registration</a>, continue to the next iteration of the loop.</p>
+            <p>If <var>registration</var> is not the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-15">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-8">containing service worker registration</a>, continue to the next iteration of the loop.</p>
            <li data-md="">
-            <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-14">service worker</a>, then:</p>
+            <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is not the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-16">service worker</a>, then:</p>
             <ol>
              <li data-md="">
               <p>Invoke <a data-link-type="dfn" href="#handle-service-worker-client-unload" id="ref-for-handle-service-worker-client-unload-1">Handle Service Worker Client Unload</a> with <var>client</var> as the argument.</p>
              <li data-md="">
-              <p>Set <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-15">service worker</a>.</p>
+              <p>Set <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-17">service worker</a>.</p>
              <li data-md="">
               <p>Invoke <a data-link-type="dfn" href="#notify-controller-change" id="ref-for-notify-controller-change-1">Notify Controller Change</a> algorithm with <var>client</var> as the argument.</p>
             </ol>
@@ -2957,10 +2965,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>Add <var>f</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-8">extend lifetime promises</a>.</p>
        <li data-md="">
-        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-2">pending promises count</a> by one.</p>
-        <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-3">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done in the microtask queued by the reaction to the promise.</p>
+        <p>Increment the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-2">pending promises count</a> by one.</p>
+        <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-3">pending promises count</a> is incremented even if the given promise has already been settled. The corresponding count decrement is done in the microtask queued by the reaction to the promise.</p>
        <li data-md="">
-        <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>f</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a> to decrease the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> by one.</p>
+        <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>f</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a> to run these substeps:</p>
+        <ol>
+         <li data-md="">
+          <p>Decrement the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> by one.</p>
+         <li data-md="">
+          <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-2">Try Activate</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>'s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-18">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>.</p>
+        </ol>
       </ol>
       <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-3">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-63">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> when <var>event</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is set or <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-5">pending promises count</a> is not zero. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
      </section>
@@ -3049,10 +3063,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-9">extend lifetime promises</a>.</p>
        <li data-md="">
-        <p>Increase the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-6">pending promises count</a> by one.</p>
-        <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-7">pending promises count</a> is increased even if the given promise has already been settled. The corresponding count decrease is done in the microtask queued by the reaction to the promise.</p>
+        <p>Increment the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-6">pending promises count</a> by one.</p>
+        <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-7">pending promises count</a> is incremented even if the given promise has already been settled. The corresponding count decrement is done in the microtask queued by the reaction to the promise.</p>
        <li data-md="">
-        <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>r</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a> to decrease the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> by one.</p>
+        <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>r</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a> to run these substeps:</p>
+        <ol>
+         <li data-md="">
+          <p>Decrement the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> by one.</p>
+         <li data-md="">
+          <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-3">Try Activate</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>'s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-19">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-10">containing service worker registration</a>.</p>
+        </ol>
         <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-3">event.respondWith(r)</a></code> extends the lifetime of the event by default as if <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">event.waitUntil(r)</a></code> is called.</p>
        <li data-md="">
         <p>Set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-propagation-flag">stop propagation flag</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">stop immediate propagation flag</a>.</p>
@@ -3215,15 +3235,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-install-event"><code>install</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-10">ExtendableEvent</a></code>
-        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-2">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-16">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-8">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-6">installing worker</a> changes. (See step 11.2 of the <a data-link-type="dfn" href="#install" id="ref-for-install-4">Install</a> algorithm.)
+        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-2">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-20">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-11">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-6">installing worker</a> changes. (See step 11.2 of the <a data-link-type="dfn" href="#install" id="ref-for-install-4">Install</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-activate-event"><code>activate</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-11">ExtendableEvent</a></code>
-        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-3">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-17">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-18">active worker</a> changes. (See step 12.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-6">Activate</a> algorithm.)
+        <td>[<a data-link-type="dfn" href="#dfn-lifecycle-events" id="ref-for-dfn-lifecycle-events-3">Lifecycle event</a>] The <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-21">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-12">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-18">active worker</a> changes. (See step 12.2 of the <a data-link-type="dfn" href="#activate" id="ref-for-activate-6">Activate</a> algorithm.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="service-worker-global-scope-fetch-event"><code>fetch</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#fetchevent" id="ref-for-fetchevent-4">FetchEvent</a></code>
-        <td>[<a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-4">Functional event</a>] The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a> invokes <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-4">Handle Fetch</a> with <var>request</var>. As a result of performing <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-5">Handle Fetch</a>, the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-18">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-1">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
+        <td>[<a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-4">Functional event</a>] The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a> invokes <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-4">Handle Fetch</a> with <var>request</var>. As a result of performing <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-5">Handle Fetch</a>, the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-22">service worker</a> returns a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> to the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch">http fetch</a>. The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a>, represented by a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, can be retrieved from a <code class="idl"><a data-link-type="idl" href="#cache" id="ref-for-cache-1">Cache</a></code> object or directly from network using <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-global-fetch">self.fetch(input, init)</a></code> method. (A custom <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object can be another option.)
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="event" data-export="" id="eventdef-serviceworkerglobalscope-message"><code>message</code></dfn>
         <td><code class="idl"><a data-link-type="idl" href="#extendablemessageevent" id="ref-for-extendablemessageevent-4">ExtendableMessageEvent</a></code>
@@ -3961,12 +3981,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="method" data-export="" id="importscripts-method"><code>importScripts(<var>urls</var>)</code></dfn> method is called on a <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-14">ServiceWorkerGlobalScope</a></code> object, the user agent <em>must</em> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">import scripts into worker global scope</a>, given this <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-15">ServiceWorkerGlobalScope</a></code> object and <var>urls</var>, and with the following steps to <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-perform-fetch">perform the fetch</a> given the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> <var>request</var>:</p>
       <ol>
        <li data-md="">
-        <p>Let <var>serviceWorker</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-19">service worker</a>.</p>
+        <p>Let <var>serviceWorker</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-23">service worker</a>.</p>
        <li data-md="">
         <p>If <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-imported-scripts-updated-flag" id="ref-for-dfn-imported-scripts-updated-flag-1">imported scripts updated flag</a> is unset, then:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>registration</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-10">containing service worker registration</a>.</p>
+          <p>Let <var>registration</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-13">containing service worker registration</a>.</p>
          <li data-md="">
           <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">cache mode</a> to "<code>no-cache</code>" if any of the following are true:</p>
           <ul>
@@ -4560,7 +4580,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-3">Resolve Job Promise</a> with <var>job</var> and the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-19">ServiceWorkerRegistration</a></code> object which represents <var>registration</var>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-38">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-15">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-89">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-11">containing service worker registration</a> is <var>registration</var>.</p>
+       <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>updatefound</code> at all the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration-20">ServiceWorkerRegistration</a></code> objects for all the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-38">service worker clients</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-8">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-15">scope url</a> and all the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-89">service workers</a> whose <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a> is <var>registration</var>.</p>
       <li data-md="">
        <p>Let <var>installingWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-8">installing worker</a>.</p>
       <li data-md="">
@@ -4611,8 +4631,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-7">waiting worker</a>.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-5">Terminate</a> <var>redundantWorker</var>.</p>
-        <li data-md="">
-         <p>The user agent <em>may</em> abort in-flight requests triggered by <var>redundantWorker</var>.</p>
        </ol>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-3">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-11">installing worker</a> as the arguments.</p>
@@ -4627,9 +4645,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Wait for all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-5">Update Worker State</a> invoked in this algorithm have executed.</p>
       <li data-md="">
-       <p>Wait until no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-39">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-4">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-9">waiting worker</a>’s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set.</p>
-      <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-10">waiting worker</a> is not null, invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-7">Activate</a> algorithm with <var>registration</var> as its argument.</p>
+       <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-4">Try Activate</a> with <var>registration</var>.</p>
+       <p class="note" role="note"><span>Note:</span> If <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-5">Try Activate</a> does not trigger <a data-link-type="dfn" href="#activate" id="ref-for-activate-7">Activate</a> here, <a data-link-type="dfn" href="#activate" id="ref-for-activate-8">Activate</a> is tried again when the last client controlled by the existing <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-19">active worker</a> is <a data-link-type="dfn" href="#handle-service-worker-client-unload" id="ref-for-handle-service-worker-client-unload-2">unloaded</a>, <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-skipwaiting" id="ref-for-dom-serviceworkerglobalscope-skipwaiting-4">skipWaiting()</a></code> is asynchronously called, and the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-11">extend lifetime promises</a> for the existing <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-20">active worker</a> settle.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Activate">
@@ -4646,30 +4663,22 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-11">waiting worker</a> is null, abort these steps.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-9">waiting worker</a> is null, abort these steps.</p>
       <li data-md="">
        <p>Let <var>redundantWorker</var> be null.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-19">active worker</a> is not null, then:</p>
-       <ol>
-        <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-20">active worker</a>.</p>
-        <li data-md="">
-         <p>Wait for <var>redundantWorker</var> to finish handling any in-progress requests.</p>
-        <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-6">Terminate</a> <var>redundantWorker</var>.</p>
-       </ol>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-21">active worker</a> is not null, <var>redundantWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-22">active worker</a>.</p>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-5">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-5">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-10">waiting worker</a> as the arguments.</p>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-6">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and null as the arguments.</p>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-6">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-21">active worker</a> and <em>activating</em> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-6">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-23">active worker</a> and <em>activating</em> as the arguments.</p>
        <p class="note" role="note"><span>Note:</span> Once an active worker is activating, neither a runtime script error nor a force termination of the active worker prevents the active worker from getting activated.</p>
       <li data-md="">
        <p>If <var>redundantWorker</var> is not null, run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-7">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
       <li data-md="">
-       <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-40">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-9">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-16">scope url</a>:</p>
+       <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-39">service worker client</a> <var>client</var> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a> <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-9">matches</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-16">scope url</a>:</p>
        <ol>
         <li data-md="">
          <p>If <var>client</var> is a <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client-6">window client</a>, unassociate <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">responsible document</a> from its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#application-cache">application cache</a>, if it has one.</p>
@@ -4678,15 +4687,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        </ol>
        <p class="note" role="note"><span>Note:</span> Resources will now use the service worker registration instead of the existing application cache.</p>
       <li data-md="">
-       <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-41">service worker client</a> <var>client</var> who is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-5">using</a> <var>registration</var>:</p>
+       <p>For each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-40">service worker client</a> <var>client</var> who is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-4">using</a> <var>registration</var>:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>client</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-22">active worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-23">active worker</a>.</p>
+         <p>Set <var>client</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-24">active worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-25">active worker</a>.</p>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#notify-controller-change" id="ref-for-notify-controller-change-2">Notify Controller Change</a> algorithm with <var>client</var> as the argument.</p>
        </ol>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-24">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-5">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
@@ -4702,11 +4711,30 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><em>WaitForAsynchronousExtensions</em>: Wait, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>, until <var>e</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-10">pending promises count</a> is zero.</p>
        </ol>
       <li data-md="">
-       <p>Wait for <var>task</var> to have executed or been discarded, or the script to have been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">termination</a> of <var>activeWorker</var>.</p>
+       <p>Wait for <var>task</var> to have executed or been discarded, or the script to have been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-6">termination</a> of <var>activeWorker</var>.</p>
       <li data-md="">
        <p>Wait for the step labeled <em>WaitForAsynchronousExtensions</em> to complete.</p>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-8">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-25">active worker</a> and <em>activated</em> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-8">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-27">active worker</a> and <em>activated</em> as the arguments.</p>
+     </ol>
+    </section>
+    <section class="algorithm" data-algorithm="Try Activate">
+     <h3 class="heading settled" id="try-activate-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="try-activate">Try Activate</dfn></span><a class="self-link" href="#try-activate-algorithm"></a></h3>
+     <dl>
+      <dt data-md="">
+       <p>Input</p>
+      <dd data-md="">
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-54">service worker registration</a></p>
+      <dt data-md="">
+       <p>Output</p>
+      <dd data-md="">
+       <p>None</p>
+     </dl>
+     <ol>
+      <li data-md="">
+       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-11">waiting worker</a> is not null.</p>
+      <li data-md="">
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-28">active worker</a> is null, or if the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-1">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-29">active worker</a> is true, and no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-41">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-5">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set, then invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-9">Activate</a> with <var>registration</var>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Run Service Worker">
@@ -4797,7 +4825,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Create a new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">WorkerLocation</a></code> object and associate it with <var>workerGlobalScope</var>.</p>
       <li data-md="">
-       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-26">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-12">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
+       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-15">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
       <li data-md="">
        <p>If <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>, then <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">run the classic script</a> <var>script</var>. Otherwise, it is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">module script</a>; <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">run the module script</a> <var>script</var>.</p>
        <p class="note" role="note"><span>Note:</span> In addition to the usual possibilities of returning a value or failing due to an exception, this could be prematurely aborted by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">kill a worker</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">terminate a worker</a> algorithms.</p>
@@ -4808,7 +4836,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>For each <var>eventType</var> of <var>settingsObject</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>'s associated list of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-listener">event listeners</a>' event types:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append">Append</a> <var>eventType</var> to <var>workerGlobalScope</var>’s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-20">service worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-1">set of event types to handle</a>.</p>
+           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append">Append</a> <var>eventType</var> to <var>workerGlobalScope</var>’s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-24">service worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-1">set of event types to handle</a>.</p>
          </ol>
        </ol>
        <p class="note" role="note"><span>Note:</span> If the global object’s associated list of event listeners does not have any event listener added at this moment, the service worker’s set of event types to handle remains an empty set. The user agents are encouraged to show a warning that the event listeners must be added on the very first evaluation of the worker script.</p>
@@ -4842,7 +4870,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>serviceWorkerGlobalScope</var>’s closing flag to true.</p>
       <li data-md="">
-       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-13">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
+       <p>If there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a>, whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is either the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-2">handle fetch task source</a> or the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-2">handle functional event task source</a>, queued in <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-16">containing service worker registration</a>’s corresponding <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-4">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>, and discard all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> (including <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is neither the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-3">handle fetch task source</a> nor the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-3">handle functional event task source</a>) from <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> without processing them.</p>
        <p class="note" role="note"><span>Note:</span> This effectively means that the fetch events and the other functional events such as push events are backed up by the registration’s task queues while the other tasks including message events are discarded.</p>
       <li data-md="">
        <p>Abort the script currently running in <var>serviceWorker</var>.</p>
@@ -4911,21 +4939,21 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>registration</var> to the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-10">Match Service Worker Registration</a> algorithm passing <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url">url</a> as the argument.</p>
         <li data-md="">
-         <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-27">active worker</a> is null, return null.</p>
+         <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-31">active worker</a> is null, return null.</p>
         <li data-md="">
-         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-28">active worker</a>.</p>
+         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-32">active worker</a>.</p>
        </ol>
-       <p class="note" role="note"><span>Note:</span> From this point, the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-43">service worker client</a> starts to <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-6">use</a> its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-14">containing service worker registration</a>.</p>
+       <p class="note" role="note"><span>Note:</span> From this point, the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-43">service worker client</a> starts to <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-6">use</a> its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-17">containing service worker registration</a>.</p>
       <li data-md="">
        <p>Else if <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a>, then:</p>
        <ol>
         <li data-md="">
-         <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is non-null, set <var>registration</var> to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-15">containing service worker registration</a>.</p>
+         <p>If <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> is non-null, set <var>registration</var> to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-18">containing service worker registration</a>.</p>
         <li data-md="">
          <p>Else, return null.</p>
        </ol>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-29">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-33">active worker</a>.</p>
       <li data-md="">
        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-2">set of event types to handle</a> does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> <code>fetch</code>, then:</p>
        <ol>
@@ -4963,6 +4991,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-5">global object</a>.</p>
         <li data-md="">
+         <p>Invoke <a data-link-type="dfn" href="#update-service-worker-extended-events-set" id="ref-for-update-service-worker-extended-events-set-2">Update Service Worker Extended Events Set</a> with <var>activeWorker</var> and <var>e</var>.</p>
+        <li data-md="">
          <p>If <var>e</var>’s <a data-link-type="dfn" href="#fetchevent-respond-with-entered-flag" id="ref-for-fetchevent-respond-with-entered-flag-3">respond-with entered flag</a> is set, set <var>respondWithEntered</var> to true.</p>
         <li data-md="">
          <p>If <var>e</var>’s <a data-link-type="dfn" href="#fetchevent-wait-to-respond-flag" id="ref-for-fetchevent-wait-to-respond-flag-3">wait to respond flag</a> is set, then:</p>
@@ -4977,7 +5007,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>If <var>e</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#canceled-flag">canceled flag</a> is set, set <var>eventCanceled</var> to true.</p>
        </ol>
-       <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-8">termination</a> of <var>activeWorker</var>, set <var>handleFetchFailed</var> to true.</p>
+       <p>If <var>task</var> is discarded or the script has been aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-7">termination</a> of <var>activeWorker</var>, set <var>handleFetchFailed</var> to true.</p>
        <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-fetch-task-source" id="ref-for-dfn-handle-fetch-task-source-4">handle fetch task source</a>.</p>
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded.</p>
@@ -5019,7 +5049,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dd data-md="">
        <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-15">ExtendableEvent</a></code> object</p>
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-54">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-55">service worker registration</a></p>
       <dd data-md="">
        <p><var>callbackSteps</var>, an algorithm</p>
       <dt data-md="">
@@ -5031,9 +5061,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p class="assertion">Assert: <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-7">scope to registration map</a> contains a value equal to <var>registration</var>.</p>
       <li data-md="">
-       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a> is not null.</p>
+       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-34">active worker</a> is not null.</p>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-31">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-35">active worker</a>.</p>
       <li data-md="">
        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-3">set of event types to handle</a> does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> <var>event</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code>, then:</p>
        <ol>
@@ -5054,6 +5084,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <ol>
         <li data-md="">
          <p>Invoke <var>callbackSteps</var> with <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-6">global object</a> as its argument.</p>
+        <li data-md="">
+         <p>Invoke <a data-link-type="dfn" href="#update-service-worker-extended-events-set" id="ref-for-update-service-worker-extended-events-set-3">Update Service Worker Extended Events Set</a> with <var>activeWorker</var> and <var>event</var>.</p>
        </ol>
        <p>The <var>task</var> <em>must</em> use <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a data-link-type="dfn" href="#dfn-handle-functional-event-task-source" id="ref-for-dfn-handle-functional-event-task-source-4">handle functional event task source</a>.</p>
       <li data-md="">
@@ -5064,7 +5096,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section class="algorithm" data-algorithm="Handle Service Worker Client Unload">
      <h3 class="heading settled" id="on-client-unload-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="handle-service-worker-client-unload">Handle Service Worker Client Unload</dfn></span><a class="self-link" href="#on-client-unload-algorithm"></a></h3>
-     <p>The user agent <em>must</em> run these steps when a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-44">service worker client</a> unloads by <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unload-a-document">unloading</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">being killed</a>, or <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-9">terminating</a>.</p>
+     <p>The user agent <em>must</em> run these steps when a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-44">service worker client</a> unloads by <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unload-a-document">unloading</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">being killed</a>, or <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-8">terminating</a>.</p>
      <dl>
       <dt data-md="">
        <p>Input</p>
@@ -5079,7 +5111,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Run the following steps atomically.</p>
       <li data-md="">
-       <p>Let <var>registration</var> be the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-55">service worker registration</a> <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-7">used</a> by <var>client</var>.</p>
+       <p>Let <var>registration</var> be the <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-56">service worker registration</a> <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-7">used</a> by <var>client</var>.</p>
       <li data-md="">
        <p>If <var>registration</var> is null, abort these steps.</p>
       <li data-md="">
@@ -5087,7 +5119,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-4">uninstalling flag</a> is set, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-4">Clear Registration</a> algorithm passing <var>registration</var> as its argument and abort these steps.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a> is not null, run <a data-link-type="dfn" href="#activate" id="ref-for-activate-8">Activate</a> algorithm with <var>registration</var> as the argument.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a> is not null, invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-6">Try Activate</a> with <var>registration</var>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle User Agent Shutdown">
@@ -5118,9 +5150,36 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-14">waiting worker</a> is not null, run the following substep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
          <ol>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-9">Activate</a> with <var>registration</var>.</p>
+           <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-10">Activate</a> with <var>registration</var>.</p>
          </ol>
        </ol>
+     </ol>
+    </section>
+    <section class="algorithm" data-algorithm="Update Service Worker Extended Events Set">
+     <h3 class="heading settled" id="update-service-worker-extended-events-set-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="update-service-worker-extended-events-set">Update Service Worker Extended Events Set</dfn></span><a class="self-link" href="#update-service-worker-extended-events-set-algorithm"></a></h3>
+     <dl>
+      <dt data-md="">
+       <p>Input</p>
+      <dd data-md="">
+       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-93">service worker</a></p>
+      <dd data-md="">
+       <p><var>event</var>, an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event">event</a></p>
+      <dt data-md="">
+       <p>Output</p>
+      <dd data-md="">
+       <p>None</p>
+     </dl>
+     <ol>
+      <li data-md="">
+       <p class="assertion">Assert: <var>event</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is unset.</p>
+      <li data-md="">
+       <p>For each <var>item</var> of <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-1">set of extended events</a>:</p>
+       <ol>
+        <li data-md="">
+         <p>If <var>item</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-11">pending promises count</a> is zero, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove">remove</a> <var>item</var> from <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-2">set of extended events</a>.</p>
+       </ol>
+      <li data-md="">
+       <p>If <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-12">pending promises count</a> is not zero, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append">append</a> <var>event</var> to <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-3">set of extended events</a>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Unregister">
@@ -5177,7 +5236,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-56">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-57">service worker registration</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -5185,7 +5244,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>scopeString</var> be <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <var>scope</var> with the <em>exclude fragment flag</em> set.</p>
       <li data-md="">
-       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-57">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-17">scope url</a> is set to <var>scope</var> and <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-5">use cache</a> is set to <var>useCache</var>.</p>
+       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-58">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-17">scope url</a> is set to <var>scope</var> and <a data-link-type="dfn" href="#dfn-use-cache" id="ref-for-dfn-use-cache-5">use cache</a> is set to <var>useCache</var>.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set">Set</a> <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-9">scope to registration map</a>[<var>scopeString</var>] to <var>registration</var>.</p>
       <li data-md="">
@@ -5198,7 +5257,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-58">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-59">service worker registration</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5215,9 +5274,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-15">installing worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-10">Terminate</a> <var>redundantWorker</var>.</p>
-        <li data-md="">
-         <p>The user agent <em>may</em> abort in-flight requests triggered by <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-9">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-7">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and null as the arguments.</p>
         <li data-md="">
@@ -5229,23 +5286,19 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-16">waiting worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-11">Terminate</a> <var>redundantWorker</var>.</p>
-        <li data-md="">
-         <p>The user agent <em>may</em> abort in-flight requests triggered by <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-10">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-8">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and null as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-10">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-32">active worker</a> is not null, then:</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-36">active worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-33">active worker</a>.</p>
+         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-12">Terminate</a> <var>redundantWorker</var>.</p>
-        <li data-md="">
-         <p>The user agent <em>may</em> abort in-flight requests triggered by <var>redundantWorker</var>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-11">Terminate</a> <var>redundantWorker</var>.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-9">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and null as the arguments.</p>
         <li data-md="">
@@ -5263,11 +5316,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-59">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-60">service worker registration</a></p>
       <dd data-md="">
        <p><var>target</var>, a string (one of "<code>installing</code>", "<code>waiting</code>", and "<code>active</code>")</p>
       <dd data-md="">
-       <p><var>source</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-93">service worker</a> or null</p>
+       <p><var>source</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-94">service worker</a> or null</p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5304,12 +5357,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Else if <var>target</var> is "<code>active</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-34">active worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-3">active</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-27">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-35">active worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-36">active worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-3">active</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-27">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a> is null.</p>
          </ol>
        </ol>
        <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <em>must</em> use <var>registrationObject</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>.</p>
@@ -5321,9 +5374,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-94">service worker</a></p>
+       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-95">service worker</a></p>
       <dd data-md="">
-       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-95">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-10">state</a></p>
+       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-96">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-10">state</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
@@ -5347,27 +5400,27 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
              <p><em>installing</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installing" id="ref-for-dom-serviceworkerstate-installing-1">"installing"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-96">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-97">service worker</a> is not active until all of the core caches are populated.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-97">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a> is not active until all of the core caches are populated.</p>
             <dt data-md="">
              <p><em>installed</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installed" id="ref-for-dom-serviceworkerstate-installed-1">"installed"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a>.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-99">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a>.</p>
             <dt data-md="">
              <p><em>activating</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activating" id="ref-for-dom-serviceworkerstate-activating-1">"activating"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-99">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-42">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
             <dt data-md="">
              <p><em>activated</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activated" id="ref-for-dom-serviceworkerstate-activated-1">"activated"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-43">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>.</p>
             <dt data-md="">
              <p><em>redundant</em></p>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-redundant" id="ref-for-dom-serviceworkerstate-redundant-2">"redundant"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> A new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a> is replacing the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-102">service worker</a>, or the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a> is being discarded due to an install failure.</p>
+             <p class="note" role="note"><span>Note:</span> A new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-102">service worker</a> is replacing the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a>, or the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> is being discarded due to an install failure.</p>
            </dl>
           <li data-md="">
            <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <code>statechange</code> at <var>workerObject</var>.</p>
@@ -5406,7 +5459,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-60">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-61">service worker registration</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -5442,7 +5495,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-61">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-62">service worker registration</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -5469,11 +5522,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dt data-md="">
        <p>Input</p>
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-62">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-63">service worker registration</a></p>
       <dt data-md="">
        <p>Output</p>
       <dd data-md="">
-       <p><var>newestWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a></p>
+       <p><var>newestWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -5485,9 +5538,36 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-21">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-22">waiting worker</a>.</p>
       <li data-md="">
-       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a>.</p>
+       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-44">active worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-45">active worker</a>.</p>
       <li data-md="">
        <p>Return <var>newestWorker</var>.</p>
+     </ol>
+    </section>
+    <section class="algorithm" data-algorithm="Service Worker Has No Pending Events">
+     <h3 class="heading settled" id="service-worker-has-no-pending-events-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="service-worker-has-no-pending-events">Service Worker Has No Pending Events</dfn></span><a class="self-link" href="#service-worker-has-no-pending-events-algorithm"></a></h3>
+     <dl>
+      <dt data-md="">
+       <p>Input</p>
+      <dd data-md="">
+       <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a></p>
+      <dt data-md="">
+       <p>Output</p>
+      <dd data-md="">
+       <p>True or false, a boolean</p>
+     </dl>
+     <ol>
+      <li data-md="">
+       <p>Let <var>sum</var> be zero.</p>
+      <li data-md="">
+       <p>For each <var>item</var> of <var>worker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-4">set of extended events</a>:</p>
+       <ol>
+        <li data-md="">
+         <p>Add <var>item</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-13">pending promises count</a> to <var>sum</var>.</p>
+       </ol>
+      <li data-md="">
+       <p>If <var>sum</var> is zero, return true.</p>
+      <li data-md="">
+       <p>Else, return false.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Create Client">
@@ -5768,18 +5848,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <h2 class="heading settled" id="extended-http-headers"><span class="content">Appendix B: Extended HTTP headers</span><a class="self-link" href="#extended-http-headers"></a></h2>
     <section>
      <h3 class="heading settled" id="service-worker-script-request"><span class="content">Service Worker Script Request</span><a class="self-link" href="#service-worker-script-request"></a></h3>
-     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker"><code>Service-Worker</code><a class="self-link" href="#service-worker"></a></dfn>`</p>
       <dd data-md="">
-       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request.</p>
+       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request.</p>
        <p class="note" role="note"><span>Note:</span> This header helps administrators log the requests and detect threats.</p>
      </dl>
     </section>
     <section>
      <h3 class="heading settled" id="service-worker-script-response"><span class="content">Service Worker Script Response</span><a class="self-link" href="#service-worker-script-response"></a></h3>
-     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
+     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-109">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
       <dt data-md="">
        <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker-allowed"><code>Service-Worker-Allowed</code><a class="self-link" href="#service-worker-allowed"></a></dfn>`</p>
@@ -5826,7 +5906,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" id="syntax"><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
-     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-17">script resource</a> requests and responses:</p>
+     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-110">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-17">script resource</a> requests and responses:</p>
 <pre>Service-Worker = %x73.63.72.69.70.74 ; "script", case-sensitive
 </pre>
      <p class="note" role="note"><span>Note:</span> The validation of the Service-Worker-Allowed header’s values is done by URL parsing algorithm (in Update algorithm) instead of using ABNF.</p>
@@ -6177,6 +6257,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </ul>
    <li><a href="#serviceworkercontainer">ServiceWorkerContainer</a><span>, in §3.4</span>
    <li><a href="#serviceworkerglobalscope">ServiceWorkerGlobalScope</a><span>, in §4.1</span>
+   <li><a href="#service-worker-has-no-pending-events">Service Worker Has No Pending Events</a><span>, in §Unnumbered section</span>
    <li><a href="#serviceworkerregistration">ServiceWorkerRegistration</a><span>, in §3.2</span>
    <li>
     service worker registration
@@ -6186,6 +6267,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </ul>
    <li><a href="#enumdef-serviceworkerstate">ServiceWorkerState</a><span>, in §3.1</span>
    <li><a href="#dfn-set-of-event-types-to-handle">set of event types to handle</a><span>, in §2.1</span>
+   <li><a href="#dfn-set-of-extended-events">set of extended events</a><span>, in §2.1</span>
    <li><a href="#set-registration">Set Registration</a><span>, in §Unnumbered section</span>
    <li><a href="#dom-clienttype-sharedworker">sharedworker</a><span>, in §4.3</span>
    <li><a href="#dom-clienttype-sharedworker">"sharedworker"</a><span>, in §4.3</span>
@@ -6215,6 +6297,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </ul>
    <li><a href="#dfn-service-worker-registration-task-queue">task queues</a><span>, in §2.2</span>
    <li><a href="#terminate-service-worker">Terminate Service Worker</a><span>, in §Unnumbered section</span>
+   <li><a href="#try-activate">Try Activate</a><span>, in §Unnumbered section</span>
    <li>
     type
     <ul>
@@ -6231,6 +6314,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#update">Update</a><span>, in §Unnumbered section</span>
    <li><a href="#service-worker-registration-updatefound-event">updatefound</a><span>, in §3.5</span>
    <li><a href="#update-registration-state">Update Registration State</a><span>, in §Unnumbered section</span>
+   <li><a href="#update-service-worker-extended-events-set">Update Service Worker Extended Events Set</a><span>, in §Unnumbered section</span>
    <li><a href="#update-worker-state">Update Worker State</a><span>, in §Unnumbered section</span>
    <li><a href="#dom-client-url">url</a><span>, in §4.2.1</span>
    <li>
@@ -6489,7 +6573,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://infra.spec.whatwg.org/#list-item">item</a>
      <li><a href="https://infra.spec.whatwg.org/#ordered-map">ordered map</a>
      <li><a href="https://infra.spec.whatwg.org/#ordered-set">ordered set</a>
-     <li><a href="https://infra.spec.whatwg.org/#map-remove">remove</a>
+     <li><a href="https://infra.spec.whatwg.org/#list-remove">remove <small>(for list)</small></a>
+     <li><a href="https://infra.spec.whatwg.org/#map-remove">remove <small>(for map)</small></a>
      <li><a href="https://infra.spec.whatwg.org/#map-set">set</a>
     </ul>
    <li>
@@ -6830,22 +6915,22 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dfn-service-worker">#dfn-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-1">1. Motivations</a> <a href="#ref-for-dfn-service-worker-2">(2)</a> <a href="#ref-for-dfn-service-worker-3">(3)</a> <a href="#ref-for-dfn-service-worker-4">(4)</a> <a href="#ref-for-dfn-service-worker-5">(5)</a> <a href="#ref-for-dfn-service-worker-6">(6)</a> <a href="#ref-for-dfn-service-worker-7">(7)</a> <a href="#ref-for-dfn-service-worker-8">(8)</a> <a href="#ref-for-dfn-service-worker-9">(9)</a> <a href="#ref-for-dfn-service-worker-10">(10)</a> <a href="#ref-for-dfn-service-worker-11">(11)</a> <a href="#ref-for-dfn-service-worker-12">(12)</a> <a href="#ref-for-dfn-service-worker-13">(13)</a> <a href="#ref-for-dfn-service-worker-14">(14)</a>
-    <li><a href="#ref-for-dfn-service-worker-15">2.1. Service Worker</a> <a href="#ref-for-dfn-service-worker-16">(2)</a> <a href="#ref-for-dfn-service-worker-17">(3)</a> <a href="#ref-for-dfn-service-worker-18">(4)</a> <a href="#ref-for-dfn-service-worker-19">(5)</a> <a href="#ref-for-dfn-service-worker-20">(6)</a> <a href="#ref-for-dfn-service-worker-21">(7)</a> <a href="#ref-for-dfn-service-worker-22">(8)</a> <a href="#ref-for-dfn-service-worker-23">(9)</a> <a href="#ref-for-dfn-service-worker-24">(10)</a> <a href="#ref-for-dfn-service-worker-25">(11)</a> <a href="#ref-for-dfn-service-worker-26">(12)</a> <a href="#ref-for-dfn-service-worker-27">(13)</a>
-    <li><a href="#ref-for-dfn-service-worker-28">2.1.1. Lifetime</a> <a href="#ref-for-dfn-service-worker-29">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-30">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-service-worker-31">(2)</a> <a href="#ref-for-dfn-service-worker-32">(3)</a> <a href="#ref-for-dfn-service-worker-33">(4)</a>
-    <li><a href="#ref-for-dfn-service-worker-34">2.5. Task Sources</a> <a href="#ref-for-dfn-service-worker-35">(2)</a> <a href="#ref-for-dfn-service-worker-36">(3)</a>
-    <li><a href="#ref-for-dfn-service-worker-37">2.6. User Agent Shutdown</a>
-    <li><a href="#ref-for-dfn-service-worker-38">3.1. ServiceWorker</a> <a href="#ref-for-dfn-service-worker-39">(2)</a> <a href="#ref-for-dfn-service-worker-40">(3)</a> <a href="#ref-for-dfn-service-worker-41">(4)</a>
-    <li><a href="#ref-for-dfn-service-worker-42">3.1.1. scriptURL</a>
-    <li><a href="#ref-for-dfn-service-worker-43">3.1.3. postMessage(message, transfer)</a>
-    <li><a href="#ref-for-dfn-service-worker-44">3.2.1. installing</a>
-    <li><a href="#ref-for-dfn-service-worker-45">3.2.2. waiting</a>
-    <li><a href="#ref-for-dfn-service-worker-46">3.2.3. active</a>
-    <li><a href="#ref-for-dfn-service-worker-47">3.4. ServiceWorkerContainer</a>
-    <li><a href="#ref-for-dfn-service-worker-48">3.4.1. controller</a>
-    <li><a href="#ref-for-dfn-service-worker-49">3.5. Events</a> <a href="#ref-for-dfn-service-worker-50">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-51">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-dfn-service-worker-52">(2)</a> <a href="#ref-for-dfn-service-worker-53">(3)</a> <a href="#ref-for-dfn-service-worker-54">(4)</a>
-    <li><a href="#ref-for-dfn-service-worker-55">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-service-worker-56">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-15">2.1. Service Worker</a> <a href="#ref-for-dfn-service-worker-16">(2)</a> <a href="#ref-for-dfn-service-worker-17">(3)</a> <a href="#ref-for-dfn-service-worker-18">(4)</a> <a href="#ref-for-dfn-service-worker-19">(5)</a> <a href="#ref-for-dfn-service-worker-20">(6)</a> <a href="#ref-for-dfn-service-worker-21">(7)</a> <a href="#ref-for-dfn-service-worker-22">(8)</a> <a href="#ref-for-dfn-service-worker-23">(9)</a> <a href="#ref-for-dfn-service-worker-24">(10)</a> <a href="#ref-for-dfn-service-worker-25">(11)</a> <a href="#ref-for-dfn-service-worker-26">(12)</a> <a href="#ref-for-dfn-service-worker-27">(13)</a> <a href="#ref-for-dfn-service-worker-28">(14)</a>
+    <li><a href="#ref-for-dfn-service-worker-29">2.1.1. Lifetime</a> <a href="#ref-for-dfn-service-worker-30">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-31">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-service-worker-32">(2)</a> <a href="#ref-for-dfn-service-worker-33">(3)</a> <a href="#ref-for-dfn-service-worker-34">(4)</a>
+    <li><a href="#ref-for-dfn-service-worker-35">2.5. Task Sources</a> <a href="#ref-for-dfn-service-worker-36">(2)</a> <a href="#ref-for-dfn-service-worker-37">(3)</a>
+    <li><a href="#ref-for-dfn-service-worker-38">2.6. User Agent Shutdown</a>
+    <li><a href="#ref-for-dfn-service-worker-39">3.1. ServiceWorker</a> <a href="#ref-for-dfn-service-worker-40">(2)</a> <a href="#ref-for-dfn-service-worker-41">(3)</a> <a href="#ref-for-dfn-service-worker-42">(4)</a>
+    <li><a href="#ref-for-dfn-service-worker-43">3.1.1. scriptURL</a>
+    <li><a href="#ref-for-dfn-service-worker-44">3.1.3. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-dfn-service-worker-45">3.2.1. installing</a>
+    <li><a href="#ref-for-dfn-service-worker-46">3.2.2. waiting</a>
+    <li><a href="#ref-for-dfn-service-worker-47">3.2.3. active</a>
+    <li><a href="#ref-for-dfn-service-worker-48">3.4. ServiceWorkerContainer</a>
+    <li><a href="#ref-for-dfn-service-worker-49">3.4.1. controller</a>
+    <li><a href="#ref-for-dfn-service-worker-50">3.5. Events</a> <a href="#ref-for-dfn-service-worker-51">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-52">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-dfn-service-worker-53">(2)</a> <a href="#ref-for-dfn-service-worker-54">(3)</a> <a href="#ref-for-dfn-service-worker-55">(4)</a>
+    <li><a href="#ref-for-dfn-service-worker-56">4.1.3. skipWaiting()</a>
     <li><a href="#ref-for-dfn-service-worker-57">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-service-worker-58">(2)</a> <a href="#ref-for-dfn-service-worker-59">(3)</a> <a href="#ref-for-dfn-service-worker-60">(4)</a> <a href="#ref-for-dfn-service-worker-61">(5)</a> <a href="#ref-for-dfn-service-worker-62">(6)</a>
     <li><a href="#ref-for-dfn-service-worker-63">4.4.1. event.waitUntil(f)</a>
     <li><a href="#ref-for-dfn-service-worker-64">4.5. FetchEvent</a> <a href="#ref-for-dfn-service-worker-65">(2)</a>
@@ -6864,12 +6949,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-90">Run Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-91">Terminate Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-92">Handle Fetch</a>
-    <li><a href="#ref-for-dfn-service-worker-93">Update Registration State</a>
-    <li><a href="#ref-for-dfn-service-worker-94">Update Worker State</a> <a href="#ref-for-dfn-service-worker-95">(2)</a> <a href="#ref-for-dfn-service-worker-96">(3)</a> <a href="#ref-for-dfn-service-worker-97">(4)</a> <a href="#ref-for-dfn-service-worker-98">(5)</a> <a href="#ref-for-dfn-service-worker-99">(6)</a> <a href="#ref-for-dfn-service-worker-100">(7)</a> <a href="#ref-for-dfn-service-worker-101">(8)</a> <a href="#ref-for-dfn-service-worker-102">(9)</a> <a href="#ref-for-dfn-service-worker-103">(10)</a>
-    <li><a href="#ref-for-dfn-service-worker-104">Get Newest Worker</a>
-    <li><a href="#ref-for-dfn-service-worker-105">Service Worker Script Request</a> <a href="#ref-for-dfn-service-worker-106">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-107">Service Worker Script Response</a>
-    <li><a href="#ref-for-dfn-service-worker-108">Syntax</a>
+    <li><a href="#ref-for-dfn-service-worker-93">Update Service Worker Extended Events Set</a>
+    <li><a href="#ref-for-dfn-service-worker-94">Update Registration State</a>
+    <li><a href="#ref-for-dfn-service-worker-95">Update Worker State</a> <a href="#ref-for-dfn-service-worker-96">(2)</a> <a href="#ref-for-dfn-service-worker-97">(3)</a> <a href="#ref-for-dfn-service-worker-98">(4)</a> <a href="#ref-for-dfn-service-worker-99">(5)</a> <a href="#ref-for-dfn-service-worker-100">(6)</a> <a href="#ref-for-dfn-service-worker-101">(7)</a> <a href="#ref-for-dfn-service-worker-102">(8)</a> <a href="#ref-for-dfn-service-worker-103">(9)</a> <a href="#ref-for-dfn-service-worker-104">(10)</a>
+    <li><a href="#ref-for-dfn-service-worker-105">Get Newest Worker</a>
+    <li><a href="#ref-for-dfn-service-worker-106">Service Worker Has No Pending Events</a>
+    <li><a href="#ref-for-dfn-service-worker-107">Service Worker Script Request</a> <a href="#ref-for-dfn-service-worker-108">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-109">Service Worker Script Response</a>
+    <li><a href="#ref-for-dfn-service-worker-110">Syntax</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-state">
@@ -6910,14 +6997,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-containing-service-worker-registration-2">2.4. Selection and Use</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-3">3.2.7. unregister()</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration-4">4.1.2. registration</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-5">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-containing-service-worker-registration-6">(2)</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-7">4.3.4. claim()</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-8">4.7. Events</a> <a href="#ref-for-dfn-containing-service-worker-registration-9">(2)</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-10">6.3.2. importScripts(urls)</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-11">Install</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-12">Run Service Worker</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-13">Terminate Service Worker</a>
-    <li><a href="#ref-for-dfn-containing-service-worker-registration-14">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration-15">(2)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-5">4.1.3. skipWaiting()</a> <a href="#ref-for-dfn-containing-service-worker-registration-6">(2)</a> <a href="#ref-for-dfn-containing-service-worker-registration-7">(3)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-8">4.3.4. claim()</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-9">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-10">4.5.6. event.respondWith(r)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-11">4.7. Events</a> <a href="#ref-for-dfn-containing-service-worker-registration-12">(2)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-13">6.3.2. importScripts(urls)</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-14">Install</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-15">Run Service Worker</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-16">Terminate Service Worker</a>
+    <li><a href="#ref-for-dfn-containing-service-worker-registration-17">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration-18">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-service-worker-id">
@@ -7001,7 +7090,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-skip-waiting-flag-1">3.5. Events</a>
     <li><a href="#ref-for-dfn-skip-waiting-flag-2">4.1.3. skipWaiting()</a>
-    <li><a href="#ref-for-dfn-skip-waiting-flag-3">Install</a>
+    <li><a href="#ref-for-dfn-skip-waiting-flag-3">Try Activate</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-imported-scripts-updated-flag">
@@ -7017,6 +7106,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle-1">Run Service Worker</a>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle-2">Handle Fetch</a>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle-3">Handle Functional Event</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dfn-set-of-extended-events">
+   <b><a href="#dfn-set-of-extended-events">#dfn-set-of-extended-events</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dfn-set-of-extended-events-1">Update Service Worker Extended Events Set</a> <a href="#ref-for-dfn-set-of-extended-events-2">(2)</a> <a href="#ref-for-dfn-set-of-extended-events-3">(3)</a>
+    <li><a href="#ref-for-dfn-set-of-extended-events-4">Service Worker Has No Pending Events</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-service-worker-registration">
@@ -7041,14 +7137,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-registration-51">Soft Update</a>
     <li><a href="#ref-for-dfn-service-worker-registration-52">Install</a>
     <li><a href="#ref-for-dfn-service-worker-registration-53">Activate</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-54">Handle Functional Event</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-55">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-56">Set Registration</a> <a href="#ref-for-dfn-service-worker-registration-57">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-58">Clear Registration</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-59">Update Registration State</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-60">Match Service Worker Registration</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-61">Get Registration</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-62">Get Newest Worker</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-54">Try Activate</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-55">Handle Functional Event</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-56">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-57">Set Registration</a> <a href="#ref-for-dfn-service-worker-registration-58">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-59">Clear Registration</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-60">Update Registration State</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-61">Match Service Worker Registration</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-62">Get Registration</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-63">Get Newest Worker</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-scope-url">
@@ -7094,8 +7191,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-waiting-worker-2">2.6. User Agent Shutdown</a>
     <li><a href="#ref-for-dfn-waiting-worker-3">4.1.3. skipWaiting()</a>
     <li><a href="#ref-for-dfn-waiting-worker-4">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-waiting-worker-5">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-6">Install</a> <a href="#ref-for-dfn-waiting-worker-7">(2)</a> <a href="#ref-for-dfn-waiting-worker-8">(3)</a> <a href="#ref-for-dfn-waiting-worker-9">(4)</a> <a href="#ref-for-dfn-waiting-worker-10">(5)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-11">Activate</a> <a href="#ref-for-dfn-waiting-worker-12">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-6">Install</a> <a href="#ref-for-dfn-waiting-worker-7">(2)</a> <a href="#ref-for-dfn-waiting-worker-8">(3)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-9">Activate</a> <a href="#ref-for-dfn-waiting-worker-10">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-11">Try Activate</a> <a href="#ref-for-dfn-waiting-worker-12">(2)</a>
     <li><a href="#ref-for-dfn-waiting-worker-13">Handle Service Worker Client Unload</a>
     <li><a href="#ref-for-dfn-waiting-worker-14">Handle User Agent Shutdown</a>
     <li><a href="#ref-for-dfn-waiting-worker-15">Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-16">(2)</a>
@@ -7116,14 +7214,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-active-worker-16">4.3.4. claim()</a>
     <li><a href="#ref-for-dfn-active-worker-17">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dfn-active-worker-18">4.7. Events</a>
-    <li><a href="#ref-for-dfn-active-worker-19">Activate</a> <a href="#ref-for-dfn-active-worker-20">(2)</a> <a href="#ref-for-dfn-active-worker-21">(3)</a> <a href="#ref-for-dfn-active-worker-22">(4)</a> <a href="#ref-for-dfn-active-worker-23">(5)</a> <a href="#ref-for-dfn-active-worker-24">(6)</a> <a href="#ref-for-dfn-active-worker-25">(7)</a>
-    <li><a href="#ref-for-dfn-active-worker-26">Run Service Worker</a>
-    <li><a href="#ref-for-dfn-active-worker-27">Handle Fetch</a> <a href="#ref-for-dfn-active-worker-28">(2)</a> <a href="#ref-for-dfn-active-worker-29">(3)</a>
-    <li><a href="#ref-for-dfn-active-worker-30">Handle Functional Event</a> <a href="#ref-for-dfn-active-worker-31">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-32">Clear Registration</a> <a href="#ref-for-dfn-active-worker-33">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-34">Update Registration State</a> <a href="#ref-for-dfn-active-worker-35">(2)</a> <a href="#ref-for-dfn-active-worker-36">(3)</a>
-    <li><a href="#ref-for-dfn-active-worker-37">Update Worker State</a> <a href="#ref-for-dfn-active-worker-38">(2)</a> <a href="#ref-for-dfn-active-worker-39">(3)</a>
-    <li><a href="#ref-for-dfn-active-worker-40">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker-41">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-19">Install</a> <a href="#ref-for-dfn-active-worker-20">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-21">Activate</a> <a href="#ref-for-dfn-active-worker-22">(2)</a> <a href="#ref-for-dfn-active-worker-23">(3)</a> <a href="#ref-for-dfn-active-worker-24">(4)</a> <a href="#ref-for-dfn-active-worker-25">(5)</a> <a href="#ref-for-dfn-active-worker-26">(6)</a> <a href="#ref-for-dfn-active-worker-27">(7)</a>
+    <li><a href="#ref-for-dfn-active-worker-28">Try Activate</a> <a href="#ref-for-dfn-active-worker-29">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-30">Run Service Worker</a>
+    <li><a href="#ref-for-dfn-active-worker-31">Handle Fetch</a> <a href="#ref-for-dfn-active-worker-32">(2)</a> <a href="#ref-for-dfn-active-worker-33">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-34">Handle Functional Event</a> <a href="#ref-for-dfn-active-worker-35">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-36">Clear Registration</a> <a href="#ref-for-dfn-active-worker-37">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-38">Update Registration State</a> <a href="#ref-for-dfn-active-worker-39">(2)</a> <a href="#ref-for-dfn-active-worker-40">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-41">Update Worker State</a> <a href="#ref-for-dfn-active-worker-42">(2)</a> <a href="#ref-for-dfn-active-worker-43">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-44">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker-45">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-last-update-check-time">
@@ -7186,8 +7286,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-client-35">6.3.1. Origin restriction</a>
     <li><a href="#ref-for-dfn-service-worker-client-36">Appendix A: Algorithms</a>
     <li><a href="#ref-for-dfn-service-worker-client-37">Create Job</a>
-    <li><a href="#ref-for-dfn-service-worker-client-38">Install</a> <a href="#ref-for-dfn-service-worker-client-39">(2)</a>
-    <li><a href="#ref-for-dfn-service-worker-client-40">Activate</a> <a href="#ref-for-dfn-service-worker-client-41">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-client-38">Install</a>
+    <li><a href="#ref-for-dfn-service-worker-client-39">Activate</a> <a href="#ref-for-dfn-service-worker-client-40">(2)</a>
+    <li><a href="#ref-for-dfn-service-worker-client-41">Try Activate</a>
     <li><a href="#ref-for-dfn-service-worker-client-42">Run Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-client-43">Handle Fetch</a>
     <li><a href="#ref-for-dfn-service-worker-client-44">Handle Service Worker Client Unload</a> <a href="#ref-for-dfn-service-worker-client-45">(2)</a> <a href="#ref-for-dfn-service-worker-client-46">(3)</a>
@@ -7260,8 +7361,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-use-1">2.4. Selection and Use</a>
     <li><a href="#ref-for-dfn-use-2">3.5. Events</a>
     <li><a href="#ref-for-dfn-use-3">4.1.3. skipWaiting()</a>
-    <li><a href="#ref-for-dfn-use-4">Install</a>
-    <li><a href="#ref-for-dfn-use-5">Activate</a>
+    <li><a href="#ref-for-dfn-use-4">Activate</a>
+    <li><a href="#ref-for-dfn-use-5">Try Activate</a>
     <li><a href="#ref-for-dfn-use-6">Handle Fetch</a>
     <li><a href="#ref-for-dfn-use-7">Handle Service Worker Client Unload</a> <a href="#ref-for-dfn-use-8">(2)</a>
     <li><a href="#ref-for-dfn-use-9">Unregister</a>
@@ -7627,15 +7728,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-1">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-2">3.2.6. update()</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker-3">4.1.2. registration</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-4">4.2.5. postMessage(message, transfer)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-5">4.2.10. navigate(url)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-6">(2)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-7">4.3.1. get(id)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-8">4.3.2. matchAll(options)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-9">(2)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-10">4.3.3. openWindow(url)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-11">4.3.4. claim()</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-12">(2)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-13">(3)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-14">(4)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-15">(5)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-16">4.7. Events</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-17">(2)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-18">(3)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-19">6.3.2. importScripts(urls)</a>
-    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-20">Run Service Worker</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-4">4.1.3. skipWaiting()</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-5">(2)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-6">4.2.5. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-7">4.2.10. navigate(url)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-8">(2)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-9">4.3.1. get(id)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-10">4.3.2. matchAll(options)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-11">(2)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-12">4.3.3. openWindow(url)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-13">4.3.4. claim()</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-14">(2)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-15">(3)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-16">(4)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-17">(5)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-18">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-19">4.5.6. event.respondWith(r)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-20">4.7. Events</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-21">(2)</a> <a href="#ref-for-serviceworkerglobalscope-service-worker-22">(3)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-23">6.3.2. importScripts(urls)</a>
+    <li><a href="#ref-for-serviceworkerglobalscope-service-worker-24">Run Service Worker</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">
@@ -7664,6 +7768,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting-1">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting-2">4.1.3. skipWaiting()</a> <a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting-3">(2)</a>
+    <li><a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting-4">Install</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-oninstall">
@@ -7954,7 +8059,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-1">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-2">(2)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-3">(3)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-4">(4)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-5">(5)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-6">(6)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-7">(7)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-8">4.4.1. event.waitUntil(f)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-9">4.5.6. event.respondWith(r)</a>
-    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-10">Install</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-10">Install</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-11">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="extendableevent-pending-promises-count">
@@ -7964,6 +8069,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-extendableevent-pending-promises-count-6">4.5.6. event.respondWith(r)</a> <a href="#ref-for-extendableevent-pending-promises-count-7">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count-8">(3)</a>
     <li><a href="#ref-for-extendableevent-pending-promises-count-9">Install</a>
     <li><a href="#ref-for-extendableevent-pending-promises-count-10">Activate</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-11">Update Service Worker Extended Events Set</a> <a href="#ref-for-extendableevent-pending-promises-count-12">(2)</a>
+    <li><a href="#ref-for-extendableevent-pending-promises-count-13">Service Worker Has No Pending Events</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-extendableevent-waituntil">
@@ -8622,9 +8729,19 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-activate-2">3.5. Events</a> <a href="#ref-for-activate-3">(2)</a>
     <li><a href="#ref-for-activate-4">4.4. ExtendableEvent</a> <a href="#ref-for-activate-5">(2)</a>
     <li><a href="#ref-for-activate-6">4.7. Events</a>
-    <li><a href="#ref-for-activate-7">Install</a>
-    <li><a href="#ref-for-activate-8">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-activate-9">Handle User Agent Shutdown</a>
+    <li><a href="#ref-for-activate-7">Install</a> <a href="#ref-for-activate-8">(2)</a>
+    <li><a href="#ref-for-activate-9">Try Activate</a>
+    <li><a href="#ref-for-activate-10">Handle User Agent Shutdown</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="try-activate">
+   <b><a href="#try-activate">#try-activate</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-try-activate-1">4.1.3. skipWaiting()</a>
+    <li><a href="#ref-for-try-activate-2">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-try-activate-3">4.5.6. event.respondWith(r)</a>
+    <li><a href="#ref-for-try-activate-4">Install</a> <a href="#ref-for-try-activate-5">(2)</a>
+    <li><a href="#ref-for-try-activate-6">Handle Service Worker Client Unload</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="run-service-worker">
@@ -8646,10 +8763,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-terminate-service-worker-2">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-terminate-service-worker-3">4.4.1. event.waitUntil(f)</a>
     <li><a href="#ref-for-terminate-service-worker-4">Install</a> <a href="#ref-for-terminate-service-worker-5">(2)</a>
-    <li><a href="#ref-for-terminate-service-worker-6">Activate</a> <a href="#ref-for-terminate-service-worker-7">(2)</a>
-    <li><a href="#ref-for-terminate-service-worker-8">Handle Fetch</a>
-    <li><a href="#ref-for-terminate-service-worker-9">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-terminate-service-worker-10">Clear Registration</a> <a href="#ref-for-terminate-service-worker-11">(2)</a> <a href="#ref-for-terminate-service-worker-12">(3)</a>
+    <li><a href="#ref-for-terminate-service-worker-6">Activate</a>
+    <li><a href="#ref-for-terminate-service-worker-7">Handle Fetch</a>
+    <li><a href="#ref-for-terminate-service-worker-8">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-terminate-service-worker-9">Clear Registration</a> <a href="#ref-for-terminate-service-worker-10">(2)</a> <a href="#ref-for-terminate-service-worker-11">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-fetch">
@@ -8672,12 +8789,21 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#handle-service-worker-client-unload">#handle-service-worker-client-unload</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-service-worker-client-unload-1">4.3.4. claim()</a>
+    <li><a href="#ref-for-handle-service-worker-client-unload-2">Install</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-user-agent-shutdown">
    <b><a href="#handle-user-agent-shutdown">#handle-user-agent-shutdown</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-user-agent-shutdown-1">2.6. User Agent Shutdown</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="update-service-worker-extended-events-set">
+   <b><a href="#update-service-worker-extended-events-set">#update-service-worker-extended-events-set</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-update-service-worker-extended-events-set-1">3.1.3. postMessage(message, transfer)</a>
+    <li><a href="#ref-for-update-service-worker-extended-events-set-2">Handle Fetch</a>
+    <li><a href="#ref-for-update-service-worker-extended-events-set-3">Handle Functional Event</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="unregister">
@@ -8757,6 +8883,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-get-newest-worker-4">Soft Update</a>
     <li><a href="#ref-for-get-newest-worker-5">Install</a>
     <li><a href="#ref-for-get-newest-worker-6">Handle User Agent Shutdown</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="service-worker-has-no-pending-events">
+   <b><a href="#service-worker-has-no-pending-events">#service-worker-has-no-pending-events</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-service-worker-has-no-pending-events-1">Try Activate</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="create-client">


### PR DESCRIPTION
This adds concepts and algorithms to track events (all service worker
events: lifecycle events, functional events, extendable message events)
that have pending extension promises so they can be used to check if the
registration's waiting worker can be promoted.

This also changes Install algorithm and related steps to match to the
implementations behavior. That is, instead of waiting for the promotion
condition in Install algorithm, newly introduced Try Activate algorithm
just tries to activate depending on the condition and return. Try
Activate is called when:
 - A service worker is installed.
 - The last client controlled by the existing active worker is unloaded.
 - skipWaiting() is called.
 - The extend lifetime promises for the existing active worker settle.

Related issue: #916.