### PR TITLE
Introduce Try Clear Registration; Delay activation

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1323,7 +1323,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
         1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |f|, [=queue a microtask=] to run these substeps:
             1. Decrement the [=ExtendableEvent/pending promises count=] by one.
-            1. Invoke [=Try Activate=] with the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
+            1. Let |registration| be the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
+            1. If |registration|'s [=uninstalling flag=] is set, invoke [=Try Clear Registration=] with |registration|.
+            1. If |registration| is not null, invoke [=Try Activate=] with |registration|.
 
         The user agent *should not* <a lt="terminate service worker">terminate</a> the [=/service worker=] associated with |event|'s <a>relevant settings object</a>'s [=environment settings object/global object=] when |event|'s [=dispatch flag=] is set or |event|'s [=ExtendableEvent/pending promises count=] is not zero. However, the user agent *may* impose a time limit to this lifetime extension.
     </section>
@@ -1464,7 +1466,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
         1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |r|, [=queue a microtask=] to run these substeps:
             1. Decrement the [=ExtendableEvent/pending promises count=] by one.
-            1. Invoke [=Try Activate=] with the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
+            1. Let |registration| be the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
+            1. If |registration|'s [=uninstalling flag=] is set, invoke [=Try Clear Registration=] with |registration|.
+            1. If |registration| is not null, invoke [=Try Activate=] with |registration|.
 
             Note: {{FetchEvent/respondWith(r)|event.respondWith(r)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(r)}} is called.
 
@@ -1582,7 +1586,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
         1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |r|, [=queue a microtask=] to run these substeps:
             1. Decrement the [=ExtendableEvent/pending promises count=] by one.
-            1. Invoke [=Try Activate=] with the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
+            1. Let |registration| be the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
+            1. If |registration|'s [=uninstalling flag=] is set, invoke [=Try Clear Registration=] with |registration|.
+            1. If |registration| is not null, invoke [=Try Activate=] with |registration|.
 
             Note: {{ForeignFetchEvent/respondWith(r)|event.respondWith(r)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(r)}} is called.
 
@@ -2612,7 +2618,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. <a>Extract a MIME type</a> from the |response|'s [=response/header list=]. If this MIME type (ignoring parameters) is not one of <code>text/javascript</code>, <code>application/x-javascript</code>, and <code>application/javascript</code>, then:
               1. Invoke <a>Reject Job Promise</a> with |job| and a "{{SecurityError}}" exception.
               1. Asynchronously complete these steps with a <a>network error</a>.
