### PR TITLE
Remove duplicate step from "Update" algorithm

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2613,10 +2613,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
           1. Set |request|'s [=service-workers mode=] to "`none`".
           1. If the [=fetching scripts/is top-level=] flag is unset, then return the result of [=/fetching=] |request|.
-          1. Append \`<code>Service-Worker</code>\`/\`<code>script</code>\` to |request|'s [=request/header list=].
-
-            Note: See the definition of the Service-Worker header in Appendix B: Extended HTTP headers.
-
           1. Set |request|'s [=request/redirect mode=] to "<code>error</code>".
           1. [=/Fetch=] |request|, and asynchronously wait to run the remaining steps as part of fetch's <a>process response</a> for the [=/response=] |response|.
           1. [=Extract a MIME type=] from the |response|'s [=response/header list=]. If this MIME type (ignoring parameters) is not a [=JavaScript MIME type=], then:

--- a/docs/index.html
+++ b/docs/index.html
@@ -4917,9 +4917,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-is-top-level">is top-level</a> flag is unset, then return the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetching</a> <var>request</var>.</p>
         <li data-md="">
-         <p>Append `<code>Service-Worker</code>`/`<code>script</code>` to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-header-list">header list</a>.</p>
-         <p class="note" role="note"><span>Note:</span> See the definition of the Service-Worker header in Appendix B: Extended HTTP headers.</p>
-        <li data-md="">
          <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">redirect mode</a> to "<code>error</code>".</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> <var>request</var>, and asynchronously wait to run the remaining steps as part of fetch’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#process-response">process response</a> for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> <var>response</var>.</p>


### PR DESCRIPTION
The `Service-Worker` header is appended to the request's header list in
a prior algorithm step.