### PR TITLE
Clarify target object of Client.postMessage can be null

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1209,7 +1209,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
                     1. Else, set |browsingContext| to |client|’s [=environment/target browsing context=].
                     1. [=Queue a task=] |task| to run the following substeps on |browsingContext|'s [=event loop=] using the [=user interaction task source=]:
                         1. If |browsingContext| has been [=a browsing context is discarded|discarded=], then set |isClientEnumerable| to false and abort these steps.
-                        1. If |client| is a window client and |client|'s [=responsible document=] is not |browsingContext|'s [=active document=],  then set |isClientEnumerable| to false and abort these steps.
+                        1. If |client| is a window client and |client|'s [=responsible document=] is not |browsingContext|'s [=active document=], then set |isClientEnumerable| to false and abort these steps.
                         1. Set |windowData|["`visibilityState`"] to |browsingContext|'s [=active document=]'s {{Document/visibilityState}} attribute value.
                         1. Set |windowData|["`focusState`"] to the result of running the [=has focus steps=] with |browsingContext|'s [=active document=] as the argument.
                         1. If |client| is a [=window client=], then set |windowData|["`ancestorOriginsList`"] to |browsingContext|'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1028,7 +1028,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       The <dfn method for="Client"><code>postMessage(|message|, |transfer|)</code></dfn> method *must* run these steps:
 
         1. Let |sourceSettings| be the <a>context object</a>'s <a>relevant settings object</a>.
-        1. Let |destination| be the {{ServiceWorkerContainer}} object whose [=ServiceWorkerContainer/service worker client=] is the <a>context object</a>'s [=Client/service worker client=], if any; otherwise let it be null.
+        1. Let |destination| be the {{ServiceWorkerContainer}} object whose [=ServiceWorkerContainer/service worker client=] is the <a>context object</a>'s [=Client/service worker client=], or null if no match is found.
         1. If |destination| is null, <a>throw</a> an "{{InvalidStateError}}" {{DOMException}}.
         1. Let |serializeWithTransferResult| be <a abstract-op>StructuredSerializeWithTransfer</a>(|message|, |transfer|). Rethrow any exceptions.
         1. Add a <a>task</a> that runs the following steps to |destination|'s [=ServiceWorkerContainer/client message queue=]:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1028,7 +1028,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       The <dfn method for="Client"><code>postMessage(|message|, |transfer|)</code></dfn> method *must* run these steps:
 
         1. Let |sourceSettings| be the <a>context object</a>'s <a>relevant settings object</a>.
-        1. Let |destination| be the {{ServiceWorkerContainer}} object whose [=ServiceWorkerContainer/service worker client=] is the <a>context object</a>'s [=Client/service worker client=].
+        1. Let |destination| be the {{ServiceWorkerContainer}} object whose [=ServiceWorkerContainer/service worker client=] is the <a>context object</a>'s [=Client/service worker client=], if any; otherwise let it be null.
         1. If |destination| is null, <a>throw</a> an "{{InvalidStateError}}" {{DOMException}}.
         1. Let |serializeWithTransferResult| be <a abstract-op>StructuredSerializeWithTransfer</a>(|message|, |transfer|). Rethrow any exceptions.
         1. Add a <a>task</a> that runs the following steps to |destination|'s [=ServiceWorkerContainer/client message queue=]:

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -966,7 +966,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       The <dfn method for="Client"><code>postMessage(|message|, |transfer|)</code></dfn> method *must* run these steps:
 
         1. Let |sourceSettings| be the <a>context object</a>'s <a>relevant settings object</a>.
-        1. Let |destination| be the {{ServiceWorkerContainer}} object whose [=ServiceWorkerContainer/service worker client=] is the <a>context object</a>'s [=Client/service worker client=], if any; otherwise let it be null.
+        1. Let |destination| be the {{ServiceWorkerContainer}} object whose [=ServiceWorkerContainer/service worker client=] is the <a>context object</a>'s [=Client/service worker client=], or null if no match is found.
         1. If |destination| is null, <a>throw</a> an "{{InvalidStateError}}" {{DOMException}}.
         1. Let |serializeWithTransferResult| be <a abstract-op>StructuredSerializeWithTransfer</a>(|message|, |transfer|). Rethrow any exceptions.
         1. Add a <a>task</a> that runs the following steps to |destination|'s [=ServiceWorkerContainer/client message queue=]:

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -966,7 +966,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       The <dfn method for="Client"><code>postMessage(|message|, |transfer|)</code></dfn> method *must* run these steps:
 
         1. Let |sourceSettings| be the <a>context object</a>'s <a>relevant settings object</a>.
-        1. Let |destination| be the {{ServiceWorkerContainer}} object whose [=ServiceWorkerContainer/service worker client=] is the <a>context object</a>'s [=Client/service worker client=].
+        1. Let |destination| be the {{ServiceWorkerContainer}} object whose [=ServiceWorkerContainer/service worker client=] is the <a>context object</a>'s [=Client/service worker client=], if any; otherwise let it be null.
         1. If |destination| is null, <a>throw</a> an "{{InvalidStateError}}" {{DOMException}}.
         1. Let |serializeWithTransferResult| be <a abstract-op>StructuredSerializeWithTransfer</a>(|message|, |transfer|). Rethrow any exceptions.
         1. Add a <a>task</a> that runs the following steps to |destination|'s [=ServiceWorkerContainer/client message queue=]:

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -1147,7 +1147,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
                     1. Else, set |browsingContext| to |client|’s [=environment/target browsing context=].
                     1. [=Queue a task=] |task| to run the following substeps on |browsingContext|'s [=event loop=] using the [=user interaction task source=]:
                         1. If |browsingContext| has been [=a browsing context is discarded|discarded=], then set |isClientEnumerable| to false and abort these steps.
-                        1. If |client| is a window client and |client|'s [=responsible document=] is not |browsingContext|'s [=active document=],  then set |isClientEnumerable| to false and abort these steps.
+                        1. If |client| is a window client and |client|'s [=responsible document=] is not |browsingContext|'s [=active document=], then set |isClientEnumerable| to false and abort these steps.
                         1. Set |windowData|["`visibilityState`"] to |browsingContext|'s [=active document=]'s {{Document/visibilityState}} attribute value.
                         1. Set |windowData|["`focusState`"] to the result of running the [=has focus steps=] with |browsingContext|'s [=active document=] as the argument.
                         1. If |client| is a [=window client=], then set |windowData|["`ancestorOriginsList`"] to |browsingContext|'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.


### PR DESCRIPTION
This change addresses the issue described in the second paragraph of
https://github.com/w3c/ServiceWorker/issues/1042#issuecomment-270043959.
This change gets |destination| variable initialized to null if the
ServiceWorkerContainer object does not exist.

Fixes #1042.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/pull/1274.html" title="Last updated on Feb 12, 2018, 2:45 AM GMT (f6def65)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1274/49f954f...f6def65.html" title="Last updated on Feb 12, 2018, 2:45 AM GMT (f6def65)">Diff</a>