-          1. Let |serviceWorkerAllowed| be the result of [=header/parse a header value|parsing=] \`<code>Service-Worker-Allowed</code>\` in |response|'s [=response/header list=].
+          1. Let |serviceWorkerAllowed| be the result of [=extracting header list values=] given \`<code>Service-Worker-Allowed</code>\` and |response|'s [=response/header list=].
 
               Note: See the definition of the Service-Worker-Allowed header in Appendix B: Extended HTTP headers.
 
@@ -2735,7 +2741,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Wait for all the <a>tasks</a> <a lt="queue a task">queued</a> by <a>Update Worker State</a> invoked in this algorithm have executed.
       1. Invoke [=Try Activate=] with |registration|.
 
-          Note: If [=Try Activate=] does not trigger [=Activate=] here, [=Activate=] is tried again when the last client controlled by the existing [=active worker=] is [=Handle Service Worker Client Unload|unloaded=], {{ServiceWorkerGlobalScope/skipWaiting()}} is asynchronously called, and the [=extend lifetime promises=] for the existing [=active worker=] settle.
+          Note: If [=Try Activate=] does not trigger [=Activate=] here, [=Activate=] is tried again when the last client controlled by the existing [=active worker=] is [=Handle Service Worker Client Unload|unloaded=], {{ServiceWorkerGlobalScope/skipWaiting()}} is asynchronously called, or the [=extend lifetime promises=] for the existing [=active worker=] settle.
   </section>
 
   <section algorithm>
@@ -2786,6 +2792,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: None
 
       1. If |registration|'s [=waiting worker=] is null, return.
+      1. If |registration|'s [=active worker=] is not null and |registration|'s [=active worker=]'s [=state=] is *activating*, return.
+
+          Note: If the existing active worker is still in activating state, the activation of the waiting worker is delayed.
+
       1. Invoke [=Activate=] with |registration| if either of the following is true:
         * |registration|'s [=active worker=] is null.
         * The result of running [=Service Worker Has No Pending Events=] with |registration|’s [=active worker=] is true, and no [=/service worker client=] is [=using=] |registration| or |registration|’s [=waiting worker=]'s [=skip waiting flag=] is set.
@@ -3103,8 +3113,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Let |registration| be the [=/service worker registration=] <a>used</a> by |client|.
       1. If |registration| is null, abort these steps.
       1. If any other [=/service worker client=] is <a>using</a> |registration|, abort these steps.
-      1. If |registration|'s <a>uninstalling flag</a> is set, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument and abort these steps.
-      1. If |registration|'s <a>waiting worker</a> is not null, invoke [=Try Activate=] with |registration|.
+      1. If |registration|'s [=uninstalling flag=] is set, invoke [=Try Clear Registration=] with |registration|.
+      1. If |registration| is not null, invoke [=Try Activate=] with |registration|.
   </section>
 
   <section algorithm>
@@ -3155,9 +3165,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Set |registration|'s <a>uninstalling flag</a>.
       1. Invoke <a>Resolve Job Promise</a> with |job| and true.
-      1. If no [=/service worker client=] is <a>using</a> |registration|, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
+      1. Invoke [=Try Clear Registration=] with |registration|.
 
-          Note: When the registration is being used for a client, the deletion of the registration is handled by the Handle Service Worker Client Unload algorithm.
+          Note: If [=Try Clear Registration=] does not trigger [=Clear Registration=] here, [=Clear Registration=] is tried again when the last client [=using=] the registration is [=Handle Service Worker Client Unload|unloaded=] or the [=extend lifetime promises=] for the registration's service workers settle.
 
       1. Invoke <a>Finish Job</a> with |job|.
   </section>
@@ -3187,24 +3197,34 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: None
 
       1. Run the following steps atomically.
-      1. Let |redundantWorker| be null.
       1. If |registration|'s <a>installing worker</a> is not null, then:
-          1. Set |redundantWorker| to |registration|'s <a>installing worker</a>.
-          1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
+          1. [=Terminate Service Worker|Terminate=] |registration|'s [=installing worker=].
+          1. Run the <a>Update Worker State</a> algorithm passing |registration|'s [=installing worker=] and *redundant* as the arguments.
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and null as the arguments.
-          1. Run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. If |registration|'s <a>waiting worker</a> is not null, then:
-          1. Set |redundantWorker| to |registration|'s <a>waiting worker</a>.
-          1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
+          1. [=Terminate Service Worker|Terminate=] |registration|'s [=waiting worker=].
+          1. Run the <a>Update Worker State</a> algorithm passing |registration|'s [=waiting worker=] and *redundant* as the arguments.
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>waiting</code>" and null as the arguments.
-          1. Run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. If |registration|'s <a>active worker</a> is not null, then:
-          1. Set |redundantWorker| to |registration|'s <a>active worker</a>.
-          1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
+          1. [=Terminate Service Worker|Terminate=] |registration|'s [=active worker=].
+          1. Run the <a>Update Worker State</a> algorithm passing |registration|'s [=active worker=] and *redundant* as the arguments.
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>active</code>" and null as the arguments.
-          1. Run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. Let |scopeString| be <a lt="URL serializer">serialized</a> |registration|'s [=service worker registration/scope url=] with the *exclude fragment flag* set.
       1. [=map/Remove=] <a>scope to registration map</a>[|scopeString|].
+  </section>
+
+  <section algorithm>
+    <h3 id="try-clear-registration-algorithm"><dfn>Try Clear Registration</dfn></h3>
+
+      : Input
+      :: |registration|, a [=/service worker registration=]
+      : Output
+      :: None
+
+      1. Invoke [=Clear Registration=] with |registration| if no [=/service worker client=] is [=using=] |registration| and all of the following conditions are true:
+          * |registration|'s [=installing worker=] is null or the result of running [=Service Worker Has No Pending Events=] with |registration|’s [=installing worker=] is true.
+          * |registration|'s [=waiting worker=] is null or the result of running [=Service Worker Has No Pending Events=] with |registration|’s [=waiting worker=] is true.
+          * |registration|'s [=active worker=] is null or the result of running [=Service Worker Has No Pending Events=] with |registration|’s [=active worker=] is true.
   </section>
 
   <section algorithm>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 70f542b3eb403344eee83c57e6631f734b1c4427" name="generator">
+  <meta content="Bikeshed version 0060add2b6463a7a7a099173ff2c8a54d3e0ce53" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-16">16 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-25">25 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1699,6 +1699,7 @@ pre.idl.highlight { color: #708090; }
       <li><a href="#unregister-algorithm"><span class="secno"></span> <span class="content"><span>Unregister</span></span></a>
       <li><a href="#set-registration-algorithm"><span class="secno"></span> <span class="content"><span>Set Registration</span></span></a>
       <li><a href="#clear-registration-algorithm"><span class="secno"></span> <span class="content"><span>Clear Registration</span></span></a>
+      <li><a href="#try-clear-registration-algorithm"><span class="secno"></span> <span class="content"><span>Try Clear Registration</span></span></a>
       <li><a href="#update-registration-state-algorithm"><span class="secno"></span> <span class="content"><span>Update Registration State</span></span></a>
       <li><a href="#update-state-algorithm"><span class="secno"></span> <span class="content"><span>Update Worker State</span></span></a>
       <li><a href="#notify-controller-change-algorithm"><span class="secno"></span> <span class="content"><span>Notify Controller Change</span></span></a>
@@ -1827,12 +1828,10 @@ pre.idl.highlight { color: #708090; }
      <h3 class="heading settled" data-level="2.5" id="task-sources"><span class="secno">2.5. </span><span class="content">Task Sources</span><a class="self-link" href="#task-sources"></a></h3>
      <p>The following additional <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a> are used by <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-37">service workers</a>.</p>
      <dl>
-      <dt data-md="">
-       <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-handle-fetch-task-source">handle fetch task source</dfn></p>
+      <dt data-md="">The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-handle-fetch-task-source">handle fetch task source</dfn>
       <dd data-md="">
        <p>This <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is used for <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-2">fetch</a></code> events to <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-38">service workers</a>.</p>
-      <dt data-md="">
-       <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-handle-functional-event-task-source">handle functional event task source</dfn></p>
+      <dt data-md="">The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-handle-functional-event-task-source">handle functional event task source</dfn>
       <dd data-md="">
        <p>This <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is used for features that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> other <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-1">functional events</a>, e.g. <code class="idl"><a class="idl-code" data-link-type="event" href="https://w3c.github.io/push-api/#h-the-push-event">push</a></code> events, to <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-39">service workers</a>.</p>
        <p class="note" role="note"><span>Note:</span> A user agent may use a separate task source for each functional event type in order to avoid a head-of-line blocking phenomenon for certain functional events.</p>
@@ -3072,7 +3071,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Decrement the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> by one.</p>
          <li data-md="">
-          <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-2">Try Activate</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>'s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-18">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>.</p>
+          <p>Let <var>registration</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>'s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-18">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>.</p>
+         <li data-md="">
+          <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-2">uninstalling flag</a> is set, invoke <a data-link-type="dfn" href="#try-clear-registration" id="ref-for-try-clear-registration-1">Try Clear Registration</a> with <var>registration</var>.</p>
+         <li data-md="">
+          <p>If <var>registration</var> is not null, invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-2">Try Activate</a> with <var>registration</var>.</p>
         </ol>
       </ol>
       <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-3">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-65">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> when <var>event</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is set or <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-5">pending promises count</a> is not zero. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
@@ -3237,7 +3240,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Decrement the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> by one.</p>
          <li data-md="">
-          <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-3">Try Activate</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>'s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-20">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-11">containing service worker registration</a>.</p>
+          <p>Let <var>registration</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>'s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-20">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-11">containing service worker registration</a>.</p>
+         <li data-md="">
+          <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-3">uninstalling flag</a> is set, invoke <a data-link-type="dfn" href="#try-clear-registration" id="ref-for-try-clear-registration-2">Try Clear Registration</a> with <var>registration</var>.</p>
+         <li data-md="">
+          <p>If <var>registration</var> is not null, invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-3">Try Activate</a> with <var>registration</var>.</p>
         </ol>
         <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-3">event.respondWith(r)</a></code> extends the lifetime of the event by default as if <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">event.waitUntil(r)</a></code> is called.</p>
        <li data-md="">
@@ -3419,7 +3426,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <li data-md="">
            <p>Decrement the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-11">pending promises count</a> by one.</p>
           <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-4">Try Activate</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>'s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-21">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-12">containing service worker registration</a>.</p>
+           <p>Let <var>registration</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>'s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-21">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-12">containing service worker registration</a>.</p>
+          <li data-md="">
+           <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-4">uninstalling flag</a> is set, invoke <a data-link-type="dfn" href="#try-clear-registration" id="ref-for-try-clear-registration-3">Try Clear Registration</a> with <var>registration</var>.</p>
+          <li data-md="">
+           <p>If <var>registration</var> is not null, invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-4">Try Activate</a> with <var>registration</var>.</p>
          </ol>
          <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="#dom-foreignfetchevent-respondwith" id="ref-for-dom-foreignfetchevent-respondwith-3">event.respondWith(r)</a></code> extends the lifetime of the event by default as if <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-6">event.waitUntil(r)</a></code> is called.</p>
         <li data-md="">
@@ -4566,8 +4577,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Create Job">
      <h3 class="heading settled" id="create-job-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="create-job">Create Job</dfn></span><a class="self-link" href="#create-job-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>jobType</var>, a <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-2">job type</a></p>
       <dd data-md="">
@@ -4578,8 +4588,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><var>promise</var>, a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a></p>
       <dd data-md="">
        <p><var>client</var>, a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-37">service worker client</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-18">job</a></p>
      </dl>
@@ -4605,12 +4614,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Schedule Job">
      <h3 class="heading settled" id="schedule-job-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="schedule-job">Schedule Job</dfn></span><a class="self-link" href="#schedule-job-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-20">job</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4636,12 +4643,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Run Job">
      <h3 class="heading settled" id="run-job-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="run-job">Run Job</dfn></span><a class="self-link" href="#run-job-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p>none</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4666,12 +4671,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Finish Job">
      <h3 class="heading settled" id="finish-job-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="finish-job">Finish Job</dfn></span><a class="self-link" href="#finish-job-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-21">job</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4687,14 +4690,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Resolve Job Promise">
      <h3 class="heading settled" id="resolve-job-promise-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="resolve-job-promise">Resolve Job Promise</dfn></span><a class="self-link" href="#resolve-job-promise-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-22">job</a></p>
       <dd data-md="">
        <p><var>value</var>, any</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4712,14 +4713,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Reject Job Promise">
      <h3 class="heading settled" id="reject-job-promise-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reject-job-promise">Reject Job Promise</dfn></span><a class="self-link" href="#reject-job-promise-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-23">job</a></p>
       <dd data-md="">
        <p><var>reason</var>, an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4737,8 +4736,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Start Register">
      <h3 class="heading settled" id="start-register-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="start-register">Start Register</dfn></span><a class="self-link" href="#start-register-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>scopeURL</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a> or failure or null</p>
       <dd data-md="">
@@ -4753,8 +4751,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><var>workerType</var>, a <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-2">worker type</a></p>
       <dd data-md="">
        <p><var>useCache</var>, a boolean</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4789,12 +4786,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Register">
      <h3 class="heading settled" id="register-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="register">Register</dfn></span><a class="self-link" href="#register-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-24">job</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4829,7 +4824,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>registration</var> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-2">uninstalling flag</a> is set, unset it.</p>
+         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-5">uninstalling flag</a> is set, unset it.</p>
         <li data-md="">
          <p>Let <var>newestWorker</var> be the result of running the <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-2">Get Newest Worker</a> algorithm passing <var>registration</var> as the argument.</p>
         <li data-md="">
@@ -4854,12 +4849,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Update">
      <h3 class="heading settled" id="update-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="update">Update</dfn></span><a class="self-link" href="#update-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-25">job</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4867,7 +4860,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>registration</var> be the result of running the <a data-link-type="dfn" href="#get-registration" id="ref-for-get-registration-2">Get Registration</a> algorithm passing <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-8">scope url</a> as the argument.</p>
       <li data-md="">
-       <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-3">uninstalling flag</a> is set, then:</p>
+       <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-6">uninstalling flag</a> is set, then:</p>
        <ol>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-4">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</p>
@@ -4891,12 +4884,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Switching on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-4">worker type</a>, run these substeps with the following options:</p>
        <dl>
-        <dt data-md="">
-         <p>"<code>classic</code>"</p>
+        <dt data-md="">"<code>classic</code>"
         <dd data-md="">
          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a>, "<code>serviceworker</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
-        <dt data-md="">
-         <p>"<code>module</code>"</p>
+        <dt data-md="">"<code>module</code>"
         <dd data-md="">
          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">Fetch a module worker script graph</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
        </dl>
@@ -4936,7 +4927,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <p>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
          </ol>
         <li data-md="">
-         <p>Let <var>serviceWorkerAllowed</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-parse">parsing</a> `<code>Service-Worker-Allowed</code>` in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>.</p>
+         <p>Let <var>serviceWorkerAllowed</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#extract-header-list-values">extracting header list values</a> given `<code>Service-Worker-Allowed</code>` and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>.</p>
          <p class="note" role="note"><span>Note:</span> See the definition of the Service-Worker-Allowed header in Appendix B: Extended HTTP headers.</p>
         <li data-md="">
          <p>Set <var>httpsState</var> to <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-https-state">HTTPS state</a>.</p>
@@ -5037,15 +5028,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <h3 class="heading settled" id="soft-update-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="soft-update">Soft Update</dfn></span><a class="self-link" href="#soft-update-algorithm"></a></h3>
      <p>The user agent <em>may</em> call this as often as it likes to check for updates.</p>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-59">service worker registration</a></p>
       <dd data-md="">
        <p><em>force bypass cache flag</em>, an optional flag unset by default</p>
        <p class="note" role="note"><span>Note:</span> Implementers may use the <em>force bypass cache flag</em> to aid debugging (e.g. invocations from developer tools), and other specifications that extend service workers may also use the flag on their own needs.</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5067,16 +5056,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Install">
      <h3 class="heading settled" id="installation-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="install">Install</dfn></span><a class="self-link" href="#installation-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-26">job</a></p>
       <dd data-md="">
        <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-94">service worker</a></p>
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-60">service worker registration</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -5156,18 +5143,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Wait for all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-5">Update Worker State</a> invoked in this algorithm have executed.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-5">Try Activate</a> with <var>registration</var>.</p>
-       <p class="note" role="note"><span>Note:</span> If <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-6">Try Activate</a> does not trigger <a data-link-type="dfn" href="#activate" id="ref-for-activate-7">Activate</a> here, <a data-link-type="dfn" href="#activate" id="ref-for-activate-8">Activate</a> is tried again when the last client controlled by the existing <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-22">active worker</a> is <a data-link-type="dfn" href="#handle-service-worker-client-unload" id="ref-for-handle-service-worker-client-unload-2">unloaded</a>, <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-skipwaiting" id="ref-for-dom-serviceworkerglobalscope-skipwaiting-4">skipWaiting()</a></code> is asynchronously called, and the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-12">extend lifetime promises</a> for the existing <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-23">active worker</a> settle.</p>
+       <p class="note" role="note"><span>Note:</span> If <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-6">Try Activate</a> does not trigger <a data-link-type="dfn" href="#activate" id="ref-for-activate-7">Activate</a> here, <a data-link-type="dfn" href="#activate" id="ref-for-activate-8">Activate</a> is tried again when the last client controlled by the existing <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-22">active worker</a> is <a data-link-type="dfn" href="#handle-service-worker-client-unload" id="ref-for-handle-service-worker-client-unload-2">unloaded</a>, <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-skipwaiting" id="ref-for-dom-serviceworkerglobalscope-skipwaiting-4">skipWaiting()</a></code> is asynchronously called, or the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-12">extend lifetime promises</a> for the existing <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-23">active worker</a> settle.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Activate">
      <h3 class="heading settled" id="activation-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activate">Activate</dfn></span><a class="self-link" href="#activation-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-61">service worker registration</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5233,12 +5218,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Try Activate">
      <h3 class="heading settled" id="try-activate-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="try-activate">Try Activate</dfn></span><a class="self-link" href="#try-activate-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-62">service worker registration</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5246,26 +5229,27 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a> is null, return.</p>
       <li data-md="">
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-32">active worker</a> is not null and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-33">active worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-6">state</a> is <em>activating</em>, return.</p>
+       <p class="note" role="note"><span>Note:</span> If the existing active worker is still in activating state, the activation of the waiting worker is delayed.</p>
+      <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-9">Activate</a> with <var>registration</var> if either of the following is true:</p>
        <ul>
         <li data-md="">
-         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-32">active worker</a> is null.</p>
+         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-34">active worker</a> is null.</p>
         <li data-md="">
-         <p>The result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-1">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-33">active worker</a> is true, and no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-42">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-5">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set.</p>
+         <p>The result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-1">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-35">active worker</a> is true, and no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-42">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-5">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set.</p>
        </ul>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Run Service Worker">
      <h3 class="heading settled" id="run-service-worker-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="run-service-worker">Run Service Worker</dfn></span><a class="self-link" href="#run-service-worker-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>serviceWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-96">service worker</a></p>
       <dd data-md="">
        <p><em>force bypass cache for importscripts flag</em>, an optional flag unset by default</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5293,40 +5277,31 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>settingsObject</var> be a new <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> whose algorithms are defined as follows:</p>
        <dl>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">realm execution context</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">realm execution context</a>
         <dd data-md="">
          <p>Return <var>realmExecutionContext</var>.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>
         <dd data-md="">
          <p>Return <var>workerGlobalScope</var>.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a>
         <dd data-md="">
          <p>Return <var>workerEventLoop</var>.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-referrer-policy">referrer policy</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-referrer-policy">referrer policy</a>
         <dd data-md="">
          <p>Return <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-referrer-policy">referrer policy</a>.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding">API URL character encoding</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding">API URL character encoding</a>
         <dd data-md="">
          <p>Return UTF-8.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">API base URL</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">API base URL</a>
         <dd data-md="">
          <p>Return <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-8">script url</a>.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>
         <dd data-md="">
          <p>Return its registering <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-43">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a>
         <dd data-md="">
          <p>Return <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">url</a>.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state">HTTPS state</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state">HTTPS state</a>
         <dd data-md="">
          <p>Return <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state">HTTPS state</a>.</p>
        </dl>
@@ -5343,7 +5318,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Create a new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">WorkerLocation</a></code> object and associate it with <var>workerGlobalScope</var>.</p>
       <li data-md="">
-       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-34">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-17">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
+       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-36">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-17">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
       <li data-md="">
        <p>If <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>, then <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">run the classic script</a> <var>script</var>. Otherwise, it is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">module script</a>; <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">run the module script</a> <var>script</var>.</p>
        <p class="note" role="note"><span>Note:</span> In addition to the usual possibilities of returning a value or failing due to an exception, this could be prematurely aborted by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">kill a worker</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">terminate a worker</a> algorithms.</p>
@@ -5371,12 +5346,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Terminate Service Worker">
      <h3 class="heading settled" id="terminate-service-worker-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="terminate-service-worker">Terminate Service Worker</dfn></span><a class="self-link" href="#terminate-service-worker-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>serviceWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-97">service worker</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5400,12 +5373,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <h3 class="heading settled" id="on-fetch-request-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="handle-fetch">Handle Fetch</dfn></span><a class="self-link" href="#on-fetch-request-algorithm"></a></h3>
      <p>The <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-7">Handle Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a> context.</p>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>request</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>response</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a></p>
      </dl>
@@ -5461,12 +5432,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>registration</var> to the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-10">Match Service Worker Registration</a> algorithm passing <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url">url</a> as the argument.</p>
         <li data-md="">
-         <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-35">active worker</a> is null, return null.</p>
+         <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a> is null, return null.</p>
         <li data-md="">
-         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-36">active worker</a>.</p>
+         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request">navigation request</a>, <var>registration</var>’s <a data-link-type="dfn" href="#service-worker-registration-navigation-preload-enabled-flag" id="ref-for-service-worker-registration-navigation-preload-enabled-flag-4">navigation preload enabled flag</a> is set, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method">method</a> is `<code>GET</code>`, and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-2">set of event types to handle</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contains</a> <code>fetch</code>, then:</p>
-         <p class="note" role="note"><span>Note:</span> If the above is true except <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-3">set of event types to handle</a> <strong>does not</strong> contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer’s intent isn’t clear.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request">navigation request</a>, <var>registration</var>’s <a data-link-type="dfn" href="#service-worker-registration-navigation-preload-enabled-flag" id="ref-for-service-worker-registration-navigation-preload-enabled-flag-4">navigation preload enabled flag</a> is set, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method">method</a> is `<code>GET</code>`, and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-2">set of event types to handle</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contains</a> <code>fetch</code>, then:</p>
+         <p class="note" role="note"><span>Note:</span> If the above is true except <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-3">set of event types to handle</a> <strong>does not</strong> contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer’s intent isn’t clear.</p>
          <ol>
           <li data-md="">
            <p>Let <var>preloadRequest</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-clone">cloning</a> the request <var>request</var>.</p>
@@ -5507,7 +5478,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Else, return null.</p>
        </ol>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a>.</p>
       <li data-md="">
        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-4">set of event types to handle</a> does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> <code>fetch</code>, then:</p>
        <ol>
@@ -5520,7 +5491,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        </ol>
        <p class="note" role="note"><span>Note:</span> To avoid unnecessary delays, the Handle Fetch enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
       <li data-md="">
-       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-6">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-7">state</a> to become <em>activated</em>.</p>
+       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-7">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-8">state</a> to become <em>activated</em>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-6">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
@@ -5599,12 +5570,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <h3 class="heading settled" id="on-foreign-fetch-request-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="handle-foreign-fetch">Handle Foreign Fetch</dfn></span><a class="self-link" href="#on-foreign-fetch-request-algorithm"></a></h3>
      <p>The <a data-link-type="dfn" href="#handle-foreign-fetch" id="ref-for-handle-foreign-fetch-5">Handle Foreign Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-99">service worker</a> context to handle foreign fetch requests.</p>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>request</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>response</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a></p>
      </dl>
@@ -5626,10 +5595,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>If <var>activeWorker</var> is null, return null.</p>
        <li data-md="">
-        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-8">state</a> is <em>activating</em>, then:</p>
+        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-9">state</a> is <em>activating</em>, then:</p>
         <ol>
          <li data-md="">
-          <p>Wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-9">state</a> to become <em>activated</em>.</p>
+          <p>Wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-10">state</a> to become <em>activated</em>.</p>
         </ol>
        <li data-md="">
         <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a> is the same as <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a>, return null.</p>
@@ -5748,16 +5717,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Handle Functional Event">
      <h3 class="heading settled" id="handle-functional-event-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="handle-functional-event">Handle Functional Event</dfn></span><a class="self-link" href="#handle-functional-event-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-17">ExtendableEvent</a></code> object</p>
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-63">service worker registration</a></p>
       <dd data-md="">
        <p><var>callbackSteps</var>, an algorithm</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5765,9 +5732,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p class="assertion">Assert: <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-7">scope to registration map</a> contains a value equal to <var>registration</var>.</p>
       <li data-md="">
-       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a> is not null.</p>
+       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-42">active worker</a> is not null.</p>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-43">active worker</a>.</p>
       <li data-md="">
        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-5">set of event types to handle</a> does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> <var>event</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code>, then:</p>
        <ol>
@@ -5780,7 +5747,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        </ol>
        <p class="note" role="note"><span>Note:</span> To avoid unnecessary delays, the Handle Functional Event enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
       <li data-md="">
-       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-10">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-11">state</a> to become <em>activated</em>.</p>
+       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-11">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-12">state</a> to become <em>activated</em>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-8">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
@@ -5802,12 +5769,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <h3 class="heading settled" id="on-client-unload-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="handle-service-worker-client-unload">Handle Service Worker Client Unload</dfn></span><a class="self-link" href="#on-client-unload-algorithm"></a></h3>
      <p>The user agent <em>must</em> run these steps when a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-45">service worker client</a> unloads by <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unload-a-document">unloading</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">being killed</a>, or <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-10">terminating</a>.</p>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>client</var>, a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-46">service worker client</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5821,20 +5786,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If any other <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-47">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-8">using</a> <var>registration</var>, abort these steps.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-4">uninstalling flag</a> is set, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-4">Clear Registration</a> algorithm passing <var>registration</var> as its argument and abort these steps.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-7">uninstalling flag</a> is set, invoke <a data-link-type="dfn" href="#try-clear-registration" id="ref-for-try-clear-registration-4">Try Clear Registration</a> with <var>registration</var>.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-14">waiting worker</a> is not null, invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-7">Try Activate</a> with <var>registration</var>.</p>
+       <p>If <var>registration</var> is not null, invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-7">Try Activate</a> with <var>registration</var>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle User Agent Shutdown">
      <h3 class="heading settled" id="on-user-agent-shutdown-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="handle-user-agent-shutdown">Handle User Agent Shutdown</dfn></span><a class="self-link" href="#on-user-agent-shutdown-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p>None</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5846,12 +5809,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-12">installing worker</a> <var>installingWorker</var> is not null, then:</p>
          <ol>
           <li data-md="">
-           <p>If the result of running <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-6">Get Newest Worker</a> with <var>registration</var> is <var>installingWorker</var>, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-5">Clear Registration</a> with <var>registration</var> and continue to the next iteration of the loop.</p>
+           <p>If the result of running <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-6">Get Newest Worker</a> with <var>registration</var> is <var>installingWorker</var>, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-4">Clear Registration</a> with <var>registration</var> and continue to the next iteration of the loop.</p>
           <li data-md="">
            <p>Else, set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-13">installing worker</a> to null.</p>
          </ol>
         <li data-md="">
-         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-15">waiting worker</a> is not null, run the following substep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-14">waiting worker</a> is not null, run the following substep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
          <ol>
           <li data-md="">
            <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-10">Activate</a> with <var>registration</var>.</p>
@@ -5862,14 +5825,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Update Service Worker Extended Events Set">
      <h3 class="heading settled" id="update-service-worker-extended-events-set-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="update-service-worker-extended-events-set">Update Service Worker Extended Events Set</dfn></span><a class="self-link" href="#update-service-worker-extended-events-set-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a></p>
       <dd data-md="">
        <p><var>event</var>, an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event">event</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5889,12 +5850,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Unregister">
      <h3 class="heading settled" id="unregister-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unregister">Unregister</dfn></span><a class="self-link" href="#unregister-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-27">job</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -5918,12 +5877,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-13">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
-       <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-5">uninstalling flag</a>.</p>
+       <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-8">uninstalling flag</a>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-5">Resolve Job Promise</a> with <var>job</var> and true.</p>
       <li data-md="">
-       <p>If no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-48">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-9">using</a> <var>registration</var>, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-6">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
-       <p class="note" role="note"><span>Note:</span> When the registration is being used for a client, the deletion of the registration is handled by the Handle Service Worker Client Unload algorithm.</p>
+       <p>Invoke <a data-link-type="dfn" href="#try-clear-registration" id="ref-for-try-clear-registration-5">Try Clear Registration</a> with <var>registration</var>.</p>
+       <p class="note" role="note"><span>Note:</span> If <a data-link-type="dfn" href="#try-clear-registration" id="ref-for-try-clear-registration-6">Try Clear Registration</a> does not trigger <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-5">Clear Registration</a> here, <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-6">Clear Registration</a> is tried again when the last client <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-9">using</a> the registration is <a data-link-type="dfn" href="#handle-service-worker-client-unload" id="ref-for-handle-service-worker-client-unload-3">unloaded</a> or the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-13">extend lifetime promises</a> for the registration’s service workers settle.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-14">Finish Job</a> with <var>job</var>.</p>
      </ol>
@@ -5931,14 +5890,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Set Registration">
      <h3 class="heading settled" id="set-registration-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="set-registration">Set Registration</dfn></span><a class="self-link" href="#set-registration-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>scope</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a></p>
       <dd data-md="">
        <p><var>useCache</var>, a boolean</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-65">service worker registration</a></p>
      </dl>
@@ -5958,12 +5915,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Clear Registration">
      <h3 class="heading settled" id="clear-registration-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="clear-registration">Clear Registration</dfn></span><a class="self-link" href="#clear-registration-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-67">service worker registration</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5971,42 +5926,34 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Run the following steps atomically.</p>
       <li data-md="">
-       <p>Let <var>redundantWorker</var> be null.</p>
-      <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-14">installing worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-15">installing worker</a>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-11">Terminate</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-15">installing worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-11">Terminate</a> <var>redundantWorker</var>.</p>
+         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-9">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-16">installing worker</a> and <em>redundant</em> as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-7">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and null as the arguments.</p>
-        <li data-md="">
-         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-9">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-16">waiting worker</a> is not null, then:</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-15">waiting worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-17">waiting worker</a>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-12">Terminate</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-16">waiting worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-12">Terminate</a> <var>redundantWorker</var>.</p>
+         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-10">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-17">waiting worker</a> and <em>redundant</em> as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-8">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and null as the arguments.</p>
-        <li data-md="">
-         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-10">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-42">active worker</a> is not null, then:</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-44">active worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-43">active worker</a>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-13">Terminate</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-45">active worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-13">Terminate</a> <var>redundantWorker</var>.</p>
+         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-11">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-46">active worker</a> and <em>redundant</em> as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-9">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and null as the arguments.</p>
-        <li data-md="">
-         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-11">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
        <p>Let <var>scopeString</var> be <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-20">scope url</a> with the <em>exclude fragment flag</em> set.</p>
@@ -6014,19 +5961,40 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-remove">Remove</a> <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-10">scope to registration map</a>[<var>scopeString</var>].</p>
      </ol>
     </section>
+    <section class="algorithm" data-algorithm="Try Clear Registration">
+     <h3 class="heading settled" id="try-clear-registration-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="try-clear-registration">Try Clear Registration</dfn></span><a class="self-link" href="#try-clear-registration-algorithm"></a></h3>
+     <dl>
+      <dt data-md="">Input
+      <dd data-md="">
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-68">service worker registration</a></p>
+      <dt data-md="">Output
+      <dd data-md="">
+       <p>None</p>
+     </dl>
+     <ol>
+      <li data-md="">
+       <p>Invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-7">Clear Registration</a> with <var>registration</var> if no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-48">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-10">using</a> <var>registration</var> and all of the following conditions are true:</p>
+       <ul>
+        <li data-md="">
+         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-17">installing worker</a> is null or the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-2">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-18">installing worker</a> is true.</p>
+        <li data-md="">
+         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-18">waiting worker</a> is null or the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-3">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-19">waiting worker</a> is true.</p>
+        <li data-md="">
+         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-47">active worker</a> is null or the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-4">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-48">active worker</a> is true.</p>
+       </ul>
+     </ol>
+    </section>
     <section class="algorithm" data-algorithm="Update Registration State">
      <h3 class="heading settled" id="update-registration-state-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="update-registration-state">Update Registration State</dfn></span><a class="self-link" href="#update-registration-state-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-68">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-69">service worker registration</a></p>
       <dd data-md="">
        <p><var>target</var>, a string (one of "<code>installing</code>", "<code>waiting</code>", and "<code>active</code>")</p>
       <dd data-md="">
        <p><var>source</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a> or null</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -6037,36 +6005,36 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>target</var> is "<code>installing</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-16">installing worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-installing" id="ref-for-dom-serviceworkerregistration-installing-3">installing</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-25">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-17">installing worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-18">installing worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-installing" id="ref-for-dom-serviceworkerregistration-installing-3">installing</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-25">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-21">installing worker</a> is null.</p>
          </ol>
        </ol>
       <li data-md="">
        <p>Else if <var>target</var> is "<code>waiting</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-18">waiting worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-waiting" id="ref-for-dom-serviceworkerregistration-waiting-3">waiting</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-26">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-19">waiting worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-waiting" id="ref-for-dom-serviceworkerregistration-waiting-3">waiting</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-26">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-21">waiting worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-22">waiting worker</a> is null.</p>
          </ol>
        </ol>
       <li data-md="">
        <p>Else if <var>target</var> is "<code>active</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-44">active worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-49">active worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-3">active</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-27">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-45">active worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-46">active worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-3">active</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-27">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-50">active worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-51">active worker</a> is null.</p>
          </ol>
        </ol>
        <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <em>must</em> use <var>registrationObject</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>.</p>
@@ -6075,20 +6043,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Update Worker State">
      <h3 class="heading settled" id="update-state-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="update-worker-state">Update Worker State</dfn></span><a class="self-link" href="#update-state-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-102">service worker</a></p>
       <dd data-md="">
-       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-12">state</a></p>
-      <dt data-md="">
-       <p>Output</p>
+       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-13">state</a></p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
      <ol>
       <li data-md="">
-       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-13">state</a> to <var>state</var>.</p>
+       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-14">state</a> to <var>state</var>.</p>
       <li data-md="">
        <p>Let <var>workerObjects</var> be an array containing all the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-28">ServiceWorker</a></code> objects associated with <var>worker</var>.</p>
       <li data-md="">
@@ -6098,30 +6064,25 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to run these substeps:</p>
          <ol>
           <li data-md="">
-           <p>Set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworker-state" id="ref-for-dom-serviceworker-state-5">state</a></code> attribute of <var>workerObject</var> to the value (in <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate-4">ServiceWorkerState</a></code> enumeration) corresponding to the first matching statement, switching on <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-14">state</a>:</p>
+           <p>Set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworker-state" id="ref-for-dom-serviceworker-state-5">state</a></code> attribute of <var>workerObject</var> to the value (in <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate-4">ServiceWorkerState</a></code> enumeration) corresponding to the first matching statement, switching on <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-15">state</a>:</p>
            <dl>
-            <dt data-md="">
-             <p><em>installing</em></p>
+            <dt data-md=""><em>installing</em>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installing" id="ref-for-dom-serviceworkerstate-installing-1">"installing"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a> is not active until all of the core caches are populated.</p>
-            <dt data-md="">
-             <p><em>installed</em></p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-22">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-23">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a> is not active until all of the core caches are populated.</p>
+            <dt data-md=""><em>installed</em>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installed" id="ref-for-dom-serviceworkerstate-installed-1">"installed"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-21">waiting worker</a>.</p>
-            <dt data-md="">
-             <p><em>activating</em></p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-23">waiting worker</a>.</p>
+            <dt data-md=""><em>activating</em>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activating" id="ref-for-dom-serviceworkerstate-activating-1">"activating"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-47">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-9">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-48">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-12">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
-            <dt data-md="">
-             <p><em>activated</em></p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-52">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-9">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-53">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-12">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
+            <dt data-md=""><em>activated</em>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activated" id="ref-for-dom-serviceworkerstate-activated-1">"activated"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-49">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-13">functional events</a>.</p>
-            <dt data-md="">
-             <p><em>redundant</em></p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-54">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-13">functional events</a>.</p>
+            <dt data-md=""><em>redundant</em>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-redundant" id="ref-for-dom-serviceworkerstate-redundant-2">"redundant"</a></code></p>
              <p class="note" role="note"><span>Note:</span> A new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-109">service worker</a> is replacing the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-110">service worker</a>, or the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-111">service worker</a> is being discarded due to an install failure.</p>
@@ -6136,12 +6097,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Notify Controller Change">
      <h3 class="heading settled" id="notify-controller-change-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="notify-controller-change">Notify Controller Change</dfn></span><a class="self-link" href="#notify-controller-change-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>client</var>, a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-49">service worker client</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -6156,14 +6115,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Match Service Worker Registration">
      <h3 class="heading settled" id="scope-match-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="match-service-worker-registration">Match Service Worker Registration</dfn></span><a class="self-link" href="#scope-match-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>clientURL</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-69">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-70">service worker registration</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -6184,7 +6141,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>registration</var> be the result of running <a data-link-type="dfn" href="#get-registration" id="ref-for-get-registration-4">Get Registration</a> algorithm passing <var>parsedMatchingScope</var> as the argument.</p>
       <li data-md="">
-       <p>If <var>registration</var> is not null and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-6">uninstalling flag</a> is set, return null.</p>
+       <p>If <var>registration</var> is not null and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-9">uninstalling flag</a> is set, return null.</p>
       <li data-md="">
        <p>Return <var>registration</var>.</p>
      </ol>
@@ -6192,12 +6149,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Match Service Worker for Foreign Fetch">
      <h3 class="heading settled" id="foreign-fetch-scope-match-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="match-service-worker-for-foreign-fetch">Match Service Worker for Foreign Fetch</dfn></span><a class="self-link" href="#foreign-fetch-scope-match-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>requestURL</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-112">service worker</a></p>
      </dl>
@@ -6209,7 +6164,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var> is null, return null.</p>
       <li data-md="">
-       <p>Let <var>worker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-50">active worker</a>.</p>
+       <p>Let <var>worker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-55">active worker</a>.</p>
       <li data-md="">
        <p>If <var>worker</var> is null, return null.</p>
       <li data-md="">
@@ -6229,14 +6184,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Get Registration">
      <h3 class="heading settled" id="get-registration-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="get-registration">Get Registration</dfn></span><a class="self-link" href="#get-registration-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>scope</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-70">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-71">service worker registration</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -6260,12 +6213,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Get Newest Worker">
      <h3 class="heading settled" id="get-newest-worker-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="get-newest-worker">Get Newest Worker</dfn></span><a class="self-link" href="#get-newest-worker-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-71">service worker registration</a></p>
-      <dt data-md="">
-       <p>Output</p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-72">service worker registration</a></p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>newestWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-113">service worker</a></p>
      </dl>
@@ -6275,11 +6226,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>newestWorker</var> be null.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-21">installing worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-22">installing worker</a>.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-24">installing worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-25">installing worker</a>.</p>
       <li data-md="">
-       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-22">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-23">waiting worker</a>.</p>
+       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-24">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-25">waiting worker</a>.</p>
       <li data-md="">
-       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-51">active worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-52">active worker</a>.</p>
+       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-56">active worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-57">active worker</a>.</p>
       <li data-md="">
        <p>Return <var>newestWorker</var>.</p>
      </ol>
@@ -6287,12 +6238,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Service Worker Has No Pending Events">
      <h3 class="heading settled" id="service-worker-has-no-pending-events-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="service-worker-has-no-pending-events">Service Worker Has No Pending Events</dfn></span><a class="self-link" href="#service-worker-has-no-pending-events-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-114">service worker</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>True or false, a boolean</p>
      </dl>
@@ -6314,12 +6263,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Create Client">
      <h3 class="heading settled" id="create-client-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="create-client">Create Client</dfn></span><a class="self-link" href="#create-client-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>client</var>, a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-50">service worker client</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>clientObject</var>, a <code class="idl"><a data-link-type="idl" href="#client" id="ref-for-client-12">Client</a></code> object</p>
      </dl>
@@ -6337,8 +6284,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Create Window Client">
      <h3 class="heading settled" id="create-windowclient-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="create-window-client">Create Window Client</dfn></span><a class="self-link" href="#create-windowclient-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>client</var>, a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-51">service worker client</a></p>
       <dd data-md="">
@@ -6347,8 +6293,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><var>focusState</var>, a boolean</p>
       <dd data-md="">
        <p><var>ancestorOriginsList</var>, a list</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>windowClient</var>, a <code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-11">WindowClient</a></code> object</p>
      </dl>
@@ -6370,16 +6315,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Query Cache">
      <h3 class="heading settled" id="query-cache-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="query-cache">Query Cache</dfn></span><a class="self-link" href="#query-cache-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>request</var>, a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> object</p>
       <dd data-md="">
        <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-cachequeryoptions" id="ref-for-dictdef-cachequeryoptions-7">CacheQueryOptions</a></code> object, optional</p>
       <dd data-md="">
        <p><var>targetStorage</var>, an array that has [<code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code>, <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code>] pairs as its elements, optional</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>resultArray</var>, an array that has [<code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code>, <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code>] pairs as its elements</p>
      </dl>
@@ -6489,12 +6432,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Batch Cache Operations">
      <h3 class="heading settled" id="batch-cache-operations-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="batch-cache-operations">Batch Cache Operations</dfn></span><a class="self-link" href="#batch-cache-operations-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>operations</var>, an array of <code class="idl"><a data-link-type="idl" href="#dictdef-cachebatchoperation" id="ref-for-dictdef-cachebatchoperation-4">CacheBatchOperation</a></code> dictionary objects</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>promise</var>, a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves with an array of <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> objects</p>
      </dl>
@@ -6591,8 +6532,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <h3 class="heading settled" id="service-worker-script-request"><span class="content">Service Worker Script Request</span><a class="self-link" href="#service-worker-script-request"></a></h3>
      <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-115">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
-      <dt data-md="">
-       <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker"><code>Service-Worker</code><a class="self-link" href="#service-worker"></a></dfn>`</p>
+      <dt data-md="">`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker"><code>Service-Worker</code><a class="self-link" href="#service-worker"></a></dfn>`
       <dd data-md="">
        <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-116">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request.</p>
        <p class="note" role="note"><span>Note:</span> This header helps administrators log the requests and detect threats.</p>
