### PR TITLE
Update orphaned references in Query Cache algo

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3154,7 +3154,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Let |fieldValues| be the [=list=] containing the elements corresponding to the [=http/field-values=] of the <a>Vary</a> header.
           1. Let |isMatched| be true.
           1. For each |fieldValue| in |fieldValues|:
-              1. If |fieldValue| matches "`*`", or the [=combined value=] given |f| and |cachedRequest|'s [=request/header list=] does not match the [=combined value=] given |f| and |request|'s [=request/header list=], then:
+              1. If |fieldValue| matches "`*`", or the [=combined value=] given |fieldValue| and |cachedRequest|'s [=request/header list=] does not match the [=combined value=] given |fieldValue| and |request|'s [=request/header list=], then:
                   1. Set |isMatched| to false.
                   1. [=Break=].
           1. If |isMatched| is true, [=list/append=] |cachedRequest|/|cachedResponse| to |resultList|.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1177,9 +1177,8 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
-  <meta content="Bikeshed version d1c8ac9ac0bb0f0e970e3942633cfb7d2f7e12e6" name="generator">
+  <meta content="Bikeshed version ae5d415446a9edf0c07d32303ac1d21767d86d57" name="generator">
   <link href="https://www.w3.org/TR/service-workers/" rel="canonical">
-  <meta content="9cca51802e8471a8f579b0a67a427ed91c229cba" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1426,7 +1425,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-01-13">13 January 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-02-21">21 February 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1467,7 +1466,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite
     this document as other than work in progress. </p>
    <p> This document was produced by a group operating under the <a href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/2004/01/pp-impl/101220/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. </p>
-   <p>This document is governed by the <a href="https://www.w3.org/2017/Process-20170301/" id="w3c_process_revision">1 March 2017 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>. </p>
+   <p>This document is governed by the <a href="https://www.w3.org/2018/Process-20180201/" id="w3c_process_revision">1 February 2018 W3C Process Document</a>. </p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">
@@ -1828,12 +1827,12 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <a class="self-link" href="#example-7e94092e"></a> Bootstrapping with a service worker: 
 <pre class="highlight"><span class="c1">// scope defaults to the path the script sits in</span>
 <span class="c1">// "/" in this example</span>
-<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/serviceworker.js"</span><span class="p">).</span>then<span class="p">(</span>registration <span class="o">=></span> <span class="p">{</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/serviceworker.js"</span><span class="p">).</span>then<span class="p">(</span>registration <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>log<span class="p">(</span><span class="s2">"success!"</span><span class="p">);</span>
   <span class="k">if</span> <span class="p">(</span>registration<span class="p">.</span>installing<span class="p">)</span> <span class="p">{</span>
     registration<span class="p">.</span>installing<span class="p">.</span>postMessage<span class="p">(</span><span class="s2">"Howdy from your installing page."</span><span class="p">);</span>
   <span class="p">}</span>
-<span class="p">},</span> err <span class="o">=></span> <span class="p">{</span>
+<span class="p">},</span> err <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Installing the worker failed!"</span><span class="p">,</span> err<span class="p">);</span>
 <span class="p">});</span>
 </pre>
@@ -2221,7 +2220,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
            <li data-md="">
             <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate">For each</a> <var>registration</var> of <var>registrations</var>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append①">append</a> the <code class="idl"><a data-link-type="idl" href="#serviceworkerregistration" id="ref-for-serviceworkerregistration①①">ServiceWorkerRegistration</a></code> object associated with <var>registration</var> to <var>registrationObjects</var>.</p>
            <li data-md="">
-            <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise">Resolve</a> <var>promise</var> with <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-frozen-array" id="ref-for-dfn-create-frozen-array">a new frozen array of</a> <var>registrationObjects</var> in <var>promise</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm">relevant Realm</a>.</p>
+            <p><a data-link-type="dfn" href="https://w3c.github.io/FileAPI/#blob-url-resolve" id="ref-for-blob-url-resolve">Resolve</a> <var>promise</var> with <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-frozen-array" id="ref-for-dfn-create-frozen-array">a new frozen array of</a> <var>registrationObjects</var> in <var>promise</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm">relevant Realm</a>.</p>
           </ol>
         </ol>
        <li data-md="">
