### PR TITLE
Warn readers that V1 is missing features compared to the nightly

### DIFF
--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -12,6 +12,9 @@ Editor: Marijn Kruisselbrink, Google, mek@chromium.org
 Repository: w3c/ServiceWorker
 Group: serviceworkers
 !Tests: <a href=https://github.com/w3c/web-platform-tests/tree/master/service-workers>web-platform-tests service-workers/</a> (<a href=https://github.com/w3c/web-platform-tests/labels/service-workers>ongoing work</a>)
+Warning: Custom
+Custom Warning Title: V1 Branch
+Custom Warning Text: This is version 1 of the service worker spec, which lacks detail and features compared to the [nightly](../). Snapshots such as this are required by W3C process and some implementors.
 Abstract: This specification describes a method that enables applications to take advantage of persistent background processing, including hooks to enable bootstrapping of web applications while offline.
 Abstract:
 Abstract: The core of this system is an event-driven <a>Web Worker</a>, which responds to events dispatched from documents and other sources. A system for managing installation, versions, and upgrades is provided.

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -14,7 +14,7 @@ Group: serviceworkers
 !Tests: <a href=https://github.com/w3c/web-platform-tests/tree/master/service-workers>web-platform-tests service-workers/</a> (<a href=https://github.com/w3c/web-platform-tests/labels/service-workers>ongoing work</a>)
 Warning: Custom
 Custom Warning Title: V1 Branch
-Custom Warning Text: This is version 1 of the service worker spec, which lacks detail and features compared to the [nightly](../). Snapshots such as this are required by W3C process and some implementors.
+Custom Warning Text: This spec is a subset of [the nightly version](../) that is advancing toward a W3C Recommendation. For implementers and developers who seek all the latest features, [Service Workers Nightly](../) is a right document that is constantly reflecting new requirements.
 Abstract: This specification describes a method that enables applications to take advantage of persistent background processing, including hooks to enable bootstrapping of web applications while offline.
 Abstract:
 Abstract: The core of this system is an event-driven <a>Web Worker</a>, which responds to events dispatched from documents and other sources. A system for managing installation, versions, and upgrades is provided.

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1179,7 +1179,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
   <meta content="Bikeshed version 3ee78e75729309d4dfc4793df74c38e4ae785832" name="generator">
   <link href="https://www.w3.org/TR/service-workers/" rel="canonical">
-  <meta content="16a480fc40e7c7def86e6d7adf08fff9e9dc7678" name="document-revision">
+  <meta content="6d4f0a8e0e34cfd6a382583b9a2a52b4f5379cf6" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1448,7 +1448,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
    <div data-fill-with="warning">
     <details class="annoying-warning" open="">
      <summary>V1 Branch</summary>
-     <p>This is version 1 of the service worker spec, which lacks detail and features compared to the <a href="../">nightly</a>. Snapshots such as this are required by W3C process and some implementors.</p>
+     <p>This spec is a subset of <a href="../">the nightly version</a> that is advancing toward a W3C Recommendation. For implementers and developers who seek all the latest features, <a href="../">Service Workers Nightly</a> is a right document that is constantly reflecting new requirements.</p>
     </details>
    </div>
    <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" rel="license">permissive document license</a> rules apply. </p>

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1179,7 +1179,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
   <meta content="Bikeshed version 3ee78e75729309d4dfc4793df74c38e4ae785832" name="generator">
   <link href="https://www.w3.org/TR/service-workers/" rel="canonical">
-  <meta content="2afc4ca9397e7227a81061aa5e41095bc273eb09" name="document-revision">
+  <meta content="16a480fc40e7c7def86e6d7adf08fff9e9dc7678" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1426,7 +1426,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-10-10">10 October 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-10-11">11 October 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1445,7 +1445,12 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <dd><a href="https://github.com/w3c/web-platform-tests/tree/master/service-workers">web-platform-tests service-workers/</a> (<a href="https://github.com/w3c/web-platform-tests/labels/service-workers">ongoing work</a>)
     </dl>
    </div>
-   <div data-fill-with="warning"></div>
+   <div data-fill-with="warning">
+    <details class="annoying-warning" open="">
+     <summary>V1 Branch</summary>
+     <p>This is version 1 of the service worker spec, which lacks detail and features compared to the <a href="../">nightly</a>. Snapshots such as this are required by W3C process and some implementors.</p>
+    </details>
+   </div>
    <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" rel="license">permissive document license</a> rules apply. </p>
    <hr title="Separator for header">
   </div>


### PR DESCRIPTION
We're seeing a lot of confusion around V1 and the nightly. As in, developers are linking to the V1 spec and wondering why they can't find particular features.

I've added a warning to the V1 spec. What do you think?

<img width="883" alt="screen shot of spec" src="https://user-images.githubusercontent.com/93594/31438303-a0c7bc8c-ae7f-11e7-9078-c5b35bea2feb.png">