@@ -6602,8 +6542,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <h3 class="heading settled" id="service-worker-script-response"><span class="content">Service Worker Script Response</span><a class="self-link" href="#service-worker-script-response"></a></h3>
      <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-117">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
-      <dt data-md="">
-       <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker-allowed"><code>Service-Worker-Allowed</code><a class="self-link" href="#service-worker-allowed"></a></dfn>`</p>
+      <dt data-md="">`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker-allowed"><code>Service-Worker-Allowed</code><a class="self-link" href="#service-worker-allowed"></a></dfn>`
       <dd data-md="">
        <p>Indicates the user agent will override the path restriction, which limits the maximum allowed <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-21">scope url</a> that the script can <a data-link-type="dfn" href="#dfn-control" id="ref-for-dfn-control-4">control</a>, to the given value.</p>
        <p class="note" role="note"><span>Note:</span> The value is a URL. If a relative URL is given, it is parsed against the script’s URL.</p>
@@ -7111,6 +7050,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dfn-service-worker-registration-task-queue">task queues</a><span>, in §2.2</span>
    <li><a href="#terminate-service-worker">Terminate Service Worker</a><span>, in §Unnumbered section</span>
    <li><a href="#try-activate">Try Activate</a><span>, in §Unnumbered section</span>
+   <li><a href="#try-clear-registration">Try Clear Registration</a><span>, in §Unnumbered section</span>
    <li>
     type
     <ul>
@@ -7178,7 +7118,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://w3c.github.io/webappsec-csp/#monitored">monitored</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[WHATWG-DOM]</a> defines the following terms:
+    <a data-link-type="biblio">[DOM]</a> defines the following terms:
     <ul>
      <li><a href="https://dom.spec.whatwg.org/#document">Document</a>
      <li><a href="https://dom.spec.whatwg.org/#event">Event</a>
@@ -7241,6 +7181,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://fetch.spec.whatwg.org/#concept-enqueue-readablestream">enqueue</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-readablestream-errored">errored</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">extract a mime type</a>
+     <li><a href="https://fetch.spec.whatwg.org/#extract-header-list-values">extracting header list values</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a>
      <li><a href="https://fetch.spec.whatwg.org/#dom-global-fetch">fetch(input, init)</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-filtered-response">filtered response</a>
