### PR TITLE
Extend attribute ref with link to external spec

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2891,7 +2891,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       1. If |serviceWorker| is not running, abort these steps.
       1. Let |serviceWorkerGlobalScope| be |serviceWorker|'s [=service worker/global object=].
-      1. Set |serviceWorkerGlobalScope|'s closing flag to true.
+      1. Set |serviceWorkerGlobalScope|'s {{closing!!attribute}} flag to true.
       1. [=set/Remove=] all the [=items=] from |serviceWorker|'s [=set of extended events=].
       1. If there are any <a>tasks</a>, whose <a>task source</a> is either the <a>handle fetch task source</a> or the <a>handle functional event task source</a>, queued in |serviceWorkerGlobalScope|'s <a>event loop</a>'s [=/task queues=], <a lt="queue a task">queue</a> them to |serviceWorker|'s <a>containing service worker registration</a>'s corresponding [=service worker registration/task queues=] in the same order using their original <a>task sources</a>, and discard all the <a>tasks</a> (including <a>tasks</a> whose <a>task source</a> is neither the <a>handle fetch task source</a> nor the <a>handle functional event task source</a>) from |serviceWorkerGlobalScope|'s <a>event loop</a>'s [=/task queues=] without processing them.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2891,7 +2891,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       1. If |serviceWorker| is not running, abort these steps.
       1. Let |serviceWorkerGlobalScope| be |serviceWorker|'s [=service worker/global object=].
-      1. Set |serviceWorkerGlobalScope|'s {{closing!!attribute}} flag to true.
+      1. Set |serviceWorkerGlobalScope|'s [=WorkerGlobalScope/closing=] flag to true.
       1. [=set/Remove=] all the [=items=] from |serviceWorker|'s [=set of extended events=].
       1. If there are any <a>tasks</a>, whose <a>task source</a> is either the <a>handle fetch task source</a> or the <a>handle functional event task source</a>, queued in |serviceWorkerGlobalScope|'s <a>event loop</a>'s [=/task queues=], <a lt="queue a task">queue</a> them to |serviceWorker|'s <a>containing service worker registration</a>'s corresponding [=service worker registration/task queues=] in the same order using their original <a>task sources</a>, and discard all the <a>tasks</a> (including <a>tasks</a> whose <a>task source</a> is neither the <a>handle fetch task source</a> nor the <a>handle functional event task source</a>) from |serviceWorkerGlobalScope|'s <a>event loop</a>'s [=/task queues=] without processing them.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -5370,7 +5370,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>serviceWorkerGlobalScope</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-4">global object</a>.</p>
       <li data-md="">
-       <p>Set <var>serviceWorkerGlobalScope</var>’s closing flag to true.</p>
+       <p>Set <var>serviceWorkerGlobalScope</var>’s <code class="idl"><a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-closing">closing</a></code> flag to true.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove">Remove</a> all the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item">items</a> from <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-1">set of extended events</a>.</p>
       <li data-md="">

--- a/docs/index.html
+++ b/docs/index.html
@@ -5370,7 +5370,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>serviceWorkerGlobalScope</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-4">global object</a>.</p>
       <li data-md="">
-       <p>Set <var>serviceWorkerGlobalScope</var>’s <code class="idl"><a class="idl-code" data-link-type="attribute" href="https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-closing">closing</a></code> flag to true.</p>
+       <p>Set <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn">closing</a> flag to true.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove">Remove</a> all the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item">items</a> from <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-1">set of extended events</a>.</p>
       <li data-md="">

--- a/docs/index.html
+++ b/docs/index.html
@@ -5370,7 +5370,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>serviceWorkerGlobalScope</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-4">global object</a>.</p>
       <li data-md="">
-       <p>Set <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn">closing</a> flag to true.</p>
+       <p>Set <var>serviceWorkerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-closing">closing</a> flag to true.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove">Remove</a> all the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item">items</a> from <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-set-of-extended-events" id="ref-for-dfn-set-of-extended-events-1">set of extended events</a>.</p>
       <li data-md="">


### PR DESCRIPTION
Because the "closing" attribute is not referenced elsewhere within the
specification, this step may cause confusion for readers who are not
familiar with its origins in the Workers specification. Extend the
reference to include a hyperlink to that document.

(The "confusion" mentioned above was my own. See gh-1143.)