### PR TITLE
Add a link to web-platform-tests to the top of the spec

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -149,7 +149,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     A [=/service worker=] has an associated <dfn export id="dfn-service-worker-id">id</dfn> (an opaque string), which uniquely identifies itself during the lifetime of its <a>containing service worker registration</a>.
 
     A [=/service worker=] has an associated <dfn export id="dfn-service-worker-global-object" for="service worker">global object</dfn> (a {{ServiceWorkerGlobalScope}} object or null).
-    
+
     A [=/service worker=] is dispatched a set of <dfn export id="dfn-lifecycle-events">lifecycle events</dfn>, {{install!!event}} and {{activate!!event}}, and <dfn export id="dfn-functional-events">functional events</dfn> including {{fetch!!event}}.
 
     A [=/service worker=] has an associated <dfn export id="dfn-script-resource">script resource</dfn> (a <a>script</a>), which represents its own script resource. It is initially set to null.
@@ -348,7 +348,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       The <dfn method for="ServiceWorker"><code>postMessage(|message|, |transfer|)</code></dfn> method *must* run these steps:
 
-        1. If the {{ServiceWorker/state}} attribute value of the <a>context object</a> is {{"redundant"}}, <a>throw</a> an "{{InvalidStateError}}" exception and abort these steps. 
+        1. If the {{ServiceWorker/state}} attribute value of the <a>context object</a> is {{"redundant"}}, <a>throw</a> an "{{InvalidStateError}}" exception and abort these steps.
         1. Let |serviceWorker| be the [=/service worker=] represented by the <a>context object</a>.
         1. Invoke <a>Run Service Worker</a> algorithm with |serviceWorker| as the argument.
         1. Let |destination| be the {{ServiceWorkerGlobalScope}} object associated with |serviceWorker|.
@@ -593,9 +593,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Run the following substeps <a>in parallel</a>:
             1. *CheckRegistration*: If the result of running <a>Match Service Worker Registration</a> algorithm with |clientURL| as its argument is not null, then:
                 1. Set |registration| to the result value.
-            1. Else:  
+            1. Else:
                 1. Wait until <a>scope to registration map</a> has a new entry.
-                1. Jump to the step labeled *CheckRegistration*.  
+                1. Jump to the step labeled *CheckRegistration*.
             1. If |registration|'s <a>active worker</a> is null, wait until |registration|'s <a>active worker</a> changes.
 
                 Note: Implementers should consider this condition is met when the corresponding registration request gets to the step 6 of <a>Activate</a> algorithm.
@@ -1797,7 +1797,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         Link: &lt;/js/sw.js&gt;; rel="serviceworker"; scope="/"
       </pre>
 
-      has more or less the same effect as a document being loaded in a secure context with the following 
+      has more or less the same effect as a document being loaded in a secure context with the following
       <code>link</code> element:
 
       <pre highlight="html">
@@ -1995,9 +1995,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
                         1. Let |varyHeaders| be the array containing the elements corresponding to the [=http/field-values=] of the <a>Vary</a> header.
                         1. Let |matchAsterisk| be false.
                         1. For each |f| in |varyHeaders|:
-                            1. If |f| matches "<code>*</code>", set |matchAsterisk| to true and break the loop.      
+                            1. If |f| matches "<code>*</code>", set |matchAsterisk| to true and break the loop.
                         1. If |matchAsterisk| is true, reject |responsePromise| with a <code>TypeError</code>.
-                        1. Else, resolve |responsePromise| with a new {{Response}} object associated with |response| and a new {{Headers}} object whose <a>guard</a> is "<code>immutable</code>".  
+                        1. Else, resolve |responsePromise| with a new {{Response}} object associated with |response| and a new {{Headers}} object whose <a>guard</a> is "<code>immutable</code>".
                     1. Else, resolve |responsePromise| with a new {{Response}} object associated with |response| and a new {{Headers}} object whose <a>guard</a> is "<code>immutable</code>".
 
                     Note: This step ensures that the promise for this fetch resolves as soon as the response's headers become available.
@@ -2930,9 +2930,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. Set |preloadRequest|'s [=service-workers mode=] to "`none`".
               1. Run the following substeps [=in parallel=]:
                   1. [=Fetch=] |preloadRequest|.
-                    
+
                       To [=process response=] for |navigationPreloadResponse|, run these substeps:
-                      
+
                       1. If |navigationPreloadResponse|'s [=response/type=] is "`error`", reject |preloadResponse| with a `TypeError` and terminate these substeps.
                       1. Associate |preloadResponseObject| with |navigationPreloadResponse|.
                       1. Resolve |preloadResponse| with |navigationPreloadResponse|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -11,6 +11,7 @@ Editor: Jake Archibald, Google, jakearchibald@chromium.org
 Editor: Marijn Kruisselbrink, Google, mek@chromium.org
 Repository: w3c/ServiceWorker
 Group: webplatform
+!Tests: <a href=https://github.com/w3c/web-platform-tests/tree/master/service-workers>web-platform-tests service-workers/</a> (<a href=https://github.com/w3c/web-platform-tests/labels/service-workers>ongoing work</a>)
 Status Text: This is a living document addressing new features including foreign fetch, header-based installation, navigation preload, etc. Readers need to be aware that this specification may include unstable features. <a href="https://w3c.github.io/ServiceWorker/v1/">Service Workers 1</a> is a version that is advancing toward a W3C Recommendation.
 Abstract: This specification describes a method that enables applications to take advantage of persistent background processing, including hooks to enable bootstrapping of web applications while offline.
 Abstract:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1440,6 +1440,8 @@ pre.idl.highlight { color: #708090; }
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:jungkee.song@samsung.com">Jungkee Song</a> (<span class="p-org org">Samsung Electronics</span>)
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:jakearchibald@chromium.org">Jake Archibald</a> (<span class="p-org org">Google</span>)
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:mek@chromium.org">Marijn Kruisselbrink</a> (<span class="p-org org">Google</span>)
+     <dt>Tests:
+     <dd><span><a href="https://github.com/w3c/web-platform-tests/tree/master/service-workers">web-platform-tests service-workers/</a> (<a href="https://github.com/w3c/web-platform-tests/labels/service-workers">ongoing work</a>)</span>
     </dl>
    </div>
    <div data-fill-with="warning"></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1177,7 +1177,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version aa692b5bb18791d7660cd494994fd0ac2ec23132" name="generator">
+  <meta content="Bikeshed version 2694cf87482eb631bb8582afc69be1fae22f2bff" name="generator">
   <link href="https://www.w3.org/TR/service-workers/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1425,7 +1425,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-04-19">19 April 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-04-20">20 April 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:


### PR DESCRIPTION
A few other specs that have something similar:
https://fetch.spec.whatwg.org/
https://w3c.github.io/IndexedDB/
https://notifications.spec.whatwg.org/
https://xhr.spec.whatwg.org/

(Also removed trailing whitespace as a first commit)