@@ -7266,7 +7207,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">opaque filtered response</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque-redirect">opaque-redirect filtered response</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a>
-     <li><a href="https://fetch.spec.whatwg.org/#concept-header-parse">parse a header value</a>
      <li><a href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">potential-navigation-or-subresource request</a>
      <li><a href="https://fetch.spec.whatwg.org/#process-response">process response</a>
      <li><a href="https://fetch.spec.whatwg.org/#process-response-done">process response done</a>
@@ -7473,7 +7413,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[WHATWG-URL]</a> defines the following terms:
+    <a data-link-type="biblio">[URL]</a> defines the following terms:
     <ul>
      <li><a href="https://url.spec.whatwg.org/#absolute-url-string">absolute-url string</a>
      <li><a href="https://url.spec.whatwg.org/#concept-url-equals">equal</a>
@@ -7516,6 +7456,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <dl>
    <dt id="biblio-csp3">[CSP3]
    <dd>Mike West. <a href="https://w3c.github.io/webappsec-csp/">Content Security Policy Level 3</a>. URL: <a href="https://w3c.github.io/webappsec-csp/">https://w3c.github.io/webappsec-csp/</a>
+   <dt id="biblio-dom">[DOM]
+   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-ecmascript">[ECMASCRIPT]
    <dd><a href="https://tc39.github.io/ecma262/">ECMAScript Language Specification</a>. URL: <a href="https://tc39.github.io/ecma262/">https://tc39.github.io/ecma262/</a>
    <dt id="biblio-fetch">[FETCH]
@@ -7542,12 +7484,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <dd>R. Fielding, Ed.; J. Reschke, Ed.. <a href="https://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7231">https://tools.ietf.org/html/rfc7231</a>
    <dt id="biblio-secure-contexts">[SECURE-CONTEXTS]
    <dd>Mike West. <a href="https://w3c.github.io/webappsec-secure-contexts/">Secure Contexts</a>. URL: <a href="https://w3c.github.io/webappsec-secure-contexts/">https://w3c.github.io/webappsec-secure-contexts/</a>
+   <dt id="biblio-url">[URL]
+   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-webidl">[WebIDL]
    <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
-   <dt id="biblio-whatwg-dom">[WHATWG-DOM]
-   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
-   <dt id="biblio-whatwg-url">[WHATWG-URL]
-   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
@@ -7877,10 +7817,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-state-1">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-state-2">(2)</a> <a href="#ref-for-dfn-state-3">(3)</a>
     <li><a href="#ref-for-dfn-state-4">3.1. ServiceWorker</a>
     <li><a href="#ref-for-dfn-state-5">3.2.7. update()</a>
-    <li><a href="#ref-for-dfn-state-6">Handle Fetch</a> <a href="#ref-for-dfn-state-7">(2)</a>
-    <li><a href="#ref-for-dfn-state-8">Handle Foreign Fetch</a> <a href="#ref-for-dfn-state-9">(2)</a>
-    <li><a href="#ref-for-dfn-state-10">Handle Functional Event</a> <a href="#ref-for-dfn-state-11">(2)</a>
-    <li><a href="#ref-for-dfn-state-12">Update Worker State</a> <a href="#ref-for-dfn-state-13">(2)</a> <a href="#ref-for-dfn-state-14">(3)</a>
+    <li><a href="#ref-for-dfn-state-6">Try Activate</a>
+    <li><a href="#ref-for-dfn-state-7">Handle Fetch</a> <a href="#ref-for-dfn-state-8">(2)</a>
+    <li><a href="#ref-for-dfn-state-9">Handle Foreign Fetch</a> <a href="#ref-for-dfn-state-10">(2)</a>
+    <li><a href="#ref-for-dfn-state-11">Handle Functional Event</a> <a href="#ref-for-dfn-state-12">(2)</a>
+    <li><a href="#ref-for-dfn-state-13">Update Worker State</a> <a href="#ref-for-dfn-state-14">(2)</a> <a href="#ref-for-dfn-state-15">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-script-url">
@@ -8079,10 +8020,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-registration-64">Handle Service Worker Client Unload</a>
     <li><a href="#ref-for-dfn-service-worker-registration-65">Set Registration</a> <a href="#ref-for-dfn-service-worker-registration-66">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-registration-67">Clear Registration</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-68">Update Registration State</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-69">Match Service Worker Registration</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-70">Get Registration</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-71">Get Newest Worker</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-68">Try Clear Registration</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-69">Update Registration State</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-70">Match Service Worker Registration</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-71">Get Registration</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-72">Get Newest Worker</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-scope-url">
@@ -8117,10 +8059,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-installing-worker-6">4.9. Events</a>
     <li><a href="#ref-for-dfn-installing-worker-7">Install</a> <a href="#ref-for-dfn-installing-worker-8">(2)</a> <a href="#ref-for-dfn-installing-worker-9">(3)</a> <a href="#ref-for-dfn-installing-worker-10">(4)</a> <a href="#ref-for-dfn-installing-worker-11">(5)</a>
     <li><a href="#ref-for-dfn-installing-worker-12">Handle User Agent Shutdown</a> <a href="#ref-for-dfn-installing-worker-13">(2)</a>
-    <li><a href="#ref-for-dfn-installing-worker-14">Clear Registration</a> <a href="#ref-for-dfn-installing-worker-15">(2)</a>
-    <li><a href="#ref-for-dfn-installing-worker-16">Update Registration State</a> <a href="#ref-for-dfn-installing-worker-17">(2)</a> <a href="#ref-for-dfn-installing-worker-18">(3)</a>
-    <li><a href="#ref-for-dfn-installing-worker-19">Update Worker State</a> <a href="#ref-for-dfn-installing-worker-20">(2)</a>
-    <li><a href="#ref-for-dfn-installing-worker-21">Get Newest Worker</a> <a href="#ref-for-dfn-installing-worker-22">(2)</a>
+    <li><a href="#ref-for-dfn-installing-worker-14">Clear Registration</a> <a href="#ref-for-dfn-installing-worker-15">(2)</a> <a href="#ref-for-dfn-installing-worker-16">(3)</a>
+    <li><a href="#ref-for-dfn-installing-worker-17">Try Clear Registration</a> <a href="#ref-for-dfn-installing-worker-18">(2)</a>
+    <li><a href="#ref-for-dfn-installing-worker-19">Update Registration State</a> <a href="#ref-for-dfn-installing-worker-20">(2)</a> <a href="#ref-for-dfn-installing-worker-21">(3)</a>
+    <li><a href="#ref-for-dfn-installing-worker-22">Update Worker State</a> <a href="#ref-for-dfn-installing-worker-23">(2)</a>
+    <li><a href="#ref-for-dfn-installing-worker-24">Get Newest Worker</a> <a href="#ref-for-dfn-installing-worker-25">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-waiting-worker">
@@ -8133,12 +8076,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-waiting-worker-6">Install</a> <a href="#ref-for-dfn-waiting-worker-7">(2)</a> <a href="#ref-for-dfn-waiting-worker-8">(3)</a> <a href="#ref-for-dfn-waiting-worker-9">(4)</a>
     <li><a href="#ref-for-dfn-waiting-worker-10">Activate</a> <a href="#ref-for-dfn-waiting-worker-11">(2)</a>
     <li><a href="#ref-for-dfn-waiting-worker-12">Try Activate</a> <a href="#ref-for-dfn-waiting-worker-13">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-14">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-dfn-waiting-worker-15">Handle User Agent Shutdown</a>
-    <li><a href="#ref-for-dfn-waiting-worker-16">Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-17">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-18">Update Registration State</a> <a href="#ref-for-dfn-waiting-worker-19">(2)</a> <a href="#ref-for-dfn-waiting-worker-20">(3)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-21">Update Worker State</a>
-    <li><a href="#ref-for-dfn-waiting-worker-22">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker-23">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-14">Handle User Agent Shutdown</a>
+    <li><a href="#ref-for-dfn-waiting-worker-15">Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-16">(2)</a> <a href="#ref-for-dfn-waiting-worker-17">(3)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-18">Try Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-19">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-20">Update Registration State</a> <a href="#ref-for-dfn-waiting-worker-21">(2)</a> <a href="#ref-for-dfn-waiting-worker-22">(3)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-23">Update Worker State</a>
+    <li><a href="#ref-for-dfn-waiting-worker-24">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker-25">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-active-worker">
@@ -8158,15 +8101,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-active-worker-21">4.9. Events</a>
     <li><a href="#ref-for-dfn-active-worker-22">Install</a> <a href="#ref-for-dfn-active-worker-23">(2)</a>
     <li><a href="#ref-for-dfn-active-worker-24">Activate</a> <a href="#ref-for-dfn-active-worker-25">(2)</a> <a href="#ref-for-dfn-active-worker-26">(3)</a> <a href="#ref-for-dfn-active-worker-27">(4)</a> <a href="#ref-for-dfn-active-worker-28">(5)</a> <a href="#ref-for-dfn-active-worker-29">(6)</a> <a href="#ref-for-dfn-active-worker-30">(7)</a> <a href="#ref-for-dfn-active-worker-31">(8)</a>
-    <li><a href="#ref-for-dfn-active-worker-32">Try Activate</a> <a href="#ref-for-dfn-active-worker-33">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-34">Run Service Worker</a>
-    <li><a href="#ref-for-dfn-active-worker-35">Handle Fetch</a> <a href="#ref-for-dfn-active-worker-36">(2)</a> <a href="#ref-for-dfn-active-worker-37">(3)</a> <a href="#ref-for-dfn-active-worker-38">(4)</a> <a href="#ref-for-dfn-active-worker-39">(5)</a>
-    <li><a href="#ref-for-dfn-active-worker-40">Handle Functional Event</a> <a href="#ref-for-dfn-active-worker-41">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-42">Clear Registration</a> <a href="#ref-for-dfn-active-worker-43">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-44">Update Registration State</a> <a href="#ref-for-dfn-active-worker-45">(2)</a> <a href="#ref-for-dfn-active-worker-46">(3)</a>
-    <li><a href="#ref-for-dfn-active-worker-47">Update Worker State</a> <a href="#ref-for-dfn-active-worker-48">(2)</a> <a href="#ref-for-dfn-active-worker-49">(3)</a>
-    <li><a href="#ref-for-dfn-active-worker-50">Match Service Worker for Foreign Fetch</a>
-    <li><a href="#ref-for-dfn-active-worker-51">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker-52">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-32">Try Activate</a> <a href="#ref-for-dfn-active-worker-33">(2)</a> <a href="#ref-for-dfn-active-worker-34">(3)</a> <a href="#ref-for-dfn-active-worker-35">(4)</a>
+    <li><a href="#ref-for-dfn-active-worker-36">Run Service Worker</a>
+    <li><a href="#ref-for-dfn-active-worker-37">Handle Fetch</a> <a href="#ref-for-dfn-active-worker-38">(2)</a> <a href="#ref-for-dfn-active-worker-39">(3)</a> <a href="#ref-for-dfn-active-worker-40">(4)</a> <a href="#ref-for-dfn-active-worker-41">(5)</a>
+    <li><a href="#ref-for-dfn-active-worker-42">Handle Functional Event</a> <a href="#ref-for-dfn-active-worker-43">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-44">Clear Registration</a> <a href="#ref-for-dfn-active-worker-45">(2)</a> <a href="#ref-for-dfn-active-worker-46">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-47">Try Clear Registration</a> <a href="#ref-for-dfn-active-worker-48">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-49">Update Registration State</a> <a href="#ref-for-dfn-active-worker-50">(2)</a> <a href="#ref-for-dfn-active-worker-51">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-52">Update Worker State</a> <a href="#ref-for-dfn-active-worker-53">(2)</a> <a href="#ref-for-dfn-active-worker-54">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-55">Match Service Worker for Foreign Fetch</a>
+    <li><a href="#ref-for-dfn-active-worker-56">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker-57">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-last-update-check-time">
@@ -8192,11 +8136,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dfn-uninstalling-flag">#dfn-uninstalling-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-uninstalling-flag-1">3.4.5. getRegistrations()</a>
-    <li><a href="#ref-for-dfn-uninstalling-flag-2">Register</a>
-    <li><a href="#ref-for-dfn-uninstalling-flag-3">Update</a>
-    <li><a href="#ref-for-dfn-uninstalling-flag-4">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-dfn-uninstalling-flag-5">Unregister</a>
-    <li><a href="#ref-for-dfn-uninstalling-flag-6">Match Service Worker Registration</a>
+    <li><a href="#ref-for-dfn-uninstalling-flag-2">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-dfn-uninstalling-flag-3">4.6.6. event.respondWith(r)</a>
+    <li><a href="#ref-for-dfn-uninstalling-flag-4">4.7.3. event.respondWith(r)</a>
+    <li><a href="#ref-for-dfn-uninstalling-flag-5">Register</a>
+    <li><a href="#ref-for-dfn-uninstalling-flag-6">Update</a>
+    <li><a href="#ref-for-dfn-uninstalling-flag-7">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-dfn-uninstalling-flag-8">Unregister</a>
+    <li><a href="#ref-for-dfn-uninstalling-flag-9">Match Service Worker Registration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-service-worker-registration-task-queue">
@@ -8253,7 +8200,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-client-43">Run Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-client-44">Handle Fetch</a>
     <li><a href="#ref-for-dfn-service-worker-client-45">Handle Service Worker Client Unload</a> <a href="#ref-for-dfn-service-worker-client-46">(2)</a> <a href="#ref-for-dfn-service-worker-client-47">(3)</a>
-    <li><a href="#ref-for-dfn-service-worker-client-48">Unregister</a>
+    <li><a href="#ref-for-dfn-service-worker-client-48">Try Clear Registration</a>
     <li><a href="#ref-for-dfn-service-worker-client-49">Notify Controller Change</a>
     <li><a href="#ref-for-dfn-service-worker-client-50">Create Client</a>
     <li><a href="#ref-for-dfn-service-worker-client-51">Create Window Client</a>
@@ -8326,6 +8273,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-use-6">Handle Fetch</a>
     <li><a href="#ref-for-dfn-use-7">Handle Service Worker Client Unload</a> <a href="#ref-for-dfn-use-8">(2)</a>
     <li><a href="#ref-for-dfn-use-9">Unregister</a>
+    <li><a href="#ref-for-dfn-use-10">Try Clear Registration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-handle-fetch-task-source">
@@ -9099,6 +9047,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-9">4.6.6. event.respondWith(r)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-10">4.7.3. event.respondWith(r)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-11">Install</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-12">(2)</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-13">Unregister</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="extendableevent-pending-promises-count">
@@ -10045,6 +9994,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-handle-service-worker-client-unload-1">4.3.4. claim()</a>
     <li><a href="#ref-for-handle-service-worker-client-unload-2">Install</a>
+    <li><a href="#ref-for-handle-service-worker-client-unload-3">Unregister</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-user-agent-shutdown">
@@ -10080,9 +10030,19 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-clear-registration-1">Update</a> <a href="#ref-for-clear-registration-2">(2)</a>
     <li><a href="#ref-for-clear-registration-3">Install</a>
-    <li><a href="#ref-for-clear-registration-4">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-clear-registration-5">Handle User Agent Shutdown</a>
-    <li><a href="#ref-for-clear-registration-6">Unregister</a>
+    <li><a href="#ref-for-clear-registration-4">Handle User Agent Shutdown</a>
+    <li><a href="#ref-for-clear-registration-5">Unregister</a> <a href="#ref-for-clear-registration-6">(2)</a>
+    <li><a href="#ref-for-clear-registration-7">Try Clear Registration</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="try-clear-registration">
+   <b><a href="#try-clear-registration">#try-clear-registration</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-try-clear-registration-1">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-try-clear-registration-2">4.6.6. event.respondWith(r)</a>
+    <li><a href="#ref-for-try-clear-registration-3">4.7.3. event.respondWith(r)</a>
+    <li><a href="#ref-for-try-clear-registration-4">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-try-clear-registration-5">Unregister</a> <a href="#ref-for-try-clear-registration-6">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="update-registration-state">
@@ -10152,6 +10112,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#service-worker-has-no-pending-events">#service-worker-has-no-pending-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-has-no-pending-events-1">Try Activate</a>
+    <li><a href="#ref-for-service-worker-has-no-pending-events-2">Try Clear Registration</a> <a href="#ref-for-service-worker-has-no-pending-events-3">(2)</a> <a href="#ref-for-service-worker-has-no-pending-events-4">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="create-client">

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -1242,7 +1242,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
         1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |f|, [=queue a microtask=] to run these substeps:
             1. Decrement the [=ExtendableEvent/pending promises count=] by one.
