### PR TITLE
Editorial: Correct value references

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2709,7 +2709,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If |newestWorker| is null, abort these steps.
       1. Let |job| be the result of running <a>Create Job</a> with *update*, |registration|'s [=service worker registration/scope url=], |newestWorker|'s [=service worker/script url=], null, and null.
       1. Set |job|'s <a>worker type</a> to |newestWorker|'s [=service worker/type=].
-      1. Set |job|'s <a>force bypass cache flag</a> if its *force bypass cache flag* is set.
+      1. Set |job|'s <a>force bypass cache flag</a> if the *force bypass cache flag* is set.
       1. Invoke <a>Schedule Job</a> with |job|.
   </section>
 
@@ -2863,7 +2863,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Set |workerGlobalScope|'s [=WorkerGlobalScope/HTTPS state=] to |serviceWorker|'s <a>script resource</a>'s <a>HTTPS state</a>.
       1. Set |workerGlobalScope|'s [=WorkerGlobalScope/referrer policy=] to |serviceWorker|'s <a>script resource</a>'s [=script resource/referrer policy=].
       1. Set |workerGlobalScope|'s [=WorkerGlobalScope/type=] to |serviceWorker|'s <a>type</a>.
-      1. Set |workerGlobalScope|'s [=ServiceWorkerGlobalScope/force bypass cache for importscripts flag=] if its *force bypass cache for importscripts flag* is set.
+      1. Set |workerGlobalScope|'s [=ServiceWorkerGlobalScope/force bypass cache for importscripts flag=] if the *force bypass cache for importscripts flag* is set.
       1. Create a new {{WorkerLocation}} object and associate it with |workerGlobalScope|.
       1. If |serviceWorker| is an <a>active worker</a>, and there are any <a>tasks</a> queued in |serviceWorker|'s <a>containing service worker registration</a>'s [=service worker registration/task queues=], <a lt="queue a task">queue</a> them to |serviceWorker|'s <a>event loop</a>'s [=/task queues=] in the same order using their original <a>task sources</a>.
       1. If |script| is a <a>classic script</a>, then <a lt="run a classic script">run the classic script</a> |script|. Otherwise, it is a <a>module script</a>; <a lt="run a module script">run the module script</a> |script|.

--- a/docs/index.html
+++ b/docs/index.html
@@ -5059,7 +5059,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type-6">worker type</a> to <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-3">type</a>.</p>
       <li data-md="">
-       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-3">force bypass cache flag</a> if its <em>force bypass cache flag</em> is set.</p>
+       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag-3">force bypass cache flag</a> if the <em>force bypass cache flag</em> is set.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#schedule-job" id="ref-for-schedule-job-4">Schedule Job</a> with <var>job</var>.</p>
      </ol>
@@ -5325,7 +5325,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type">type</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type-4">type</a>.</p>
       <li data-md="">
-       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag" id="ref-for-serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag-2">force bypass cache for importscripts flag</a> if its <em>force bypass cache for importscripts flag</em> is set.</p>
+       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag" id="ref-for-serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag-2">force bypass cache for importscripts flag</a> if the <em>force bypass cache for importscripts flag</em> is set.</p>
       <li data-md="">
        <p>Create a new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">WorkerLocation</a></code> object and associate it with <var>workerGlobalScope</var>.</p>
       <li data-md="">


### PR DESCRIPTION
Set job properties based on the value of the like-named algorithm inputs
(not the job properties themselves).

---

Even after application of this patch, the language is still somewhat confusing
because the job properties and algorithm inputs continue to share the same
name. I think a better fix would be to re-name the algorithm inputs (maybe
simply by removing the word "flag"), but I'd like to hear from an editor about
that.