### PR TITLE
Fix fetchEvent.request initialization

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2913,9 +2913,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Let |handleFetchFailed| be false.
       1. Let |respondWithEntered| be false.
       1. Let |eventCanceled| be false.
-      1. Let |r| be a new {{Request}} object associated with |request|.
-      1. Let |headersObject| be |r|'s {{Request/headers}} attribute value.
-      1. Set |headersObject|'s [=Headers/guard=] to *immutable*.
       1. Let |response| be null.
       1. Let |registration| be null.
       1. Let |client| be |request|'s [=request/client=].
@@ -2974,7 +2971,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Let |e| be the result of <a>creating an event</a> with {{FetchEvent}}.
           1. Initialize |e|’s {{Event/type}} attribute to {{fetch!!event}}.
           1. Initialize |e|’s {{Event/cancelable}} attribute to true.
-          1. Initialize |e|’s {{FetchEvent/request}} attribute to |r|.
+          1. Initialize |e|’s {{FetchEvent/request}} attribute to a new {{Request}} object associated with |request| and a new associated {{Headers}} object whose [=guard=] is "`immutable`".
           1. Initialize |e|’s {{FetchEvent/preloadResponse}} to |preloadResponse|.
           1. Initialize |e|'s {{FetchEvent/clientId}} attribute to |client|'s [=environment/id=].
           1. If |request| is a <a>non-subresource request</a> and |request|'s [=request/destination=] is not {{RequestDestination/"report"}}, initialize |e|'s {{FetchEvent/reservedClientId}} attribute to |reservedClient|'s [=environment/id=], and to the empty string otherwise.
@@ -3039,13 +3036,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
           Note: In the future this might be relaxed by adding supported methods and headers to the {{ForeignFetchOptions}}.
 
-      1. Let |r| be a new {{Request}} object associated with |request|.
       1. Invoke [=Run Service Worker=] algorithm with |activeWorker| as the argument.
       1. <a>Queue a task</a> |task| to run the following substeps:
           1. Let |e| be the result of <a>creating an event</a> with {{ForeignFetchEvent}}.
           1. Initialize |e|’s {{Event/type}} attribute to {{foreignfetch!!event}}.
           1. Initialize |e|’s {{Event/cancelable}} attribute to true.