-            1. Invoke [=Try Activate=] with the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
+            1. Let |registration| be the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
+            1. If |registration|'s [=uninstalling flag=] is set, invoke [=Try Clear Registration=] with |registration|.
+            1. If |registration| is not null, invoke [=Try Activate=] with |registration|.
 
         The user agent *should not* <a lt="terminate service worker">terminate</a> the [=/service worker=] associated with |event|'s <a>relevant settings object</a>'s [=environment settings object/global object=] when |event|'s [=dispatch flag=] is set or |event|'s [=ExtendableEvent/pending promises count=] is not zero. However, the user agent *may* impose a time limit to this lifetime extension.
     </section>
@@ -1330,7 +1332,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
         1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |r|, [=queue a microtask=] to run these substeps:
             1. Decrement the [=ExtendableEvent/pending promises count=] by one.
-            1. Invoke [=Try Activate=] with the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
+            1. Let |registration| be the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
+            1. If |registration|'s [=uninstalling flag=] is set, invoke [=Try Clear Registration=] with |registration|.
+            1. If |registration| is not null, invoke [=Try Activate=] with |registration|.
 
             Note: {{FetchEvent/respondWith(r)|event.respondWith(r)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(r)}} is called.
 
@@ -2234,7 +2238,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. <a>Extract a MIME type</a> from the |response|'s [=response/header list=]. If this MIME type (ignoring parameters) is not one of <code>text/javascript</code>, <code>application/x-javascript</code>, and <code>application/javascript</code>, then:
               1. Invoke <a>Reject Job Promise</a> with |job| and a "{{SecurityError}}" exception.
               1. Asynchronously complete these steps with a <a>network error</a>.
