### PR TITLE
Cast `resolveWith` argument to a Promise

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1457,12 +1457,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. If the [=FetchEvent/respond-with entered flag=] is set, then:
             1. <a>Throw</a> an "{{InvalidStateError}}" exception.
             1. Abort these steps.
-        1. Add |r| to the <a>extend lifetime promises</a>.
+        1. Let |promise| be <a>a promise resolved with</a> |r|.
+        1. Add |promise| to the <a>extend lifetime promises</a>.
         1. Increment the [=ExtendableEvent/pending promises count=] by one.
 
             Note: The [=ExtendableEvent/pending promises count=] is incremented even if the given promise has already been settled. The corresponding count decrement is done in the microtask queued by the reaction to the promise.
 
-        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |r|, [=queue a microtask=] to run these substeps:
+        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |promise|, [=queue a microtask=] to run these substeps:
             1. Decrement the [=ExtendableEvent/pending promises count=] by one.
             1. Let |registration| be the [=context object=]'s [=relevant global object=]'s associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
             1. If |registration|'s [=uninstalling flag=] is set, invoke [=Try Clear Registration=] with |registration|.
@@ -1475,10 +1476,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Set the [=FetchEvent/wait to respond flag=].
         1. Let |targetRealm| be the <a>relevant Realm</a> of the <a>context object</a>.
         1. Run the following substeps <a>in parallel</a>:
-            1. Wait until |r| settles.
-            1. If |r| rejected, then:
+            1. Wait until |promise| settles.
+            1. If |promise| rejected, then:
                 1. Set the [=FetchEvent/respond-with error flag=].
-            1. If |r| resolved with |response|, then:
+            1. If |promise| resolved with |response|, then:
                 1. If |response| is a {{Response}} object, then:
                     1. If |response| is [=Body/disturbed=] or [=Body/locked=], then:
                         1. Set the [=FetchEvent/respond-with error flag=].

--- a/docs/index.html
+++ b/docs/index.html
@@ -3230,12 +3230,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
           <p>Abort these steps.</p>
         </ol>
        <li data-md="">
-        <p>Add <var>r</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-9">extend lifetime promises</a>.</p>
+        <p>Let <var>promise</var> be <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-resolved-with">a promise resolved with</a> <var>r</var>.</p>
+       <li data-md="">
+        <p>Add <var>promise</var> to the <a data-link-type="dfn" href="#extendableevent-extend-lifetime-promises" id="ref-for-extendableevent-extend-lifetime-promises-9">extend lifetime promises</a>.</p>
        <li data-md="">
         <p>Increment the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-6">pending promises count</a> by one.</p>
         <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-7">pending promises count</a> is incremented even if the given promise has already been settled. The corresponding count decrement is done in the microtask queued by the reaction to the promise.</p>
        <li data-md="">
-        <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>r</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a> to run these substeps:</p>
+        <p>Upon <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">fulfillment</a> or <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">rejection</a> of <var>promise</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a> to run these substeps:</p>
         <ol>
          <li data-md="">
           <p>Decrement the <a data-link-type="dfn" href="#extendableevent-pending-promises-count" id="ref-for-extendableevent-pending-promises-count-8">pending promises count</a> by one.</p>
@@ -3259,15 +3261,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
         <ol>
          <li data-md="">
-          <p>Wait until <var>r</var> settles.</p>
+          <p>Wait until <var>promise</var> settles.</p>
          <li data-md="">
-          <p>If <var>r</var> rejected, then:</p>
+          <p>If <var>promise</var> rejected, then:</p>
           <ol>
            <li data-md="">
             <p>Set the <a data-link-type="dfn" href="#fetchevent-respond-with-error-flag" id="ref-for-fetchevent-respond-with-error-flag-1">respond-with error flag</a>.</p>
           </ol>
          <li data-md="">
-          <p>If <var>r</var> resolved with <var>response</var>, then:</p>
+          <p>If <var>promise</var> resolved with <var>response</var>, then:</p>
           <ol>
            <li data-md="">
             <p>If <var>response</var> is a <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#response">Response</a></code> object, then:</p>
@@ -7462,6 +7464,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <a data-link-type="biblio">[promises-guide]</a> defines the following terms:
     <ul>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-resolved-with">a promise resolved with</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise">reject</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise">resolve</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#transforming-by">transforming</a>


### PR DESCRIPTION
The non-normative Note that describes the `event.respondWith` algorithm
states:

> Developers can set the argument r with either a promise that resolves
> with a Response object or a Response object (which is automatically
> cast to a promise). [...]

Previously, the algorithm did not explicitly perform such type casting.

Insert an additional step to harmonize the algorithm and its
description.