### PR TITLE
Add check for CORS-safelisted methods and headers to foreign fetch.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2976,6 +2976,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. For each |origin| in |activeWorker|'s <a>list of foreign fetch origins</a>:
           1. If |origin| is equal to |request|'s [=request/origin=], set |originMatches| to true.
       1. If |originMatches| is false, return null.
+      1. If |request|'s [=request/method=] is not a [=CORS-safelisted method=], or if there is at least one [=header=] in |request|'s [=request/header list=] for whose [=header/name=] is not a [=CORS-safelisted request-header=], return null.
+
+          Note: In the future this might be relaxed by adding supported methods and headers to the {{ForeignFetchOptions}}.
+
       1. Let |r| be a new {{Request}} object associated with |request|.
       1. Invoke [=Run Service Worker=] algorithm with |activeWorker| as the argument.
       1. <a>Queue a task</a> |task| to run the following substeps:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 862f905dcd28738c926b57b7cfebee04d3d6e31e" name="generator">
+  <meta content="Bikeshed version 017e947f5c8044969eb6c697519bf98b715cf564" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -5595,6 +5595,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>If <var>originMatches</var> is false, return null.</p>
        <li data-md="">
+        <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method">method</a> is not a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-safelisted-method">CORS-safelisted method</a>, or if there is at least one <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a> in <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-header-list">header list</a> for whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-name">name</a> is not a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-safelisted-request-header">CORS-safelisted request-header</a>, return null.</p>
+        <p class="note" role="note"><span>Note:</span> In the future this might be relaxed by adding supported methods and headers to the <code class="idl"><a data-link-type="idl" href="#dictdef-foreignfetchoptions" id="ref-for-dictdef-foreignfetchoptions-2">ForeignFetchOptions</a></code>.</p>
+       <li data-md="">
         <p>Let <var>r</var> be a new <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> object associated with <var>request</var>.</p>
        <li data-md="">
         <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-7">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
@@ -7123,6 +7126,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://fetch.spec.whatwg.org/#concept-construct-readablestream">construct a readablestream object</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-cors">cors filtered response</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-response-cors-exposed-header-name-list">cors-exposed header-name list</a>
+     <li><a href="https://fetch.spec.whatwg.org/#cors-safelisted-method">cors-safelisted method</a>
+     <li><a href="https://fetch.spec.whatwg.org/#cors-safelisted-request-header">cors-safelisted request-header</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-body-disturbed">disturbed</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-empty-readablestream">empty</a>
@@ -8997,6 +9002,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dictdef-foreignfetchoptions">#dictdef-foreignfetchoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-foreignfetchoptions-1">4.5. InstallEvent</a>
+    <li><a href="#ref-for-dictdef-foreignfetchoptions-2">Handle Foreign Fetch</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-foreignfetchoptions-scopes">


### PR DESCRIPTION
We probably ultimately want to add the extra options to
ForeignFetchOptions as discussed in #880, but for now just limiting
headers and methods to CORS safelisted values seems reasonable, and
matches chrome's implementation.