-          1. Let |serviceWorkerAllowed| be the result of [=header/parse a header value|parsing=] \`<code>Service-Worker-Allowed</code>\` in |response|'s [=response/header list=].
+          1. Let |serviceWorkerAllowed| be the result of [=extracting header list values=] given \`<code>Service-Worker-Allowed</code>\` and |response|'s [=response/header list=].
 
               Note: See the definition of the Service-Worker-Allowed header in Appendix B: Extended HTTP headers.
 
@@ -2357,7 +2361,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Wait for all the <a>tasks</a> <a lt="queue a task">queued</a> by <a>Update Worker State</a> invoked in this algorithm have executed.
       1. Invoke [=Try Activate=] with |registration|.
 
-          Note: If [=Try Activate=] does not trigger [=Activate=] here, [=Activate=] is tried again when the last client controlled by the existing [=active worker=] is [=Handle Service Worker Client Unload|unloaded=], {{ServiceWorkerGlobalScope/skipWaiting()}} is asynchronously called, and the [=extend lifetime promises=] for the existing [=active worker=] settle.
+          Note: If [=Try Activate=] does not trigger [=Activate=] here, [=Activate=] is tried again when the last client controlled by the existing [=active worker=] is [=Handle Service Worker Client Unload|unloaded=], {{ServiceWorkerGlobalScope/skipWaiting()}} is asynchronously called, or the [=extend lifetime promises=] for the existing [=active worker=] settle.
   </section>
 
   <section algorithm>
@@ -2408,6 +2412,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: None
 
       1. If |registration|'s [=waiting worker=] is null, return.
+      1. If |registration|'s [=active worker=] is not null and |registration|'s [=active worker=]'s [=state=] is *activating*, return.
+
+          Note: If the existing active worker is still in activating state, the activation of the waiting worker is delayed.
+
       1. Invoke [=Activate=] with |registration| if either of the following is true:
         * |registration|'s [=active worker=] is null.
         * The result of running [=Service Worker Has No Pending Events=] with |registration|’s [=active worker=] is true, and no [=/service worker client=] is [=using=] |registration| or |registration|’s [=waiting worker=]'s [=skip waiting flag=] is set.
@@ -2625,8 +2633,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Let |registration| be the [=/service worker registration=] <a>used</a> by |client|.
       1. If |registration| is null, abort these steps.
       1. If any other [=/service worker client=] is <a>using</a> |registration|, abort these steps.
-      1. If |registration|'s <a>uninstalling flag</a> is set, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument and abort these steps.
-      1. If |registration|'s <a>waiting worker</a> is not null, invoke [=Try Activate=] with |registration|.
+      1. If |registration|'s [=uninstalling flag=] is set, invoke [=Try Clear Registration=] with |registration|.
+      1. If |registration| is not null, invoke [=Try Activate=] with |registration|.
   </section>
 
   <section algorithm>
@@ -2677,9 +2685,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Set |registration|'s <a>uninstalling flag</a>.
       1. Invoke <a>Resolve Job Promise</a> with |job| and true.
-      1. If no [=/service worker client=] is <a>using</a> |registration|, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
+      1. Invoke [=Try Clear Registration=] with |registration|.
 
-          Note: When the registration is being used for a client, the deletion of the registration is handled by the Handle Service Worker Client Unload algorithm.
+          Note: If [=Try Clear Registration=] does not trigger [=Clear Registration=] here, [=Clear Registration=] is tried again when the last client [=using=] the registration is [=Handle Service Worker Client Unload|unloaded=] or the [=extend lifetime promises=] for the registration's service workers settle.
 
       1. Invoke <a>Finish Job</a> with |job|.
   </section>
@@ -2709,24 +2717,34 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: None
 
       1. Run the following steps atomically.
-      1. Let |redundantWorker| be null.
       1. If |registration|'s <a>installing worker</a> is not null, then:
-          1. Set |redundantWorker| to |registration|'s <a>installing worker</a>.
-          1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
+          1. [=Terminate Service Worker|Terminate=] |registration|'s [=installing worker=].
+          1. Run the <a>Update Worker State</a> algorithm passing |registration|'s [=installing worker=] and *redundant* as the arguments.
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and null as the arguments.
-          1. Run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. If |registration|'s <a>waiting worker</a> is not null, then:
-          1. Set |redundantWorker| to |registration|'s <a>waiting worker</a>.
-          1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
+          1. [=Terminate Service Worker|Terminate=] |registration|'s [=waiting worker=].
+          1. Run the <a>Update Worker State</a> algorithm passing |registration|'s [=waiting worker=] and *redundant* as the arguments.
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>waiting</code>" and null as the arguments.
-          1. Run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. If |registration|'s <a>active worker</a> is not null, then:
-          1. Set |redundantWorker| to |registration|'s <a>active worker</a>.
-          1. <a lt="Terminate Service Worker">Terminate</a> |redundantWorker|.
+          1. [=Terminate Service Worker|Terminate=] |registration|'s [=active worker=].
+          1. Run the <a>Update Worker State</a> algorithm passing |registration|'s [=active worker=] and *redundant* as the arguments.
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>active</code>" and null as the arguments.
-          1. Run the <a>Update Worker State</a> algorithm passing |redundantWorker| and *redundant* as the arguments.
       1. Let |scopeString| be <a lt="URL serializer">serialized</a> |registration|'s [=service worker registration/scope url=] with the *exclude fragment flag* set.
       1. [=map/Remove=] <a>scope to registration map</a>[|scopeString|].
+  </section>
+
+  <section algorithm>
+    <h3 id="try-clear-registration-algorithm"><dfn>Try Clear Registration</dfn></h3>
+
+      : Input
+      :: |registration|, a [=/service worker registration=]
+      : Output
+      :: None
+
+      1. Invoke [=Clear Registration=] with |registration| if no [=/service worker client=] is [=using=] |registration| and all of the following conditions are true:
+          * |registration|'s [=installing worker=] is null or the result of running [=Service Worker Has No Pending Events=] with |registration|’s [=installing worker=] is true.
+          * |registration|'s [=waiting worker=] is null or the result of running [=Service Worker Has No Pending Events=] with |registration|’s [=waiting worker=] is true.
+          * |registration|'s [=active worker=] is null or the result of running [=Service Worker Has No Pending Events=] with |registration|’s [=active worker=] is true.
   </section>
 
   <section algorithm>

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 70f542b3eb403344eee83c57e6631f734b1c4427" name="generator">
+  <meta content="Bikeshed version 0060add2b6463a7a7a099173ff2c8a54d3e0ce53" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1424,7 +1424,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-16">16 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-25">25 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1667,6 +1667,7 @@ pre.idl.highlight { color: #708090; }
       <li><a href="#unregister-algorithm"><span class="secno"></span> <span class="content"><span>Unregister</span></span></a>
       <li><a href="#set-registration-algorithm"><span class="secno"></span> <span class="content"><span>Set Registration</span></span></a>
       <li><a href="#clear-registration-algorithm"><span class="secno"></span> <span class="content"><span>Clear Registration</span></span></a>
+      <li><a href="#try-clear-registration-algorithm"><span class="secno"></span> <span class="content"><span>Try Clear Registration</span></span></a>
       <li><a href="#update-registration-state-algorithm"><span class="secno"></span> <span class="content"><span>Update Registration State</span></span></a>
       <li><a href="#update-state-algorithm"><span class="secno"></span> <span class="content"><span>Update Worker State</span></span></a>
       <li><a href="#notify-controller-change-algorithm"><span class="secno"></span> <span class="content"><span>Notify Controller Change</span></span></a>
@@ -1789,12 +1790,10 @@ pre.idl.highlight { color: #708090; }
      <h3 class="heading settled" data-level="2.5" id="task-sources"><span class="secno">2.5. </span><span class="content">Task Sources</span><a class="self-link" href="#task-sources"></a></h3>
      <p>The following additional <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a> are used by <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-35">service workers</a>.</p>
      <dl>
-      <dt data-md="">
-       <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-handle-fetch-task-source">handle fetch task source</dfn></p>
+      <dt data-md="">The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-handle-fetch-task-source">handle fetch task source</dfn>
       <dd data-md="">
        <p>This <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is used for <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatching</a> <code class="idl"><a class="idl-code" data-link-type="event" href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-2">fetch</a></code> events to <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-36">service workers</a>.</p>
-      <dt data-md="">
-       <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-handle-functional-event-task-source">handle functional event task source</dfn></p>
+      <dt data-md="">The <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="dfn-handle-functional-event-task-source">handle functional event task source</dfn>
       <dd data-md="">
        <p>This <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task source</a> is used for features that <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatch</a> other <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-1">functional events</a>, e.g. <code class="idl"><a class="idl-code" data-link-type="event" href="https://w3c.github.io/push-api/#h-the-push-event">push</a></code> events, to <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-37">service workers</a>.</p>
        <p class="note" role="note"><span>Note:</span> A user agent may use a separate task source for each functional event type in order to avoid a head-of-line blocking phenomenon for certain functional events.</p>
@@ -2972,7 +2971,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Decrement the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-4">pending promises count</a> by one.</p>
          <li data-md="">
-          <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-2">Try Activate</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>'s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-18">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>.</p>
+          <p>Let <var>registration</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>'s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-18">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-9">containing service worker registration</a>.</p>
+         <li data-md="">
+          <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-2">uninstalling flag</a> is set, invoke <a data-link-type="dfn" href="#try-clear-registration" id="ref-for-try-clear-registration-1">Try Clear Registration</a> with <var>registration</var>.</p>
+         <li data-md="">
+          <p>If <var>registration</var> is not null, invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-2">Try Activate</a> with <var>registration</var>.</p>
         </ol>
       </ol>
       <p>The user agent <em>should not</em> <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-3">terminate</a> the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-63">service worker</a> associated with <var>event</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a> when <var>event</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#dispatch-flag">dispatch flag</a> is set or <var>event</var>’s <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-5">pending promises count</a> is not zero. However, the user agent <em>may</em> impose a time limit to this lifetime extension.</p>
@@ -3063,7 +3066,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Decrement the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> by one.</p>
          <li data-md="">
-          <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-3">Try Activate</a> with the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>'s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-19">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-10">containing service worker registration</a>.</p>
+          <p>Let <var>registration</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>'s associated <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-19">service worker</a>'s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-10">containing service worker registration</a>.</p>
+         <li data-md="">
+          <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-3">uninstalling flag</a> is set, invoke <a data-link-type="dfn" href="#try-clear-registration" id="ref-for-try-clear-registration-2">Try Clear Registration</a> with <var>registration</var>.</p>
+         <li data-md="">
+          <p>If <var>registration</var> is not null, invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-3">Try Activate</a> with <var>registration</var>.</p>
         </ol>
         <p class="note" role="note"><span>Note:</span> <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-respondwith" id="ref-for-dom-fetchevent-respondwith-3">event.respondWith(r)</a></code> extends the lifetime of the event by default as if <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-5">event.waitUntil(r)</a></code> is called.</p>
        <li data-md="">
@@ -4105,8 +4112,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Create Job">
      <h3 class="heading settled" id="create-job-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="create-job">Create Job</dfn></span><a class="self-link" href="#create-job-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>jobType</var>, a <a data-link-type="dfn" href="#dfn-job-type" id="ref-for-dfn-job-type-2">job type</a></p>
       <dd data-md="">
@@ -4117,8 +4123,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><var>promise</var>, a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a></p>
       <dd data-md="">
        <p><var>client</var>, a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-37">service worker client</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-17">job</a></p>
      </dl>
@@ -4142,12 +4147,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Schedule Job">
      <h3 class="heading settled" id="schedule-job-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="schedule-job">Schedule Job</dfn></span><a class="self-link" href="#schedule-job-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-19">job</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4173,12 +4176,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Run Job">
      <h3 class="heading settled" id="run-job-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="run-job">Run Job</dfn></span><a class="self-link" href="#run-job-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p>none</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4203,12 +4204,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Finish Job">
      <h3 class="heading settled" id="finish-job-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="finish-job">Finish Job</dfn></span><a class="self-link" href="#finish-job-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-20">job</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4224,14 +4223,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Resolve Job Promise">
      <h3 class="heading settled" id="resolve-job-promise-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="resolve-job-promise">Resolve Job Promise</dfn></span><a class="self-link" href="#resolve-job-promise-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-21">job</a></p>
       <dd data-md="">
        <p><var>value</var>, any</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4249,14 +4246,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Reject Job Promise">
      <h3 class="heading settled" id="reject-job-promise-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="reject-job-promise">Reject Job Promise</dfn></span><a class="self-link" href="#reject-job-promise-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-22">job</a></p>
       <dd data-md="">
        <p><var>reason</var>, an <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-exception">exception</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4274,12 +4269,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Register">
      <h3 class="heading settled" id="register-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="register">Register</dfn></span><a class="self-link" href="#register-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-23">job</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4314,7 +4307,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>registration</var> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-2">uninstalling flag</a> is set, unset it.</p>
+         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-4">uninstalling flag</a> is set, unset it.</p>
         <li data-md="">
          <p>Let <var>newestWorker</var> be the result of running the <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-2">Get Newest Worker</a> algorithm passing <var>registration</var> as the argument.</p>
         <li data-md="">
@@ -4339,12 +4332,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Update">
      <h3 class="heading settled" id="update-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="update">Update</dfn></span><a class="self-link" href="#update-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-24">job</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4352,7 +4343,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>registration</var> be the result of running the <a data-link-type="dfn" href="#get-registration" id="ref-for-get-registration-2">Get Registration</a> algorithm passing <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url-8">scope url</a> as the argument.</p>
       <li data-md="">
-       <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-3">uninstalling flag</a> is set, then:</p>
+       <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-5">uninstalling flag</a> is set, then:</p>
        <ol>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise-4">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</p>
@@ -4376,12 +4367,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Switching on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-3">worker type</a>, run these substeps with the following options:</p>
        <dl>
-        <dt data-md="">
-         <p>"<code>classic</code>"</p>
+        <dt data-md="">"<code>classic</code>"
         <dd data-md="">
          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-12">client</a>, "<code>serviceworker</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
-        <dt data-md="">
-         <p>"<code>module</code>"</p>
+        <dt data-md="">"<code>module</code>"
         <dd data-md="">
          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">Fetch a module worker script graph</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client-13">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
        </dl>
@@ -4421,7 +4410,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <p>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.</p>
          </ol>
         <li data-md="">
-         <p>Let <var>serviceWorkerAllowed</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-parse">parsing</a> `<code>Service-Worker-Allowed</code>` in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>.</p>
+         <p>Let <var>serviceWorkerAllowed</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#extract-header-list-values">extracting header list values</a> given `<code>Service-Worker-Allowed</code>` and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>.</p>
          <p class="note" role="note"><span>Note:</span> See the definition of the Service-Worker-Allowed header in Appendix B: Extended HTTP headers.</p>
         <li data-md="">
          <p>Set <var>httpsState</var> to <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-https-state">HTTPS state</a>.</p>
@@ -4522,15 +4511,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <h3 class="heading settled" id="soft-update-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="soft-update">Soft Update</dfn></span><a class="self-link" href="#soft-update-algorithm"></a></h3>
      <p>The user agent <em>may</em> call this as often as it likes to check for updates.</p>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-51">service worker registration</a></p>
       <dd data-md="">
        <p><em>force bypass cache flag</em>, an optional flag unset by default</p>
        <p class="note" role="note"><span>Note:</span> Implementers may use the <em>force bypass cache flag</em> to aid debugging (e.g. invocations from developer tools), and other specifications that extend service workers may also use the flag on their own needs.</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -4552,16 +4539,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Install">
      <h3 class="heading settled" id="installation-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="install">Install</dfn></span><a class="self-link" href="#installation-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-25">job</a></p>
       <dd data-md="">
        <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-88">service worker</a></p>
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-52">service worker registration</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -4641,18 +4626,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Wait for all the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-5">Update Worker State</a> invoked in this algorithm have executed.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-4">Try Activate</a> with <var>registration</var>.</p>
-       <p class="note" role="note"><span>Note:</span> If <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-5">Try Activate</a> does not trigger <a data-link-type="dfn" href="#activate" id="ref-for-activate-7">Activate</a> here, <a data-link-type="dfn" href="#activate" id="ref-for-activate-8">Activate</a> is tried again when the last client controlled by the existing <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-19">active worker</a> is <a data-link-type="dfn" href="#handle-service-worker-client-unload" id="ref-for-handle-service-worker-client-unload-2">unloaded</a>, <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-skipwaiting" id="ref-for-dom-serviceworkerglobalscope-skipwaiting-4">skipWaiting()</a></code> is asynchronously called, and the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-11">extend lifetime promises</a> for the existing <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-20">active worker</a> settle.</p>
+       <p class="note" role="note"><span>Note:</span> If <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-5">Try Activate</a> does not trigger <a data-link-type="dfn" href="#activate" id="ref-for-activate-7">Activate</a> here, <a data-link-type="dfn" href="#activate" id="ref-for-activate-8">Activate</a> is tried again when the last client controlled by the existing <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-19">active worker</a> is <a data-link-type="dfn" href="#handle-service-worker-client-unload" id="ref-for-handle-service-worker-client-unload-2">unloaded</a>, <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-skipwaiting" id="ref-for-dom-serviceworkerglobalscope-skipwaiting-4">skipWaiting()</a></code> is asynchronously called, or the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-11">extend lifetime promises</a> for the existing <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-20">active worker</a> settle.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Activate">
      <h3 class="heading settled" id="activation-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activate">Activate</dfn></span><a class="self-link" href="#activation-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-53">service worker registration</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -4718,12 +4701,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Try Activate">
      <h3 class="heading settled" id="try-activate-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="try-activate">Try Activate</dfn></span><a class="self-link" href="#try-activate-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-54">service worker registration</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -4731,26 +4712,27 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-12">waiting worker</a> is null, return.</p>
       <li data-md="">
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-29">active worker</a> is not null and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-6">state</a> is <em>activating</em>, return.</p>
+       <p class="note" role="note"><span>Note:</span> If the existing active worker is still in activating state, the activation of the waiting worker is delayed.</p>
+      <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-9">Activate</a> with <var>registration</var> if either of the following is true:</p>
        <ul>
         <li data-md="">
-         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-29">active worker</a> is null.</p>
+         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-31">active worker</a> is null.</p>
         <li data-md="">
-         <p>The result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-1">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-30">active worker</a> is true, and no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-41">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-5">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set.</p>
+         <p>The result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-1">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-32">active worker</a> is true, and no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-41">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-5">using</a> <var>registration</var> or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-13">waiting worker</a>'s <a data-link-type="dfn" href="#dfn-skip-waiting-flag" id="ref-for-dfn-skip-waiting-flag-3">skip waiting flag</a> is set.</p>
        </ul>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Run Service Worker">
      <h3 class="heading settled" id="run-service-worker-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="run-service-worker">Run Service Worker</dfn></span><a class="self-link" href="#run-service-worker-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>serviceWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-90">service worker</a></p>
       <dd data-md="">
        <p><em>force bypass cache for importscripts flag</em>, an optional flag unset by default</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -4778,40 +4760,31 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>settingsObject</var> be a new <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> whose algorithms are defined as follows:</p>
        <dl>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">realm execution context</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">realm execution context</a>
         <dd data-md="">
          <p>Return <var>realmExecutionContext</var>.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>
         <dd data-md="">
          <p>Return <var>workerGlobalScope</var>.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a>
         <dd data-md="">
          <p>Return <var>workerEventLoop</var>.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-referrer-policy">referrer policy</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-referrer-policy">referrer policy</a>
         <dd data-md="">
          <p>Return <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-referrer-policy">referrer policy</a>.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding">API URL character encoding</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding">API URL character encoding</a>
         <dd data-md="">
          <p>Return UTF-8.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">API base URL</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">API base URL</a>
         <dd data-md="">
          <p>Return <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url-8">script url</a>.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>
         <dd data-md="">
          <p>Return its registering <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-42">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a>
         <dd data-md="">
          <p>Return <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">url</a>.</p>
-        <dt data-md="">
-         <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state">HTTPS state</a></p>
+        <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state">HTTPS state</a>
         <dd data-md="">
          <p>Return <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state">HTTPS state</a>.</p>
        </dl>
@@ -4828,7 +4801,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Create a new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">WorkerLocation</a></code> object and associate it with <var>workerGlobalScope</var>.</p>
       <li data-md="">
-       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-31">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-15">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
+       <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-33">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-15">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue-3">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task sources</a>.</p>
       <li data-md="">
        <p>If <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">classic script</a>, then <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">run the classic script</a> <var>script</var>. Otherwise, it is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">module script</a>; <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">run the module script</a> <var>script</var>.</p>
        <p class="note" role="note"><span>Note:</span> In addition to the usual possibilities of returning a value or failing due to an exception, this could be prematurely aborted by the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">kill a worker</a> or <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">terminate a worker</a> algorithms.</p>
@@ -4856,12 +4829,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Terminate Service Worker">
      <h3 class="heading settled" id="terminate-service-worker-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="terminate-service-worker">Terminate Service Worker</dfn></span><a class="self-link" href="#terminate-service-worker-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>serviceWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-91">service worker</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -4885,12 +4856,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <h3 class="heading settled" id="on-fetch-request-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="handle-fetch">Handle Fetch</dfn></span><a class="self-link" href="#on-fetch-request-algorithm"></a></h3>
      <p>The <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch-7">Handle Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-92">service worker</a> context.</p>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>request</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>response</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a></p>
      </dl>
@@ -4944,9 +4913,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>registration</var> to the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-10">Match Service Worker Registration</a> algorithm passing <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url">url</a> as the argument.</p>
         <li data-md="">
-         <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-32">active worker</a> is null, return null.</p>
+         <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-34">active worker</a> is null, return null.</p>
         <li data-md="">
-         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-33">active worker</a>.</p>
+         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-35">active worker</a>.</p>
        </ol>
        <p class="note" role="note"><span>Note:</span> From this point, the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-43">service worker client</a> starts to <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-6">use</a> its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-17">containing service worker registration</a>.</p>
       <li data-md="">
@@ -4958,7 +4927,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Else, return null.</p>
        </ol>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-34">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-36">active worker</a>.</p>
       <li data-md="">
        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-2">set of event types to handle</a> does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> <code>fetch</code>, then:</p>
        <ol>
@@ -4971,7 +4940,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        </ol>
        <p class="note" role="note"><span>Note:</span> To avoid unnecessary delays, the Handle Fetch enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
       <li data-md="">
-       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-6">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-7">state</a> to become <em>activated</em>.</p>
+       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-7">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-8">state</a> to become <em>activated</em>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-6">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
@@ -5047,16 +5016,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Handle Functional Event">
      <h3 class="heading settled" id="handle-functional-event-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="handle-functional-event">Handle Functional Event</dfn></span><a class="self-link" href="#handle-functional-event-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>event</var>, an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent-16">ExtendableEvent</a></code> object</p>
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-55">service worker registration</a></p>
       <dd data-md="">
        <p><var>callbackSteps</var>, an algorithm</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5064,9 +5031,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p class="assertion">Assert: <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-7">scope to registration map</a> contains a value equal to <var>registration</var>.</p>
       <li data-md="">
-       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-35">active worker</a> is not null.</p>
+       <p class="assertion">Assert: <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a> is not null.</p>
       <li data-md="">
-       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-36">active worker</a>.</p>
+       <p>Let <var>activeWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a>.</p>
       <li data-md="">
        <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle-3">set of event types to handle</a> does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain">contain</a> <var>event</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code>, then:</p>
        <ol>
@@ -5079,7 +5046,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        </ol>
        <p class="note" role="note"><span>Note:</span> To avoid unnecessary delays, the Handle Functional Event enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
       <li data-md="">
-       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-8">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-9">state</a> to become <em>activated</em>.</p>
+       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-9">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-10">state</a> to become <em>activated</em>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-7">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
@@ -5101,12 +5068,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <h3 class="heading settled" id="on-client-unload-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="handle-service-worker-client-unload">Handle Service Worker Client Unload</dfn></span><a class="self-link" href="#on-client-unload-algorithm"></a></h3>
      <p>The user agent <em>must</em> run these steps when a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-44">service worker client</a> unloads by <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unload-a-document">unloading</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">being killed</a>, or <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-9">terminating</a>.</p>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>client</var>, a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-45">service worker client</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5120,20 +5085,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If any other <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-46">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-8">using</a> <var>registration</var>, abort these steps.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-4">uninstalling flag</a> is set, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-4">Clear Registration</a> algorithm passing <var>registration</var> as its argument and abort these steps.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-6">uninstalling flag</a> is set, invoke <a data-link-type="dfn" href="#try-clear-registration" id="ref-for-try-clear-registration-3">Try Clear Registration</a> with <var>registration</var>.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-14">waiting worker</a> is not null, invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-6">Try Activate</a> with <var>registration</var>.</p>
+       <p>If <var>registration</var> is not null, invoke <a data-link-type="dfn" href="#try-activate" id="ref-for-try-activate-6">Try Activate</a> with <var>registration</var>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle User Agent Shutdown">
      <h3 class="heading settled" id="on-user-agent-shutdown-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="handle-user-agent-shutdown">Handle User Agent Shutdown</dfn></span><a class="self-link" href="#on-user-agent-shutdown-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p>None</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5145,12 +5108,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-12">installing worker</a> <var>installingWorker</var> is not null, then:</p>
          <ol>
           <li data-md="">
-           <p>If the result of running <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-6">Get Newest Worker</a> with <var>registration</var> is <var>installingWorker</var>, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-5">Clear Registration</a> with <var>registration</var> and continue to the next iteration of the loop.</p>
+           <p>If the result of running <a data-link-type="dfn" href="#get-newest-worker" id="ref-for-get-newest-worker-6">Get Newest Worker</a> with <var>registration</var> is <var>installingWorker</var>, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-4">Clear Registration</a> with <var>registration</var> and continue to the next iteration of the loop.</p>
           <li data-md="">
            <p>Else, set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-13">installing worker</a> to null.</p>
          </ol>
         <li data-md="">
-         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-15">waiting worker</a> is not null, run the following substep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
+         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-14">waiting worker</a> is not null, run the following substep <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
          <ol>
           <li data-md="">
            <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate-10">Activate</a> with <var>registration</var>.</p>
@@ -5161,14 +5124,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Update Service Worker Extended Events Set">
      <h3 class="heading settled" id="update-service-worker-extended-events-set-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="update-service-worker-extended-events-set">Update Service Worker Extended Events Set</dfn></span><a class="self-link" href="#update-service-worker-extended-events-set-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-93">service worker</a></p>
       <dd data-md="">
        <p><var>event</var>, an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event">event</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5188,12 +5149,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Unregister">
      <h3 class="heading settled" id="unregister-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unregister">Unregister</dfn></span><a class="self-link" href="#unregister-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>job</var>, a <a data-link-type="dfn" href="#dfn-job" id="ref-for-dfn-job-26">job</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>none</p>
      </dl>
@@ -5217,12 +5176,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-13">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
-       <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-5">uninstalling flag</a>.</p>
+       <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-7">uninstalling flag</a>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise-5">Resolve Job Promise</a> with <var>job</var> and true.</p>
       <li data-md="">
-       <p>If no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-47">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-9">using</a> <var>registration</var>, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-6">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
-       <p class="note" role="note"><span>Note:</span> When the registration is being used for a client, the deletion of the registration is handled by the Handle Service Worker Client Unload algorithm.</p>
+       <p>Invoke <a data-link-type="dfn" href="#try-clear-registration" id="ref-for-try-clear-registration-4">Try Clear Registration</a> with <var>registration</var>.</p>
+       <p class="note" role="note"><span>Note:</span> If <a data-link-type="dfn" href="#try-clear-registration" id="ref-for-try-clear-registration-5">Try Clear Registration</a> does not trigger <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-5">Clear Registration</a> here, <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-6">Clear Registration</a> is tried again when the last client <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-9">using</a> the registration is <a data-link-type="dfn" href="#handle-service-worker-client-unload" id="ref-for-handle-service-worker-client-unload-3">unloaded</a> or the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-12">extend lifetime promises</a> for the registration’s service workers settle.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job-14">Finish Job</a> with <var>job</var>.</p>
      </ol>
@@ -5230,14 +5189,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Set Registration">
      <h3 class="heading settled" id="set-registration-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="set-registration">Set Registration</dfn></span><a class="self-link" href="#set-registration-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>scope</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a></p>
       <dd data-md="">
        <p><var>useCache</var>, a boolean</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-57">service worker registration</a></p>
      </dl>
@@ -5257,12 +5214,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Clear Registration">
      <h3 class="heading settled" id="clear-registration-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="clear-registration">Clear Registration</dfn></span><a class="self-link" href="#clear-registration-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-59">service worker registration</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5270,42 +5225,34 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Run the following steps atomically.</p>
       <li data-md="">
-       <p>Let <var>redundantWorker</var> be null.</p>
-      <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-14">installing worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-15">installing worker</a>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-10">Terminate</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-15">installing worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-10">Terminate</a> <var>redundantWorker</var>.</p>
+         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-9">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-16">installing worker</a> and <em>redundant</em> as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-7">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and null as the arguments.</p>
-        <li data-md="">
-         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-9">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-16">waiting worker</a> is not null, then:</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-15">waiting worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-17">waiting worker</a>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-11">Terminate</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-16">waiting worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-11">Terminate</a> <var>redundantWorker</var>.</p>
+         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-10">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-17">waiting worker</a> and <em>redundant</em> as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-8">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and null as the arguments.</p>
-        <li data-md="">
-         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-10">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-37">active worker</a> is not null, then:</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>redundantWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-38">active worker</a>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-12">Terminate</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker-12">Terminate</a> <var>redundantWorker</var>.</p>
+         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-11">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a> and <em>redundant</em> as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state-9">Update Registration State</a> algorithm passing <var>registration</var>, "<code>active</code>" and null as the arguments.</p>
-        <li data-md="">
-         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state-11">Update Worker State</a> algorithm passing <var>redundantWorker</var> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
        <p>Let <var>scopeString</var> be <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-18">scope url</a> with the <em>exclude fragment flag</em> set.</p>
@@ -5313,19 +5260,40 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-remove">Remove</a> <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-10">scope to registration map</a>[<var>scopeString</var>].</p>
      </ol>
     </section>
+    <section class="algorithm" data-algorithm="Try Clear Registration">
+     <h3 class="heading settled" id="try-clear-registration-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="try-clear-registration">Try Clear Registration</dfn></span><a class="self-link" href="#try-clear-registration-algorithm"></a></h3>
+     <dl>
+      <dt data-md="">Input
+      <dd data-md="">
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-60">service worker registration</a></p>
+      <dt data-md="">Output
+      <dd data-md="">
+       <p>None</p>
+     </dl>
+     <ol>
+      <li data-md="">
+       <p>Invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration-7">Clear Registration</a> with <var>registration</var> if no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-47">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use-10">using</a> <var>registration</var> and all of the following conditions are true:</p>
+       <ul>
+        <li data-md="">
+         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-17">installing worker</a> is null or the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-2">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-18">installing worker</a> is true.</p>
+        <li data-md="">
+         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-18">waiting worker</a> is null or the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-3">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-19">waiting worker</a> is true.</p>
+        <li data-md="">
+         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-42">active worker</a> is null or the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events-4">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-43">active worker</a> is true.</p>
+       </ul>
+     </ol>
+    </section>
     <section class="algorithm" data-algorithm="Update Registration State">
      <h3 class="heading settled" id="update-registration-state-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="update-registration-state">Update Registration State</dfn></span><a class="self-link" href="#update-registration-state-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-60">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-61">service worker registration</a></p>
       <dd data-md="">
        <p><var>target</var>, a string (one of "<code>installing</code>", "<code>waiting</code>", and "<code>active</code>")</p>
       <dd data-md="">
        <p><var>source</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-94">service worker</a> or null</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5336,36 +5304,36 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>target</var> is "<code>installing</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-16">installing worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-installing" id="ref-for-dom-serviceworkerregistration-installing-3">installing</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-25">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-17">installing worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-18">installing worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-installing" id="ref-for-dom-serviceworkerregistration-installing-3">installing</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-25">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-21">installing worker</a> is null.</p>
          </ol>
        </ol>
       <li data-md="">
        <p>Else if <var>target</var> is "<code>waiting</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-18">waiting worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-waiting" id="ref-for-dom-serviceworkerregistration-waiting-3">waiting</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-26">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-19">waiting worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-20">waiting worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-waiting" id="ref-for-dom-serviceworkerregistration-waiting-3">waiting</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-26">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-21">waiting worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-22">waiting worker</a> is null.</p>
          </ol>
        </ol>
       <li data-md="">
        <p>Else if <var>target</var> is "<code>active</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-39">active worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-44">active worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-3">active</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-27">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-40">active worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-41">active worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-active" id="ref-for-dom-serviceworkerregistration-active-3">active</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-27">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-45">active worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-46">active worker</a> is null.</p>
          </ol>
        </ol>
        <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <em>must</em> use <var>registrationObject</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">responsible event loop</a> and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>.</p>
@@ -5374,20 +5342,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Update Worker State">
      <h3 class="heading settled" id="update-state-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="update-worker-state">Update Worker State</dfn></span><a class="self-link" href="#update-state-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-95">service worker</a></p>
       <dd data-md="">
-       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-96">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-10">state</a></p>
-      <dt data-md="">
-       <p>Output</p>
+       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-96">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-11">state</a></p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
      <ol>
       <li data-md="">
-       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-11">state</a> to <var>state</var>.</p>
+       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-12">state</a> to <var>state</var>.</p>
       <li data-md="">
        <p>Let <var>workerObjects</var> be an array containing all the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-28">ServiceWorker</a></code> objects associated with <var>worker</var>.</p>
       <li data-md="">
@@ -5397,30 +5363,25 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to run these substeps:</p>
          <ol>
           <li data-md="">
-           <p>Set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworker-state" id="ref-for-dom-serviceworker-state-5">state</a></code> attribute of <var>workerObject</var> to the value (in <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate-4">ServiceWorkerState</a></code> enumeration) corresponding to the first matching statement, switching on <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-12">state</a>:</p>
+           <p>Set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworker-state" id="ref-for-dom-serviceworker-state-5">state</a></code> attribute of <var>workerObject</var> to the value (in <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate-4">ServiceWorkerState</a></code> enumeration) corresponding to the first matching statement, switching on <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state-13">state</a>:</p>
            <dl>
-            <dt data-md="">
-             <p><em>installing</em></p>
+            <dt data-md=""><em>installing</em>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installing" id="ref-for-dom-serviceworkerstate-installing-1">"installing"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-97">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-19">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-20">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a> is not active until all of the core caches are populated.</p>
-            <dt data-md="">
-             <p><em>installed</em></p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-97">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-22">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-7">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall-2">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-23">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-98">service worker</a> is not active until all of the core caches are populated.</p>
+            <dt data-md=""><em>installed</em>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installed" id="ref-for-dom-serviceworkerstate-installed-1">"installed"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-99">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-21">waiting worker</a>.</p>
-            <dt data-md="">
-             <p><em>activating</em></p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-99">service worker</a> in this state is considered a <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-23">waiting worker</a>.</p>
+            <dt data-md=""><em>activating</em>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activating" id="ref-for-dom-serviceworkerstate-activating-1">"activating"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-42">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-43">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
-            <dt data-md="">
-             <p><em>activated</em></p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-47">active worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil-8">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-onactivate" id="ref-for-dom-serviceworkerglobalscope-onactivate-2">onactivate</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-48">active worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves successfully. No <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional events</a> are dispatched until the state becomes <em>activated</em>.</p>
+            <dt data-md=""><em>activated</em>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-activated" id="ref-for-dom-serviceworkerstate-activated-1">"activated"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-44">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>.</p>
-            <dt data-md="">
-             <p><em>redundant</em></p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-101">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-49">active worker</a> ready to handle <a data-link-type="dfn" href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>.</p>
+            <dt data-md=""><em>redundant</em>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-redundant" id="ref-for-dom-serviceworkerstate-redundant-2">"redundant"</a></code></p>
              <p class="note" role="note"><span>Note:</span> A new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-102">service worker</a> is replacing the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-103">service worker</a>, or the current <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-104">service worker</a> is being discarded due to an install failure.</p>
@@ -5435,12 +5396,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Notify Controller Change">
      <h3 class="heading settled" id="notify-controller-change-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="notify-controller-change">Notify Controller Change</dfn></span><a class="self-link" href="#notify-controller-change-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>client</var>, a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-48">service worker client</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
@@ -5455,14 +5414,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Match Service Worker Registration">
      <h3 class="heading settled" id="scope-match-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="match-service-worker-registration">Match Service Worker Registration</dfn></span><a class="self-link" href="#scope-match-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>clientURL</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-61">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-62">service worker registration</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -5483,7 +5440,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>registration</var> be the result of running <a data-link-type="dfn" href="#get-registration" id="ref-for-get-registration-4">Get Registration</a> algorithm passing <var>parsedMatchingScope</var> as the argument.</p>
       <li data-md="">
-       <p>If <var>registration</var> is not null and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-6">uninstalling flag</a> is set, return null.</p>
+       <p>If <var>registration</var> is not null and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-uninstalling-flag" id="ref-for-dfn-uninstalling-flag-8">uninstalling flag</a> is set, return null.</p>
       <li data-md="">
        <p>Return <var>registration</var>.</p>
      </ol>
@@ -5491,14 +5448,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Get Registration">
      <h3 class="heading settled" id="get-registration-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="get-registration">Get Registration</dfn></span><a class="self-link" href="#get-registration-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>scope</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-62">service worker registration</a></p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-63">service worker registration</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -5522,12 +5477,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Get Newest Worker">
      <h3 class="heading settled" id="get-newest-worker-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="get-newest-worker">Get Newest Worker</dfn></span><a class="self-link" href="#get-newest-worker-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
-       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-63">service worker registration</a></p>
-      <dt data-md="">
-       <p>Output</p>
+       <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-64">service worker registration</a></p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>newestWorker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-105">service worker</a></p>
      </dl>
@@ -5537,11 +5490,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>newestWorker</var> be null.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-21">installing worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-22">installing worker</a>.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-24">installing worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-25">installing worker</a>.</p>
       <li data-md="">
-       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-22">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-23">waiting worker</a>.</p>
+       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-24">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-25">waiting worker</a>.</p>
       <li data-md="">
-       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-45">active worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-46">active worker</a>.</p>
+       <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-50">active worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker-51">active worker</a>.</p>
       <li data-md="">
        <p>Return <var>newestWorker</var>.</p>
      </ol>
@@ -5549,12 +5502,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Service Worker Has No Pending Events">
      <h3 class="heading settled" id="service-worker-has-no-pending-events-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="service-worker-has-no-pending-events">Service Worker Has No Pending Events</dfn></span><a class="self-link" href="#service-worker-has-no-pending-events-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-106">service worker</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p>True or false, a boolean</p>
      </dl>
@@ -5576,12 +5527,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Create Client">
      <h3 class="heading settled" id="create-client-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="create-client">Create Client</dfn></span><a class="self-link" href="#create-client-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>client</var>, a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-49">service worker client</a></p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>clientObject</var>, a <code class="idl"><a data-link-type="idl" href="#client" id="ref-for-client-12">Client</a></code> object</p>
      </dl>
@@ -5599,8 +5548,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Create Window Client">
      <h3 class="heading settled" id="create-windowclient-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="create-window-client">Create Window Client</dfn></span><a class="self-link" href="#create-windowclient-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>client</var>, a <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-50">service worker client</a></p>
       <dd data-md="">
@@ -5609,8 +5557,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><var>focusState</var>, a boolean</p>
       <dd data-md="">
        <p><var>ancestorOriginsList</var>, a list</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>windowClient</var>, a <code class="idl"><a data-link-type="idl" href="#windowclient" id="ref-for-windowclient-11">WindowClient</a></code> object</p>
      </dl>
@@ -5632,16 +5579,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Query Cache">
      <h3 class="heading settled" id="query-cache-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="query-cache">Query Cache</dfn></span><a class="self-link" href="#query-cache-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>request</var>, a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> object</p>
       <dd data-md="">
        <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-cachequeryoptions" id="ref-for-dictdef-cachequeryoptions-7">CacheQueryOptions</a></code> object, optional</p>
       <dd data-md="">
        <p><var>targetStorage</var>, an array that has [<code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code>, <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code>] pairs as its elements, optional</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>resultArray</var>, an array that has [<code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code>, <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code>] pairs as its elements</p>
      </dl>
@@ -5751,12 +5696,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <section class="algorithm" data-algorithm="Batch Cache Operations">
      <h3 class="heading settled" id="batch-cache-operations-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="batch-cache-operations">Batch Cache Operations</dfn></span><a class="self-link" href="#batch-cache-operations-algorithm"></a></h3>
      <dl>
-      <dt data-md="">
-       <p>Input</p>
+      <dt data-md="">Input
       <dd data-md="">
        <p><var>operations</var>, an array of <code class="idl"><a data-link-type="idl" href="#dictdef-cachebatchoperation" id="ref-for-dictdef-cachebatchoperation-4">CacheBatchOperation</a></code> dictionary objects</p>
-      <dt data-md="">
-       <p>Output</p>
+      <dt data-md="">Output
       <dd data-md="">
        <p><var>promise</var>, a <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects">promise</a> resolves with an array of <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> objects</p>
      </dl>
@@ -5853,8 +5796,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <h3 class="heading settled" id="service-worker-script-request"><span class="content">Service Worker Script Request</span><a class="self-link" href="#service-worker-script-request"></a></h3>
      <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-107">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-14">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
-      <dt data-md="">
-       <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker"><code>Service-Worker</code><a class="self-link" href="#service-worker"></a></dfn>`</p>
+      <dt data-md="">`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker"><code>Service-Worker</code><a class="self-link" href="#service-worker"></a></dfn>`
       <dd data-md="">
        <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-108">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-15">script resource</a> request.</p>
        <p class="note" role="note"><span>Note:</span> This header helps administrators log the requests and detect threats.</p>