-          1. Initialize |e|’s {{ForeignFetchEvent/request}} attribute to |r|.
+          1. Initialize |e|’s {{ForeignFetchEvent/request}} attribute to a new {{Request}} object associated with |request| and a new associated {{Headers}} object whose [=guard=] is "`immutable`".
           1. Initialize |e|’s {{ForeignFetchEvent/origin}} attribute to the  <a lt="Unicode serialization of an origin">Unicode serialization</a> of |request|'s [=request/origin=].
           1. <a>Dispatch</a> |e| at |activeWorker|'s [=service worker/global object=].
           1. Invoke [=Update Service Worker Extended Events Set=] with |activeWorker| and |e|.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1425,7 +1425,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-12">12 May 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-19">19 May 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1933,7 +1933,7 @@ pre.idl.highlight { color: #708090; }
            <dd>a new <code class="idl"><a data-link-type="idl" href="#client" id="ref-for-client-1">Client</a></code> object that represents <var>incumbentGlobal</var>’s associated worker 
           </dl>
          <li data-md="">
-          <p>Let <var>origin</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin">Unicode serialization</a> of <var>incumbentSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
+          <p>Let <var>origin</var> be the <a data-link-type="dfn">Unicode serialization</a> of <var>incumbentSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
          <li data-md="">
           <p>Let <var>destination</var> be the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-3">ServiceWorkerGlobalScope</a></code> object associated with <var>serviceWorker</var>.</p>
          <li data-md="">
@@ -2579,7 +2579,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>Add a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> that runs the following steps to <var>destination</var>’s <a data-link-type="dfn" href="#dfn-client-message-queue" id="ref-for-dfn-client-message-queue-6">client message queue</a>:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>origin</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin">Unicode serialization</a> of <var>sourceSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
+          <p>Let <var>origin</var> be the <a data-link-type="dfn">Unicode serialization</a> of <var>sourceSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
          <li data-md="">
           <p>Let <var>source</var> be a <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-22">ServiceWorker</a></code> object, which represents the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-6">service worker</a> associated with <var>sourceSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>.</p>
          <li data-md="">
@@ -5399,12 +5399,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>eventCanceled</var> be false.</p>
       <li data-md="">
-       <p>Let <var>r</var> be a new <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> object associated with <var>request</var>.</p>
-      <li data-md="">
-       <p>Let <var>headersObject</var> be <var>r</var>’s <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-request-headers">headers</a></code> attribute value.</p>
-      <li data-md="">
-       <p>Set <var>headersObject</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-headers-guard">guard</a> to <em>immutable</em>.</p>
-      <li data-md="">
        <p>Let <var>response</var> be null.</p>
       <li data-md="">
        <p>Let <var>registration</var> be null.</p>
@@ -5515,7 +5509,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-cancelable">cancelable</a></code> attribute to true.</p>
         <li data-md="">
-         <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-request" id="ref-for-dom-fetchevent-request-3">request</a></code> attribute to <var>r</var>.</p>
+         <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-request" id="ref-for-dom-fetchevent-request-3">request</a></code> attribute to a new <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> object associated with <var>request</var> and a new associated <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#headers">Headers</a></code> object whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-headers-guard">guard</a> is "<code>immutable</code>".</p>
         <li data-md="">
          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-preloadresponse" id="ref-for-dom-fetchevent-preloadresponse-3">preloadResponse</a></code> to <var>preloadResponse</var>.</p>
         <li data-md="">
@@ -5629,8 +5623,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method">method</a> is not a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-safelisted-method">CORS-safelisted method</a>, or if there is at least one <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header">header</a> in <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-header-list">header list</a> for whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-name">name</a> is not a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-safelisted-request-header">CORS-safelisted request-header</a>, return null.</p>
         <p class="note" role="note"><span>Note:</span> In the future this might be relaxed by adding supported methods and headers to the <code class="idl"><a data-link-type="idl" href="#dictdef-foreignfetchoptions" id="ref-for-dictdef-foreignfetchoptions-2">ForeignFetchOptions</a></code>.</p>
        <li data-md="">
-        <p>Let <var>r</var> be a new <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> object associated with <var>request</var>.</p>
-       <li data-md="">
         <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker-7">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
        <li data-md="">
         <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps:</p>
@@ -5642,9 +5634,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-cancelable">cancelable</a></code> attribute to true.</p>
          <li data-md="">
-          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-foreignfetchevent-request" id="ref-for-dom-foreignfetchevent-request-3">request</a></code> attribute to <var>r</var>.</p>
+          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-foreignfetchevent-request" id="ref-for-dom-foreignfetchevent-request-3">request</a></code> attribute to a new <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> object associated with <var>request</var> and a new associated <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#headers">Headers</a></code> object whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-headers-guard">guard</a> is "<code>immutable</code>".</p>
          <li data-md="">
-          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-foreignfetchevent-origin" id="ref-for-dom-foreignfetchevent-origin-3">origin</a></code> attribute to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin">Unicode serialization</a> of <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a>.</p>
+          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-foreignfetchevent-origin" id="ref-for-dom-foreignfetchevent-origin-3">origin</a></code> attribute to the <a data-link-type="dfn">Unicode serialization</a> of <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a>.</p>
          <li data-md="">
           <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch">Dispatch</a> <var>e</var> at <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object-6">global object</a>.</p>
          <li data-md="">
@@ -5670,7 +5662,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
             <p>Else set <var>response</var> to an <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">opaque filtered response</a> of <var>internalResponse</var>.</p>
           </ol>
          <li data-md="">
-          <p>Else if <var>e</var>’s <a data-link-type="dfn" href="#foreignfetchevent-origin" id="ref-for-foreignfetchevent-origin-3">origin</a> is not equal to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin">Unicode serialization</a> of <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a>, set <var>handleFetchFailed</var> to true.</p>
+          <p>Else if <var>e</var>’s <a data-link-type="dfn" href="#foreignfetchevent-origin" id="ref-for-foreignfetchevent-origin-3">origin</a> is not equal to the <a data-link-type="dfn">Unicode serialization</a> of <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a>, set <var>handleFetchFailed</var> to true.</p>
          <li data-md="">
           <p>Else if <var>e</var>’s <a data-link-type="dfn" href="#foreignfetchevent-potential-response" id="ref-for-foreignfetchevent-potential-response-5">potential response</a> is an <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">opaque filtered response</a> or is an <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque-redirect">opaque-redirect filtered response</a>, set <var>response</var> to <var>e</var>’s <a data-link-type="dfn" href="#foreignfetchevent-potential-response" id="ref-for-foreignfetchevent-potential-response-6">potential response</a>.</p>
          <li data-md="">
@@ -7362,7 +7354,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation">triggered by user activation</a>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type">type</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin">unicode serialization of an origin</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#unload-a-document">unload a document</a>
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#unsafe-response">unsafe response</a>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">url</a>

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -2533,9 +2533,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Let |handleFetchFailed| be false.
       1. Let |respondWithEntered| be false.
       1. Let |eventCanceled| be false.
-      1. Let |r| be a new {{Request}} object associated with |request|.
-      1. Let |headersObject| be |r|'s {{Request/headers}} attribute value.
-      1. Set |headersObject|'s [=Headers/guard=] to *immutable*.
       1. Let |response| be null.
       1. Let |registration| be null.
       1. Let |client| be |request|'s [=request/client=].
@@ -2575,7 +2572,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Let |e| be the result of <a>creating an event</a> with {{FetchEvent}}.
           1. Initialize |e|’s {{Event/type}} attribute to {{fetch!!event}}.
           1. Initialize |e|’s {{Event/cancelable}} attribute to true.
-          1. Initialize |e|’s {{FetchEvent/request}} attribute to |r|.
+          1. Initialize |e|’s {{FetchEvent/request}} attribute to a new {{Request}} object associated with |request| and a new associated {{Headers}} object whose [=guard=] is "`immutable`".
           1. Initialize |e|'s {{FetchEvent/clientId}} attribute to |client|'s [=environment/id=].
           1. If |request| is a <a>non-subresource request</a> and |request|'s [=request/destination=] is not {{RequestDestination/"report"}}, initialize |e|'s {{FetchEvent/reservedClientId}} attribute to |reservedClient|'s [=environment/id=], and to the empty string otherwise.
           1. If |request| is a <a>navigation request</a>, initialize |e|'s {{FetchEvent/targetClientId}} attribute to |request|'s [=request/target client id=], and to the empty string otherwise.

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1425,7 +1425,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-12">12 May 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-05-19">19 May 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1895,7 +1895,7 @@ pre.idl.highlight { color: #708090; }
            <dd>a new <code class="idl"><a data-link-type="idl" href="#client" id="ref-for-client-1">Client</a></code> object that represents <var>incumbentGlobal</var>’s associated worker 
           </dl>
          <li data-md="">
-          <p>Let <var>origin</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin">Unicode serialization</a> of <var>incumbentSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
+          <p>Let <var>origin</var> be the <a data-link-type="dfn">Unicode serialization</a> of <var>incumbentSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
          <li data-md="">
           <p>Let <var>destination</var> be the <code class="idl"><a data-link-type="idl" href="#serviceworkerglobalscope" id="ref-for-serviceworkerglobalscope-3">ServiceWorkerGlobalScope</a></code> object associated with <var>serviceWorker</var>.</p>
          <li data-md="">
@@ -2479,7 +2479,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <p>Add a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> that runs the following steps to <var>destination</var>’s <a data-link-type="dfn" href="#dfn-client-message-queue" id="ref-for-dfn-client-message-queue-6">client message queue</a>:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>origin</var> be the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin">Unicode serialization</a> of <var>sourceSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
+          <p>Let <var>origin</var> be the <a data-link-type="dfn">Unicode serialization</a> of <var>sourceSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>.</p>
          <li data-md="">
           <p>Let <var>source</var> be a <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker-22">ServiceWorker</a></code> object, which represents the <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker-6">service worker</a> associated with <var>sourceSettings</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">global object</a>.</p>
          <li data-md="">
@@ -4882,12 +4882,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>eventCanceled</var> be false.</p>
       <li data-md="">
-       <p>Let <var>r</var> be a new <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> object associated with <var>request</var>.</p>
-      <li data-md="">
-       <p>Let <var>headersObject</var> be <var>r</var>’s <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-request-headers">headers</a></code> attribute value.</p>
-      <li data-md="">
-       <p>Set <var>headersObject</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-headers-guard">guard</a> to <em>immutable</em>.</p>
-      <li data-md="">
        <p>Let <var>response</var> be null.</p>
       <li data-md="">
        <p>Let <var>registration</var> be null.</p>
@@ -4964,7 +4958,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-cancelable">cancelable</a></code> attribute to true.</p>
         <li data-md="">
-         <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-request" id="ref-for-dom-fetchevent-request-3">request</a></code> attribute to <var>r</var>.</p>
+         <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-request" id="ref-for-dom-fetchevent-request-3">request</a></code> attribute to a new <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> object associated with <var>request</var> and a new associated <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#headers">Headers</a></code> object whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-headers-guard">guard</a> is "<code>immutable</code>".</p>
         <li data-md="">
          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-clientid" id="ref-for-dom-fetchevent-clientid-3">clientId</a></code> attribute to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id">id</a>.</p>
         <li data-md="">
@@ -6518,7 +6512,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation">triggered by user activation</a>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type">type</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#unicode-serialisation-of-an-origin">unicode serialization of an origin</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#unload-a-document">unload a document</a>
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#unsafe-response">unsafe response</a>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">url</a>


### PR DESCRIPTION
This patch moves the creation of a Request object and its associated
Headers object to a right place. It moves those steps from outside into
the task where the fetch event's request attribute is initialized.

Fixes #951.