### PR TITLE
Make the promise settlement type of WindowClient.navigate() nullable

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -981,7 +981,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         readonly attribute boolean focused;
         [SameObject] readonly attribute FrozenArray&lt;USVString&gt; ancestorOrigins;
         [NewObject] Promise&lt;WindowClient&gt; focus();
-        [NewObject] Promise&lt;WindowClient&gt; navigate(USVString url);
+        [NewObject] Promise&lt;WindowClient?&gt; navigate(USVString url);
       };
     </pre>
 


### PR DESCRIPTION
The navigate() can be resolved as null if If browsingContext’s Window
object’s environment settings object’s creation URL’s origin is not
the same as the service worker's origin[1].

[1] https://w3c.github.io/ServiceWorker/#ref-for-dom-windowclient-navigate


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/romandev/ServiceWorker/pull/1253.html" title="Last updated on Dec 21, 2017, 1:50 AM GMT (eccf275)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1253/90c04cd...romandev:eccf275.html" title="Last updated on Dec 21, 2017, 1:50 AM GMT (eccf275)">Diff</a>