@@ -5864,8 +5806,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <h3 class="heading settled" id="service-worker-script-response"><span class="content">Service Worker Script Response</span><a class="self-link" href="#service-worker-script-response"></a></h3>
      <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker-109">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource-16">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a>:</p>
      <dl>
-      <dt data-md="">
-       <p>`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker-allowed"><code>Service-Worker-Allowed</code><a class="self-link" href="#service-worker-allowed"></a></dfn>`</p>
+      <dt data-md="">`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker-allowed"><code>Service-Worker-Allowed</code><a class="self-link" href="#service-worker-allowed"></a></dfn>`
       <dd data-md="">
        <p>Indicates the user agent will override the path restriction, which limits the maximum allowed <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url-19">scope url</a> that the script can <a data-link-type="dfn" href="#dfn-control" id="ref-for-dfn-control-4">control</a>, to the given value.</p>
        <p class="note" role="note"><span>Note:</span> The value is a URL. If a relative URL is given, it is parsed against the script’s URL.</p>
@@ -6295,6 +6236,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dfn-service-worker-registration-task-queue">task queues</a><span>, in §2.2</span>
    <li><a href="#terminate-service-worker">Terminate Service Worker</a><span>, in §Unnumbered section</span>
    <li><a href="#try-activate">Try Activate</a><span>, in §Unnumbered section</span>
+   <li><a href="#try-clear-registration">Try Clear Registration</a><span>, in §Unnumbered section</span>
    <li>
     type
     <ul>
@@ -6353,7 +6295,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://w3c.github.io/webappsec-csp/#monitored">monitored</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[WHATWG-DOM]</a> defines the following terms:
+    <a data-link-type="biblio">[DOM]</a> defines the following terms:
     <ul>
      <li><a href="https://dom.spec.whatwg.org/#document">Document</a>
      <li><a href="https://dom.spec.whatwg.org/#event">Event</a>
@@ -6408,6 +6350,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://fetch.spec.whatwg.org/#concept-enqueue-readablestream">enqueue</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-readablestream-errored">errored</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">extract a mime type</a>
+     <li><a href="https://fetch.spec.whatwg.org/#extract-header-list-values">extracting header list values</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a>
      <li><a href="https://fetch.spec.whatwg.org/#dom-global-fetch">fetch(input, init)</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-filtered-response">filtered response</a>
@@ -6430,7 +6373,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>
      <li><a href="https://fetch.spec.whatwg.org/#ok-status">ok status</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">opaque filtered response</a>
-     <li><a href="https://fetch.spec.whatwg.org/#concept-header-parse">parse a header value</a>
      <li><a href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">potential-navigation-or-subresource request</a>
      <li><a href="https://fetch.spec.whatwg.org/#process-response">process response</a>
      <li><a href="https://fetch.spec.whatwg.org/#process-response-done">process response done</a>
@@ -6616,7 +6558,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>
     </ul>
    <li>
-    <a data-link-type="biblio">[WHATWG-URL]</a> defines the following terms:
+    <a data-link-type="biblio">[URL]</a> defines the following terms:
     <ul>
      <li><a href="https://url.spec.whatwg.org/#concept-url-equals">equal</a>
      <li><a href="https://url.spec.whatwg.org/#is-local">is local</a>
@@ -6657,6 +6599,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <dl>
    <dt id="biblio-csp3">[CSP3]
    <dd>Mike West. <a href="https://w3c.github.io/webappsec-csp/">Content Security Policy Level 3</a>. URL: <a href="https://w3c.github.io/webappsec-csp/">https://w3c.github.io/webappsec-csp/</a>
