### PR TITLE
Editorial: Simplify `ready`

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -596,12 +596,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
         1. If the <a>context object</a>'s [=ServiceWorkerContainer/ready promise=] is settled, return the <a>context object</a>'s [=ServiceWorkerContainer/ready promise=].
         1. Let |client| be the <a>context object</a>'s [=ServiceWorkerContainer/service worker client=].
-        1. Let |registration| be null.
         1. Let |clientURL| be |client|'s <a>creation URL</a>.
         1. Run the following substeps <a>in parallel</a>:
-            1. *CheckRegistration*: If the result of running <a>Match Service Worker Registration</a> algorithm with |clientURL| as its argument is not null, then:
-                1. Set |registration| to the result value.
-            1. Else:
+            1. *CheckRegistration*: Let |registration| be the result of running <a>Match Service Worker Registration</a> algorithm with |clientURL|.
+            1. If |registration| is null, then:
                 1. Wait until <a>scope to registration map</a> has a new entry.
                 1. Jump to the step labeled *CheckRegistration*.
             1. If |registration|'s <a>active worker</a> is null, wait until |registration|'s <a>active worker</a> changes.

--- a/docs/index.html
+++ b/docs/index.html
@@ -2133,20 +2133,14 @@ pre.idl.highlight { color: #708090; }
        <li data-md="">
         <p>Let <var>client</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a>’s <a data-link-type="dfn" href="#serviceworkercontainer-service-worker-client" id="ref-for-serviceworkercontainer-service-worker-client-2">service worker client</a>.</p>
        <li data-md="">
-        <p>Let <var>registration</var> be null.</p>
-       <li data-md="">
         <p>Let <var>clientURL</var> be <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">creation URL</a>.</p>
        <li data-md="">
         <p>Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>:</p>
         <ol>
          <li data-md="">
-          <p><em>CheckRegistration</em>: If the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-5">Match Service Worker Registration</a> algorithm with <var>clientURL</var> as its argument is not null, then:</p>
-          <ol>
-           <li data-md="">
-            <p>Set <var>registration</var> to the result value.</p>
-          </ol>
+          <p><em>CheckRegistration</em>: Let <var>registration</var> be the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration-5">Match Service Worker Registration</a> algorithm with <var>clientURL</var>.</p>
          <li data-md="">
-          <p>Else:</p>
+          <p>If <var>registration</var> is null, then:</p>
           <ol>
            <li data-md="">
             <p>Wait until <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map-4">scope to registration map</a> has a new entry.</p>


### PR DESCRIPTION
The previous structure for the `ready` algorithm involved a recursive
path through an "else" branch. This tended to obscure the fact that the
corresponding branch was *not* recursive and that the following steps
were indeed reachable.

Re-factor the algorithm to include fewer total branches and to contain
the recursion more tightly.

---

I recognize that this is pretty subjective, so I'll be satisfied with the
opinion of the editors, whatever that is.