### PR TITLE
Use [SameObject] for the navigationPreload attribute

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -402,7 +402,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         readonly attribute ServiceWorker? installing;
         readonly attribute ServiceWorker? waiting;
         readonly attribute ServiceWorker? active;
-        readonly attribute NavigationPreloadManager navigationPreload;
+        [SameObject] readonly attribute NavigationPreloadManager navigationPreload;
 
         readonly attribute USVString scope;
         readonly attribute boolean useCache;


### PR DESCRIPTION
The spec says "A service worker registration has an associated
NavigationPreloadManager object" and this object never changes. This is
also true of Blink's implementation.