+   <dt id="biblio-dom">[DOM]
+   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-ecmascript">[ECMASCRIPT]
    <dd><a href="https://tc39.github.io/ecma262/">ECMAScript Language Specification</a>. URL: <a href="https://tc39.github.io/ecma262/">https://tc39.github.io/ecma262/</a>
    <dt id="biblio-fetch">[FETCH]
@@ -6681,12 +6625,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <dd>R. Fielding, Ed.; J. Reschke, Ed.. <a href="https://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7231">https://tools.ietf.org/html/rfc7231</a>
    <dt id="biblio-secure-contexts">[SECURE-CONTEXTS]
    <dd>Mike West. <a href="https://w3c.github.io/webappsec-secure-contexts/">Secure Contexts</a>. URL: <a href="https://w3c.github.io/webappsec-secure-contexts/">https://w3c.github.io/webappsec-secure-contexts/</a>
+   <dt id="biblio-url">[URL]
+   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-webidl">[WebIDL]
    <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
-   <dt id="biblio-whatwg-dom">[WHATWG-DOM]
-   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
-   <dt id="biblio-whatwg-url">[WHATWG-URL]
-   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
@@ -6960,9 +6902,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-state-1">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-state-2">(2)</a> <a href="#ref-for-dfn-state-3">(3)</a>
     <li><a href="#ref-for-dfn-state-4">3.1. ServiceWorker</a>
     <li><a href="#ref-for-dfn-state-5">3.2.6. update()</a>
-    <li><a href="#ref-for-dfn-state-6">Handle Fetch</a> <a href="#ref-for-dfn-state-7">(2)</a>
-    <li><a href="#ref-for-dfn-state-8">Handle Functional Event</a> <a href="#ref-for-dfn-state-9">(2)</a>
-    <li><a href="#ref-for-dfn-state-10">Update Worker State</a> <a href="#ref-for-dfn-state-11">(2)</a> <a href="#ref-for-dfn-state-12">(3)</a>
+    <li><a href="#ref-for-dfn-state-6">Try Activate</a>
+    <li><a href="#ref-for-dfn-state-7">Handle Fetch</a> <a href="#ref-for-dfn-state-8">(2)</a>
+    <li><a href="#ref-for-dfn-state-9">Handle Functional Event</a> <a href="#ref-for-dfn-state-10">(2)</a>
+    <li><a href="#ref-for-dfn-state-11">Update Worker State</a> <a href="#ref-for-dfn-state-12">(2)</a> <a href="#ref-for-dfn-state-13">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-script-url">
@@ -7138,10 +7081,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-registration-56">Handle Service Worker Client Unload</a>
     <li><a href="#ref-for-dfn-service-worker-registration-57">Set Registration</a> <a href="#ref-for-dfn-service-worker-registration-58">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-registration-59">Clear Registration</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-60">Update Registration State</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-61">Match Service Worker Registration</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-62">Get Registration</a>
-    <li><a href="#ref-for-dfn-service-worker-registration-63">Get Newest Worker</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-60">Try Clear Registration</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-61">Update Registration State</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-62">Match Service Worker Registration</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-63">Get Registration</a>
+    <li><a href="#ref-for-dfn-service-worker-registration-64">Get Newest Worker</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-scope-url">
@@ -7174,10 +7118,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-installing-worker-6">4.7. Events</a>
     <li><a href="#ref-for-dfn-installing-worker-7">Install</a> <a href="#ref-for-dfn-installing-worker-8">(2)</a> <a href="#ref-for-dfn-installing-worker-9">(3)</a> <a href="#ref-for-dfn-installing-worker-10">(4)</a> <a href="#ref-for-dfn-installing-worker-11">(5)</a>
     <li><a href="#ref-for-dfn-installing-worker-12">Handle User Agent Shutdown</a> <a href="#ref-for-dfn-installing-worker-13">(2)</a>
-    <li><a href="#ref-for-dfn-installing-worker-14">Clear Registration</a> <a href="#ref-for-dfn-installing-worker-15">(2)</a>
-    <li><a href="#ref-for-dfn-installing-worker-16">Update Registration State</a> <a href="#ref-for-dfn-installing-worker-17">(2)</a> <a href="#ref-for-dfn-installing-worker-18">(3)</a>
-    <li><a href="#ref-for-dfn-installing-worker-19">Update Worker State</a> <a href="#ref-for-dfn-installing-worker-20">(2)</a>
-    <li><a href="#ref-for-dfn-installing-worker-21">Get Newest Worker</a> <a href="#ref-for-dfn-installing-worker-22">(2)</a>
+    <li><a href="#ref-for-dfn-installing-worker-14">Clear Registration</a> <a href="#ref-for-dfn-installing-worker-15">(2)</a> <a href="#ref-for-dfn-installing-worker-16">(3)</a>
+    <li><a href="#ref-for-dfn-installing-worker-17">Try Clear Registration</a> <a href="#ref-for-dfn-installing-worker-18">(2)</a>
+    <li><a href="#ref-for-dfn-installing-worker-19">Update Registration State</a> <a href="#ref-for-dfn-installing-worker-20">(2)</a> <a href="#ref-for-dfn-installing-worker-21">(3)</a>
+    <li><a href="#ref-for-dfn-installing-worker-22">Update Worker State</a> <a href="#ref-for-dfn-installing-worker-23">(2)</a>
+    <li><a href="#ref-for-dfn-installing-worker-24">Get Newest Worker</a> <a href="#ref-for-dfn-installing-worker-25">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-waiting-worker">
@@ -7190,12 +7135,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-waiting-worker-6">Install</a> <a href="#ref-for-dfn-waiting-worker-7">(2)</a> <a href="#ref-for-dfn-waiting-worker-8">(3)</a> <a href="#ref-for-dfn-waiting-worker-9">(4)</a>
     <li><a href="#ref-for-dfn-waiting-worker-10">Activate</a> <a href="#ref-for-dfn-waiting-worker-11">(2)</a>
     <li><a href="#ref-for-dfn-waiting-worker-12">Try Activate</a> <a href="#ref-for-dfn-waiting-worker-13">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-14">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-dfn-waiting-worker-15">Handle User Agent Shutdown</a>
-    <li><a href="#ref-for-dfn-waiting-worker-16">Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-17">(2)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-18">Update Registration State</a> <a href="#ref-for-dfn-waiting-worker-19">(2)</a> <a href="#ref-for-dfn-waiting-worker-20">(3)</a>
-    <li><a href="#ref-for-dfn-waiting-worker-21">Update Worker State</a>
-    <li><a href="#ref-for-dfn-waiting-worker-22">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker-23">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-14">Handle User Agent Shutdown</a>
+    <li><a href="#ref-for-dfn-waiting-worker-15">Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-16">(2)</a> <a href="#ref-for-dfn-waiting-worker-17">(3)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-18">Try Clear Registration</a> <a href="#ref-for-dfn-waiting-worker-19">(2)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-20">Update Registration State</a> <a href="#ref-for-dfn-waiting-worker-21">(2)</a> <a href="#ref-for-dfn-waiting-worker-22">(3)</a>
+    <li><a href="#ref-for-dfn-waiting-worker-23">Update Worker State</a>
+    <li><a href="#ref-for-dfn-waiting-worker-24">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker-25">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-active-worker">
@@ -7212,14 +7157,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-active-worker-18">4.7. Events</a>
     <li><a href="#ref-for-dfn-active-worker-19">Install</a> <a href="#ref-for-dfn-active-worker-20">(2)</a>
     <li><a href="#ref-for-dfn-active-worker-21">Activate</a> <a href="#ref-for-dfn-active-worker-22">(2)</a> <a href="#ref-for-dfn-active-worker-23">(3)</a> <a href="#ref-for-dfn-active-worker-24">(4)</a> <a href="#ref-for-dfn-active-worker-25">(5)</a> <a href="#ref-for-dfn-active-worker-26">(6)</a> <a href="#ref-for-dfn-active-worker-27">(7)</a> <a href="#ref-for-dfn-active-worker-28">(8)</a>
-    <li><a href="#ref-for-dfn-active-worker-29">Try Activate</a> <a href="#ref-for-dfn-active-worker-30">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-31">Run Service Worker</a>
-    <li><a href="#ref-for-dfn-active-worker-32">Handle Fetch</a> <a href="#ref-for-dfn-active-worker-33">(2)</a> <a href="#ref-for-dfn-active-worker-34">(3)</a>
-    <li><a href="#ref-for-dfn-active-worker-35">Handle Functional Event</a> <a href="#ref-for-dfn-active-worker-36">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-37">Clear Registration</a> <a href="#ref-for-dfn-active-worker-38">(2)</a>
-    <li><a href="#ref-for-dfn-active-worker-39">Update Registration State</a> <a href="#ref-for-dfn-active-worker-40">(2)</a> <a href="#ref-for-dfn-active-worker-41">(3)</a>
-    <li><a href="#ref-for-dfn-active-worker-42">Update Worker State</a> <a href="#ref-for-dfn-active-worker-43">(2)</a> <a href="#ref-for-dfn-active-worker-44">(3)</a>
-    <li><a href="#ref-for-dfn-active-worker-45">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker-46">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-29">Try Activate</a> <a href="#ref-for-dfn-active-worker-30">(2)</a> <a href="#ref-for-dfn-active-worker-31">(3)</a> <a href="#ref-for-dfn-active-worker-32">(4)</a>
+    <li><a href="#ref-for-dfn-active-worker-33">Run Service Worker</a>
+    <li><a href="#ref-for-dfn-active-worker-34">Handle Fetch</a> <a href="#ref-for-dfn-active-worker-35">(2)</a> <a href="#ref-for-dfn-active-worker-36">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-37">Handle Functional Event</a> <a href="#ref-for-dfn-active-worker-38">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-39">Clear Registration</a> <a href="#ref-for-dfn-active-worker-40">(2)</a> <a href="#ref-for-dfn-active-worker-41">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-42">Try Clear Registration</a> <a href="#ref-for-dfn-active-worker-43">(2)</a>
+    <li><a href="#ref-for-dfn-active-worker-44">Update Registration State</a> <a href="#ref-for-dfn-active-worker-45">(2)</a> <a href="#ref-for-dfn-active-worker-46">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-47">Update Worker State</a> <a href="#ref-for-dfn-active-worker-48">(2)</a> <a href="#ref-for-dfn-active-worker-49">(3)</a>
+    <li><a href="#ref-for-dfn-active-worker-50">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker-51">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-last-update-check-time">
@@ -7245,11 +7191,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dfn-uninstalling-flag">#dfn-uninstalling-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-uninstalling-flag-1">3.4.5. getRegistrations()</a>
-    <li><a href="#ref-for-dfn-uninstalling-flag-2">Register</a>
-    <li><a href="#ref-for-dfn-uninstalling-flag-3">Update</a>
-    <li><a href="#ref-for-dfn-uninstalling-flag-4">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-dfn-uninstalling-flag-5">Unregister</a>
-    <li><a href="#ref-for-dfn-uninstalling-flag-6">Match Service Worker Registration</a>
+    <li><a href="#ref-for-dfn-uninstalling-flag-2">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-dfn-uninstalling-flag-3">4.5.5. event.respondWith(r)</a>
+    <li><a href="#ref-for-dfn-uninstalling-flag-4">Register</a>
+    <li><a href="#ref-for-dfn-uninstalling-flag-5">Update</a>
+    <li><a href="#ref-for-dfn-uninstalling-flag-6">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-dfn-uninstalling-flag-7">Unregister</a>
+    <li><a href="#ref-for-dfn-uninstalling-flag-8">Match Service Worker Registration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-service-worker-registration-task-queue">
@@ -7288,7 +7236,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-service-worker-client-42">Run Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-client-43">Handle Fetch</a>
     <li><a href="#ref-for-dfn-service-worker-client-44">Handle Service Worker Client Unload</a> <a href="#ref-for-dfn-service-worker-client-45">(2)</a> <a href="#ref-for-dfn-service-worker-client-46">(3)</a>
-    <li><a href="#ref-for-dfn-service-worker-client-47">Unregister</a>
+    <li><a href="#ref-for-dfn-service-worker-client-47">Try Clear Registration</a>
     <li><a href="#ref-for-dfn-service-worker-client-48">Notify Controller Change</a>
     <li><a href="#ref-for-dfn-service-worker-client-49">Create Client</a>
     <li><a href="#ref-for-dfn-service-worker-client-50">Create Window Client</a>
@@ -7361,6 +7309,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-use-6">Handle Fetch</a>
     <li><a href="#ref-for-dfn-use-7">Handle Service Worker Client Unload</a> <a href="#ref-for-dfn-use-8">(2)</a>
     <li><a href="#ref-for-dfn-use-9">Unregister</a>
+    <li><a href="#ref-for-dfn-use-10">Try Clear Registration</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-handle-fetch-task-source">
@@ -8056,6 +8005,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-8">4.4.1. event.waitUntil(f)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-9">4.5.5. event.respondWith(r)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises-10">Install</a> <a href="#ref-for-extendableevent-extend-lifetime-promises-11">(2)</a>
+    <li><a href="#ref-for-extendableevent-extend-lifetime-promises-12">Unregister</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="extendableevent-pending-promises-count">
@@ -8778,6 +8728,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-handle-service-worker-client-unload-1">4.3.4. claim()</a>
     <li><a href="#ref-for-handle-service-worker-client-unload-2">Install</a>
+    <li><a href="#ref-for-handle-service-worker-client-unload-3">Unregister</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="handle-user-agent-shutdown">
@@ -8812,9 +8763,18 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-clear-registration-1">Update</a> <a href="#ref-for-clear-registration-2">(2)</a>
     <li><a href="#ref-for-clear-registration-3">Install</a>
-    <li><a href="#ref-for-clear-registration-4">Handle Service Worker Client Unload</a>
-    <li><a href="#ref-for-clear-registration-5">Handle User Agent Shutdown</a>
-    <li><a href="#ref-for-clear-registration-6">Unregister</a>
+    <li><a href="#ref-for-clear-registration-4">Handle User Agent Shutdown</a>
+    <li><a href="#ref-for-clear-registration-5">Unregister</a> <a href="#ref-for-clear-registration-6">(2)</a>
+    <li><a href="#ref-for-clear-registration-7">Try Clear Registration</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="try-clear-registration">
+   <b><a href="#try-clear-registration">#try-clear-registration</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-try-clear-registration-1">4.4.1. event.waitUntil(f)</a>
+    <li><a href="#ref-for-try-clear-registration-2">4.5.5. event.respondWith(r)</a>
+    <li><a href="#ref-for-try-clear-registration-3">Handle Service Worker Client Unload</a>
+    <li><a href="#ref-for-try-clear-registration-4">Unregister</a> <a href="#ref-for-try-clear-registration-5">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="update-registration-state">
@@ -8877,6 +8837,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#service-worker-has-no-pending-events">#service-worker-has-no-pending-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-has-no-pending-events-1">Try Activate</a>
+    <li><a href="#ref-for-service-worker-has-no-pending-events-2">Try Clear Registration</a> <a href="#ref-for-service-worker-has-no-pending-events-3">(2)</a> <a href="#ref-for-service-worker-has-no-pending-events-4">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="create-client">


### PR DESCRIPTION
This is a follow-up change, to [1], which addresses the issues posed in
[2] and the comments afterwards.

This change makes the callers to the Clear Registration algorithm to
check if no client is using the registration and the registration's
associated service workers have no pending extended events before
invoking the algorithm. Unregister, Handle Service Worker Client Unload,
and the microtasks queued by the extension promises' settlement handlers
invoke Try Clear Registration.

Other error handling steps on registrations that have no associated
worker and Handle User Agent Shutdown invoke Clear Registration directly
as they do.

[1] https://github.com/w3c/ServiceWorker/commit/f1a1120ff07120a2e8f311fb61f429c9a74db1ef
[2] https://github.com/w3c/ServiceWorker/issues/916#issuecomment-237272060

Summary of the issues: https://github.com/w3c/ServiceWorker/issues/916#issuecomment-281274267.

Fixes #916.