@@ -2323,7 +2322,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       <li data-md="">
        <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#service-worker-registration-navigation-preload-enabled-flag" id="ref-for-service-worker-registration-navigation-preload-enabled-flag">navigation preload enabled flag</a>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise①">Resolve</a> <var>promise</var> with undefined.</p>
+       <p><a data-link-type="dfn" href="https://w3c.github.io/FileAPI/#blob-url-resolve" id="ref-for-blob-url-resolve①">Resolve</a> <var>promise</var> with undefined.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="navigation-preload-manager-disable">
@@ -2337,7 +2336,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       <li data-md="">
        <p>Unset <var>registration</var>’s <a data-link-type="dfn" href="#service-worker-registration-navigation-preload-enabled-flag" id="ref-for-service-worker-registration-navigation-preload-enabled-flag①">navigation preload enabled flag</a>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise②">Resolve</a> <var>promise</var> with undefined.</p>
+       <p><a data-link-type="dfn" href="https://w3c.github.io/FileAPI/#blob-url-resolve" id="ref-for-blob-url-resolve②">Resolve</a> <var>promise</var> with undefined.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="navigation-preload-manager-setheadervalue">
@@ -2351,7 +2350,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       <li data-md="">
        <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#service-worker-registration-navigation-preload-header-value" id="ref-for-service-worker-registration-navigation-preload-header-value">navigation preload header value</a> to <var>value</var>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise③">Resolve</a> <var>promise</var> with undefined.</p>
+       <p><a data-link-type="dfn" href="https://w3c.github.io/FileAPI/#blob-url-resolve" id="ref-for-blob-url-resolve③">Resolve</a> <var>promise</var> with undefined.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="navigation-preload-manager-getstate">
@@ -2367,7 +2366,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
       <li data-md="">
        <p>Set <var>state</var>’s <code class="idl"><a data-link-type="idl" href="#dom-navigationpreloadstate-headervalue" id="ref-for-dom-navigationpreloadstate-headervalue">headerValue</a></code> dictionary member to the <var>registration</var>’s <a data-link-type="dfn" href="#service-worker-registration-navigation-preload-header-value" id="ref-for-service-worker-registration-navigation-preload-header-value①">navigation preload header value</a>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise④">Resolve</a> <var>promise</var> with <var>state</var>.</p>
+       <p><a data-link-type="dfn" href="https://w3c.github.io/FileAPI/#blob-url-resolve" id="ref-for-blob-url-resolve④">Resolve</a> <var>promise</var> with <var>state</var>.</p>
      </ol>
     </section>
    </section>
@@ -2376,10 +2375,10 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     <div class="example" id="example-744d6b8b">
      <a class="self-link" href="#example-744d6b8b"></a> Serving Cached Resources: 
 <pre class="highlight"><span class="c1">// caching.js</span>
