### PR TITLE
Use Web IDL's new-ish interface mixins concept

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -301,7 +301,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         // event
         attribute EventHandler onstatechange;
       };
-      ServiceWorker implements AbstractWorker;
+      ServiceWorker includes AbstractWorker;
 
       enum ServiceWorkerState {
         "installing",


### PR DESCRIPTION
WebIDL recently introduced dedicated syntax for mixins [1]. So, this
change replaces the existing `implements` with `includes` as per the new
concept.

[1] https://github.com/heycam/webidl/commit/45e8173d40ddff8dcf81697326e094bcf8b92920


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/romandev/ServiceWorker/pull/1252.html" title="Last updated on Dec 21, 2017, 1:49 AM GMT (4512b72)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1252/90c04cd...romandev:4512b72.html" title="Last updated on Dec 21, 2017, 1:49 AM GMT (4512b72)">Diff</a>