### PR TITLE
Fix the perform the fetch steps in Update algorithm

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2622,7 +2622,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       : Output
       :: none
 
-      1. Let |registration| be the result of running the <a>Get Registration</a> algorithm passing |job|'s [=job/scope url=] as the argument.
+      1. Let |registration| be the result of running <a>Get Registration</a> algorithm passing |job|'s [=job/scope url=] as the argument.
       1. If |registration| is null or |registration|'s <a>uninstalling flag</a> is set, then:
           1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
@@ -2656,17 +2656,15 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. If the [=fetching scripts/is top-level=] flag is unset, then return the result of [=/fetching=] |request|.
           1. Set |request|'s [=request/redirect mode=] to "<code>error</code>".
           1. [=/Fetch=] |request|, and asynchronously wait to run the remaining steps as part of fetch's <a>process response</a> for the [=/response=] |response|.
-          1. [=Extract a MIME type=] from the |response|'s [=response/header list=]. If this MIME type (ignoring parameters) is not a [=JavaScript MIME type=], then:
-              1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" {{DOMException}}.
-              1. Asynchronously complete these steps with a [=network error=].
+          1. Let |mimeType| be the result of [=extracting a MIME type=] from the |response|'s [=response/header list=].
+          1. If |mimeType| (ignoring parameters) is not a [=JavaScript MIME type=], asynchronously complete these steps with a [=network error=] and "{{SecurityError}}" {{DOMException}}, and abort these steps.
           1. Let |serviceWorkerAllowed| be the result of [=extracting header list values=] given \`<code>Service-Worker-Allowed</code>\` and |response|'s [=response/header list=].
 
               Note: See the definition of the Service-Worker-Allowed header in Appendix B: Extended HTTP headers.
 
           1. Set |httpsState| to |response|'s [=response/HTTPS state=].
           1. Set |referrerPolicy| to the result of <a>parse a referrer policy from a <code>Referrer-Policy</code> header</a> of |response|.
-          1. If |serviceWorkerAllowed| is failure, then:
-              1. Asynchronously complete these steps with a <a>network error</a>.
+          1. If |serviceWorkerAllowed| is failure, asynchronously complete these steps with a <a>network error</a> and `TypeError`, and abort these steps.
           1. Let |scopeURL| be |registration|'s [=service worker registration/scope url=].
           1. Let |maxScopeString| be null.
           1. If |serviceWorkerAllowed| is null, then:
@@ -2675,22 +2673,16 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. Let |maxScope| be the result of <a lt="URL parser">parsing</a> |serviceWorkerAllowed| with |job|'s [=job/script url=].
               1. Set |maxScopeString| to "<code>/</code>" concatenated with the strings in |maxScope|'s [=url/path=] (including empty strings), separated from each other by "<code>/</code>".
           1. Let |scopeString| be "<code>/</code>" concatenated with the strings in |scopeURL|'s [=url/path=] (including empty strings), separated from each other by "<code>/</code>".
-          1. If |scopeString| starts with |maxScopeString|, do nothing.
-          1. Else:
-              1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" {{DOMException}}.
-              1. Asynchronously complete these steps with a <a>network error</a>.
+          1. If |scopeString| does not start with |maxScopeString|, asynchronously complete these steps with a <a>network error</a> and "{{SecurityError}}" {{DOMException}}, and abort these steps.
           1. If |response|'s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|'s <a>last update check time</a> to the current time.
 
               Issue: The response's cache state concept had been removed from fetch. The fetch issue <a href="https://github.com/whatwg/fetch/issues/376">#376</a> tracks the request to restore the concept or add some similar way to check this state.
 
-          1. Return true.
+          1. Asynchronously complete the [=perform the fetch=] steps with |response|.
 
-          If the algorithm asynchronously completes with null, then:
+          If the algorithm asynchronously completes with null and |errorData|, then:
 
-              1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
-
-                  Note: This will do nothing if [=Reject Job Promise=] was previously invoked with "{{SecurityError}}" {{DOMException}}.
-
+              1. Invoke [=Reject Job Promise=] with |job| and |errorData|.
               1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
 


### PR DESCRIPTION
This fixes the peform the fetch steps so as for it not to synchronously
return true on success but to asynchronously coplete with response. This
factors the promise rejection of the fail cases out of the perform the
fetch steps so the fetch a * worker script algorithm's remaining step
will invoke the Reject Job Promise with provided error data.