-<span class="c1"></span>self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"install"</span><span class="p">,</span> event <span class="o">=></span> <span class="p">{</span>
+<span class="c1"></span>self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"install"</span><span class="p">,</span> event <span class="p">=></span> <span class="p">{</span>
   event<span class="p">.</span>waitUntil<span class="p">(</span>
     <span class="c1">// Open a cache of resources.</span>
-<span class="c1"></span>    caches<span class="p">.</span>open<span class="p">(</span><span class="s2">"shell-v1"</span><span class="p">).</span>then<span class="p">(</span>cache <span class="o">=></span> <span class="p">{</span>
+<span class="c1"></span>    caches<span class="p">.</span>open<span class="p">(</span><span class="s2">"shell-v1"</span><span class="p">).</span>then<span class="p">(</span>cache <span class="p">=></span> <span class="p">{</span>
       <span class="c1">// Begins the process of fetching them.</span>
 <span class="c1"></span>      <span class="c1">// The coast is only clear when all the resources are ready.</span>
 <span class="c1"></span>      <span class="k">return</span> cache<span class="p">.</span>addAll<span class="p">([</span>
@@ -2393,16 +2392,16 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <span class="p">);</span>
 <span class="p">});</span>
 
-self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"fetch"</span><span class="p">,</span> event <span class="o">=></span> <span class="p">{</span>
+self<span class="p">.</span>addEventListener<span class="p">(</span><span class="s2">"fetch"</span><span class="p">,</span> event <span class="p">=></span> <span class="p">{</span>
   <span class="c1">// No "fetch" events are dispatched to the service worker until it</span>
 <span class="c1"></span>  <span class="c1">// successfully installs and activates.</span>
 <span class="c1"></span>
   <span class="c1">// All operations on caches are async, including matching URLs, so we use</span>
 <span class="c1"></span>  <span class="c1">// promises heavily. e.respondWith() even takes promises to enable this:</span>
 <span class="c1"></span>  event<span class="p">.</span>respondWith<span class="p">(</span>
-    caches<span class="p">.</span>match<span class="p">(</span>e<span class="p">.</span>request<span class="p">).</span>then<span class="p">(</span>response <span class="o">=></span> <span class="p">{</span>
+    caches<span class="p">.</span>match<span class="p">(</span>e<span class="p">.</span>request<span class="p">).</span>then<span class="p">(</span>response <span class="p">=></span> <span class="p">{</span>
       <span class="k">return</span> response <span class="o">||</span> fetch<span class="p">(</span>e<span class="p">.</span>request<span class="p">);</span>
-    <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="o">=></span> <span class="p">{</span>
+    <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
       <span class="k">return</span> caches<span class="p">.</span>match<span class="p">(</span><span class="s2">"/fallback.html"</span><span class="p">);</span>
     <span class="p">})</span>
   <span class="p">);</span>
@@ -2908,7 +2907,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
             </ul>
             <p class="note" role="note"><span>Note:</span> <a data-link-type="dfn" href="#dfn-window-client" id="ref-for-dfn-window-client⑤">Window clients</a> are always placed before <a data-link-type="dfn" href="#dfn-worker-client" id="ref-for-dfn-worker-client②">worker clients</a>.</p>
            <li data-md="">
-            <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise⑤">Resolve</a> <var>promise</var> with <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-frozen-array" id="ref-for-dfn-create-frozen-array①">a new frozen array of</a> <var>clientObjects</var> in <var>promise</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm②">relevant Realm</a>.</p>
+            <p><a data-link-type="dfn" href="https://w3c.github.io/FileAPI/#blob-url-resolve" id="ref-for-blob-url-resolve⑤">Resolve</a> <var>promise</var> with <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-create-frozen-array" id="ref-for-dfn-create-frozen-array①">a new frozen array of</a> <var>clientObjects</var> in <var>promise</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm" id="ref-for-concept-relevant-realm②">relevant Realm</a>.</p>
           </ol>
         </ol>
        <li data-md="">
@@ -4094,7 +4093,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <li data-md="">
           <p>If <var>response</var>’s <a href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time②">last update check time</a> to the current time.</p>
          <li data-md="">
-          <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type">Extract a MIME type</a> from the <var>response</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response" id="ref-for-unsafe-response">unsafe response</a>'s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list②">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#javascript-mime-type" id="ref-for-javascript-mime-type">JavaScript MIME type</a>, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error②">network error</a>.</p>
+          <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type">Extract a MIME type</a> from the <var>response</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response" id="ref-for-unsafe-response">unsafe response</a>'s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list②">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#javascript-mime-type" id="ref-for-javascript-mime-type">JavaScript MIME type</a>, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error②">network error</a>.</p>
          <li data-md="">
           <p>If <var>response</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response" id="ref-for-unsafe-response①">unsafe response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type" id="ref-for-concept-response-type①">type</a> is not "<code>error</code>", and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status②">status</a> is an <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#ok-status" id="ref-for-ok-status①">ok status</a>, then:</p>
           <ol>
@@ -4583,7 +4582,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①②">Fetch</a> <var>request</var>, and asynchronously wait to run the remaining steps as part of fetch’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#process-response" id="ref-for-process-response①">process response</a> for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑥">response</a> <var>response</var>.</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type①">Extract a MIME type</a> from the <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list③">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#javascript-mime-type" id="ref-for-javascript-mime-type①">JavaScript MIME type</a>, then:</p>
+         <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type①">Extract a MIME type</a> from the <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list③">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#javascript-mime-type" id="ref-for-javascript-mime-type①">JavaScript MIME type</a>, then:</p>
          <ol>
           <li data-md="">
            <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise⑤">Reject Job Promise</a> with <var>job</var> and "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror" id="ref-for-securityerror⑥">SecurityError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException②②">DOMException</a></code>.</p>
@@ -5877,7 +5876,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>For each <var>fieldValue</var> in <var>fieldValues</var>:</p>
          <ol>
           <li data-md="">
-           <p>If <var>fieldValue</var> matches "<code>*</code>", or the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-value-combined" id="ref-for-concept-header-value-combined">combined value</a> given <var>f</var> and <var>cachedRequest</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-header-list" id="ref-for-concept-request-header-list②">header list</a> does not match the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-value-combined" id="ref-for-concept-header-value-combined①">combined value</a> given <var>f</var> and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-header-list" id="ref-for-concept-request-header-list③">header list</a>, then:</p>
+           <p>If <var>fieldValue</var> matches "<code>*</code>", or the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-value-combined" id="ref-for-concept-header-value-combined">combined value</a> given <var>fieldValue</var> and <var>cachedRequest</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-header-list" id="ref-for-concept-request-header-list②">header list</a> does not match the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-value-combined" id="ref-for-concept-header-value-combined①">combined value</a> given <var>fieldValue</var> and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-header-list" id="ref-for-concept-request-header-list③">header list</a>, then:</p>
            <ol>
             <li data-md="">
              <p>Set <var>isMatched</var> to false.</p>
@@ -6014,7 +6013,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <a class="self-link" href="#example-bf118df6"></a> Default scope: 
 <pre class="highlight"><span class="c1">// Maximum allowed scope defaults to the path the script sits in</span>
 <span class="c1">// "/js" in this example</span>
-<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">).</span>then<span class="p">(()</span> <span class="o">=></span> <span class="p">{</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">).</span>then<span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Install succeeded with the default scope '/js'."</span><span class="p">);</span>
 <span class="p">});</span>
 </pre>
@@ -6023,7 +6022,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <a class="self-link" href="#example-76c5aa8b"></a> Upper path without Service-Worker-Allowed header: 
 <pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location</span>
 <span class="c1">// Response has no Service-Worker-Allowed header</span>
-<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="o">=></span> <span class="p">{</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Install failed due to the path restriction violation."</span><span class="p">);</span>
 <span class="p">});</span>
 </pre>
@@ -6032,7 +6031,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <a class="self-link" href="#example-49d267fe"></a> Upper path with Service-Worker-Allowed header: 
 <pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location</span>
 <span class="c1">// Response included "Service-Worker-Allowed : /"</span>
-<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span>then<span class="p">(()</span> <span class="o">=></span> <span class="p">{</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span>then<span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>log<span class="p">(</span><span class="s2">"Install succeeded as the max allowed scope was overriden to '/'."</span><span class="p">);</span>
 <span class="p">});</span>
 </pre>
@@ -6041,7 +6040,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <a class="self-link" href="#example-7a18b25f"></a> A path restriction voliation even with Service-Worker-Allowed header: 
 <pre class="highlight"><span class="c1">// Set the scope to an upper path of the script location</span>
 <span class="c1">// Response included "Service-Worker-Allowed : /foo"</span>
-<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/foo/bar/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="o">=></span> <span class="p">{</span>
+<span class="c1"></span>navigator<span class="p">.</span>serviceWorker<span class="p">.</span>register<span class="p">(</span><span class="s2">"/foo/bar/sw.js"</span><span class="p">,</span> <span class="p">{</span> scope<span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(()</span> <span class="p">=></span> <span class="p">{</span>
   console<span class="p">.</span>error<span class="p">(</span><span class="s2">"Install failed as the scope is still out of the overriden maximum allowed scope."</span><span class="p">);</span>
 <span class="p">});</span>
 </pre>
@@ -6641,6 +6640,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://fetch.spec.whatwg.org/#concept-header-value">value</a>
     </ul>
    <li>
+    <a data-link-type="biblio">[FileAPI]</a> defines the following terms:
+    <ul>
+     <li><a href="https://w3c.github.io/FileAPI/#blob-url-resolve">resolve</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#abstractworker">AbstractWorker</a>
@@ -6697,7 +6701,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-is-top-level">is top-level</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#javascript-mime-type">javascript mime type</a>
      <li><a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#list-of-active-timers">list of active timers</a>
      <li><a href="https://html.spec.whatwg.org/multipage/indices.html#event-message">message</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">module script</a>
@@ -6776,6 +6779,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://infra.spec.whatwg.org/#map-value">value</a>
     </ul>
    <li>
+    <a data-link-type="biblio">[MIMESNIFF]</a> defines the following terms:
+    <ul>
+     <li><a href="https://mimesniff.spec.whatwg.org/#javascript-mime-type">javascript mime type</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[page-visibility]</a> defines the following terms:
     <ul>
      <li><a href="https://www.w3.org/TR/page-visibility/#VisibilityState">VisibilityState</a>
@@ -6788,7 +6796,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with">a promise rejected with</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-resolved-with">a promise resolved with</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise">reject</a>
-     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise">resolve</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#transforming-by">transforming</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-fulfillment">upon fulfillment</a>
      <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#upon-rejection">upon rejection</a>
@@ -6879,10 +6886,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <dd><a href="https://tc39.github.io/ecma262/">ECMAScript Language Specification</a>. URL: <a href="https://tc39.github.io/ecma262/">https://tc39.github.io/ecma262/</a>
    <dt id="biblio-fetch">[FETCH]
    <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+   <dt id="biblio-fileapi">[FileAPI]
+   <dd>Marijn Kruisselbrink. <a href="https://www.w3.org/TR/FileAPI/">File API</a>. 26 October 2017. WD. URL: <a href="https://www.w3.org/TR/FileAPI/">https://www.w3.org/TR/FileAPI/</a>
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-infra">[INFRA]
    <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+   <dt id="biblio-mimesniff">[MIMESNIFF]
+   <dd>Gordon P. Hemsley. <a href="https://mimesniff.spec.whatwg.org/">MIME Sniffing Standard</a>. Living Standard. URL: <a href="https://mimesniff.spec.whatwg.org/">https://mimesniff.spec.whatwg.org/</a>
    <dt id="biblio-page-visibility">[PAGE-VISIBILITY]
    <dd>Jatinder Mann; Arvind Jain. <a href="https://www.w3.org/TR/page-visibility/">Page Visibility (Second Edition)</a>. 29 October 2013. REC. URL: <a href="https://www.w3.org/TR/page-visibility/">https://www.w3.org/TR/page-visibility/</a>
    <dt id="biblio-promises-guide">[PROMISES-GUIDE]


### PR DESCRIPTION
Query Cache algorithm contains orphaned 'f' references.
Replaced with references to 'fieldValue'.

resolves #1280


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewilligers/ServiceWorker/pull/1281.html" title="Last updated on Feb 22, 2018, 12:12 AM GMT (a02e52d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1281/49f954f...ewilligers:a02e52d.html" title="Last updated on Feb 22, 2018, 12:12 AM GMT (a02e52d)">Diff</a>