### PR TITLE
FetchEvent init preloadResponse should be optional. Fixes #1114.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1422,7 +1422,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <pre class="idl" id="fetch-event-init-dictionary">
       dictionary FetchEventInit : ExtendableEventInit {
         required Request request;
-        required Promise&lt;any&gt; preloadResponse;
+        Promise&lt;any&gt; preloadResponse;
         DOMString clientId = "";
         DOMString reservedClientId = "";
         DOMString targetClientId = "";
@@ -1446,7 +1446,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <section>
       <h4 id="fetch-event-preloadresponse">{{FetchEvent/preloadResponse|event.preloadResponse}}</h4>
 
-      <dfn attribute for="FetchEvent"><code>preloadResponse</code></dfn> attribute *must* return the value it was initialized to.
+      <dfn attribute for="FetchEvent"><code>preloadResponse</code></dfn> attribute *must* return the value it was initialized to. When an <a>event</a> is created the attribute *must* be initialized to [=a promise resolved with=] undefined.
     </section>
 
     <section>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/ServiceWorker/preload-optional.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/ServiceWorker/c577b77...5b1ff00.html)