### PR TITLE
Improve service worker script caching and update

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -165,7 +165,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A [=/service worker=] has an associated <dfn export id="dfn-skip-waiting-flag">skip waiting flag</dfn>. Unless stated otherwise it is unset.
 
-    A [=/service worker=] has an associated <dfn export id="dfn-imported-scripts-updated-flag">imported scripts updated flag</dfn>. It is initially unset.
+    A [=/service worker=] has an associated <dfn export id="dfn-classic-scripts-imported-flag">classic scripts imported flag</dfn>. It is initially unset.
+
+    A [=/service worker=] has an associated <dfn export id="dfn-include-updated-resources-flag">include updated resources flag</dfn>. It is initially unset.
 
     A [=/service worker=] has an associated <dfn export id="dfn-set-of-event-types-to-handle">set of event types to handle</dfn> (a [=ordered set|set=]) whose [=list/item=] is an <a>event listener</a>'s event type. It is initially an empty set.
 
@@ -2027,22 +2029,28 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       When the <dfn method for="ServiceWorkerGlobalScope" id="importscripts-method"><code>importScripts(|urls|)</code></dfn> method is called on a {{ServiceWorkerGlobalScope}} object, the user agent *must* <a>import scripts into worker global scope</a>, given this {{ServiceWorkerGlobalScope}} object and |urls|, and with the following steps to [=fetching scripts/perform the fetch=] given the [=/request=] |request|:
 
         1. Let |serviceWorker| be |request|'s [=request/client=]'s [=environment settings object/global object=]'s [=ServiceWorkerGlobalScope/service worker=].
-        1. If |serviceWorker|'s <a>imported scripts updated flag</a> is unset, then:
-            1. Let |registration| be |serviceWorker|'s [=containing service worker registration=].
-            1. Set |request|'s [=service-workers mode=] to "`none`".
-            1. Set |request|'s [=request/cache mode=] to "<code>no-cache</code>" if any of the following are true:
-                * |registration|'s [=service worker registration/update via cache mode=] is "`none`".
-                * The [=current global object=]'s [=force bypass cache for importscripts flag=] is set.
-                * |registration|'s [=last update check time=] is not null and the time difference in seconds calculated by the current time minus |registration|’s [=last update check time=] is greater than 86400.
-            1. Let |response| be the result of <a lt="fetch">fetching</a> |request|.
-            1. If |response|’s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|’s [=service worker registration/last update check time=] to the current time.
-            1. [=Extract a MIME type=] from the |response|'s [=unsafe response=]'s [=response/header list=]. If this MIME type (ignoring parameters) is not a [=JavaScript MIME type=], return a [=network error=].
-            1. If |response|'s <a>unsafe response</a>'s [=response/type=] is not "<code>error</code>", and |response|'s [=response/status=] is an <a>ok status</a>, then:
-                1. [=map/Set=] <a>script resource map</a>[|request|'s [=request/url=]] to |response|.
-            1. Return |response|.
-        1. Else:
-            1. If <a>script resource map</a>[|url|] [=map/exists=], return <a>script resource map</a>[|url|].
-            1. Else, return a <a>network error</a>.
+        1. If |serviceWorker|'s [=service worker/script resource map=][|request|'s [=request/url=]] [=map/exists=], return [=service worker/script resource map=][|request|'s [=request/url=]].
+        1. If |serviceWorker|'s [=state=] is *installed*, *activating*, *activated*, or *redundant*, return a [=network error=].
+        1. Let |registration| be |serviceWorker|'s [=containing service worker registration=].
+        1. Set |request|'s [=service-workers mode=] to "`none`".
+        1. Set |request|'s [=request/cache mode=] to "<code>no-cache</code>" if any of the following are true:
+            * |registration|'s [=service worker registration/update via cache mode=] is "`none`".
+            * The [=current global object=]'s [=force bypass cache for importscripts flag=] is set.
+            * |registration|'s [=last update check time=] is not null and the time difference in seconds calculated by the current time minus |registration|’s [=last update check time=] is greater than 86400.
+        1. Let |response| be the result of <a lt="fetch">fetching</a> |request|.
+        1. If |response|’s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|’s [=service worker registration/last update check time=] to the current time.
+        1. [=Extract a MIME type=] from the |response|'s [=unsafe response=]'s [=response/header list=]. If this MIME type (ignoring parameters) is not a [=JavaScript MIME type=], return a [=network error=].
+        1. If |response|'s <a>unsafe response</a>'s [=response/type=] is not "<code>error</code>", and |response|'s [=response/status=] is an <a>ok status</a>, then:
+            1. Let |newestWorker| be the result of running [=Get Newest Worker=] with |registration|.
+            1. Let |resource| be null.
+            1. If |newestWorker| is not null, set |resource| to |newestWorker|'s [=service worker/script resource map=][|request|'s [=request/url=]], or null if it does not [=map/exist=].
+            1. Set |serviceWorker|'s [=service worker/include updated resources flag=] if any of the following are true:
+                * |newestWorker| is null.
+                * |resource| is null.
+                * |resource|'s [=response/body=] is not byte-for-byte identical with |response|'s [=response/body=]. 
+            1. [=map/Set=] [=service worker/script resource map=][|request|'s [=request/url=]] to |response|.
+            1. Set |serviceWorker|'s [=classic scripts imported flag=].
+        1. Return |response|.
     </section>
   </section>
 
@@ -2069,7 +2077,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   <section>
     <h3 id="privacy">Privacy</h3>
 
-    [=/Service workers=] introduce new persistent storage features including <a>scope to registration map</a> (for [=/service worker registrations=] and their [=/service workers=]), [=request response list=] and <a>name to cache map</a> (for caches), and <a>script resource map</a> (for script resources). In order to protect users from any potential <a biblio data-biblio-type="informative" lt="unsanctioned-tracking">unsanctioned tracking</a> threat, these persistent storages *should* be cleared when users intend to clear them and *should* maintain and interoperate with existing user controls e.g. purging all existing persistent storages.
+    [=/Service workers=] introduce new persistent storage features including <a>scope to registration map</a> (for [=/service worker registrations=] and their [=/service workers=]), [=request response list=] and <a>name to cache map</a> (for caches), and [=service worker/script resource map=] (for script resources). In order to protect users from any potential <a biblio data-biblio-type="informative" lt="unsanctioned-tracking">unsanctioned tracking</a> threat, these persistent storages *should* be cleared when users intend to clear them and *should* maintain and interoperate with existing user controls e.g. purging all existing persistent storages.
   </section>
 </section>
 
@@ -2147,7 +2155,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A <a>job</a> has a <dfn id="dfn-job-worker-type">worker type</dfn> ("<code>classic</code>" or "<code>module</code>").
 
+    A [=job=] has a <dfn export id="dfn-job-script-resource-map">script resource map</dfn> which is an <a>ordered map</a> where the keys are [=/URLs=] and the values are [=/responses=].
+
     A <a>job</a> has an <dfn id="dfn-job-update-via-cache-mode">update via cache mode</dfn>, which is "`imports`", "`all`", or "`none`".
+
+    A [=job=] has a <dfn id="dfn-job-potentially-include-updated-resources-flag">potentially include updated resources flag</dfn>. It is initially unset.
 
     A <a>job</a> has a <dfn id="dfn-job-client">client</dfn> (a [=/service worker client=]). It is initially null.
 
@@ -2418,6 +2430,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Else:
               1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" {{DOMException}}.
               1. Asynchronously complete these steps with a <a>network error</a>.
+          1. Set |job|'s [=job/potentially include updated resources flag=] if any of the following are true:
+              * |newestWorker| is null.
+              * |newestWorker|'s [=classic scripts imported flag=] is set.
+              * |newestWorker|'s [=service worker/script resource map=][|request|'s [=request/url=]]'s [=response/body=] is not byte-for-byte identical with |response|'s [=response/body=].
+          1. Set |job|'s [=job/script resource map=][|request|'s [=request/url=]] to |response|.
           1. If |response|'s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|'s <a>last update check time</a> to the current time.
 
               Issue: The response's cache state concept had been removed from fetch. The fetch issue <a href="https://github.com/whatwg/fetch/issues/376">#376</a> tracks the request to restore the concept or add some similar way to check this state.
@@ -2434,20 +2451,23 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
 
           Else, continue the rest of these steps after the algorithm's asynchronous completion, with |script| being the asynchronous completion value.
-
-      1. If |newestWorker| is not null, |newestWorker|'s [=service worker/script url=] [=url/equals=] |job|'s [=job/script url=], and |script|'s [=source text=] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=source text=], if |script| is a [=classic script=], and |script|'s [=module script/module record=]'s \[[ECMAScriptCode]] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=module script/module record=]'s \[[ECMAScriptCode]] otherwise, then:
+      1. If |job|'s [=job/potentially include updated resources flag=] is unset, then:
           1. Invoke [=Resolve Job Promise=] with |job| and |registration|.
+          1. Invoke [=Finish Job=] with |job| and abort these steps.
+      1. Let |worker| be a new [=/service worker=].
+      1. Set |worker|'s [=service worker/script url=] to |job|'s [=job/script url=], |worker|'s <a>script resource</a> to |script|, and |worker|'s [=service worker/type=] to |job|'s <a>worker type</a>.
+      1. [=map/For each=] |url| → |response| of |job|'s [=job/script resource map=]:
+          1. Set |worker|'s [=service worker/script resource map=][|url|] to |response|.
+      1. Set |worker|'s <a>script resource</a>'s <a>HTTPS state</a> to |httpsState|.
+      1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
+      1. Invoke <a>Run Service Worker</a> algorithm given |worker|, and with the *force bypass cache for importscripts flag* set if |job|'s [=job/force bypass cache flag=] is set.
+      1. If an uncaught runtime script error occurs during the above step, then:
+          1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
+          1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
-      1. Else:
-          1. Let |worker| be a new [=/service worker=].
-          1. Set |worker|'s [=service worker/script url=] to |job|'s [=job/script url=], |worker|'s <a>script resource</a> to |script|, and |worker|'s [=service worker/type=] to |job|'s <a>worker type</a>.
-          1. Set |worker|'s <a>script resource</a>'s <a>HTTPS state</a> to |httpsState|.
-          1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
-          1. Invoke <a>Run Service Worker</a> algorithm given |worker|, and with the *force bypass cache for importscripts flag* set if |job|'s [=job/force bypass cache flag=] is set.
-          1. If an uncaught runtime script error occurs during the above step, then:
-              1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
-              1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
-              1. Invoke <a>Finish Job</a> with |job| and abort these steps.
+      1. If |worker|'s [=classic scripts imported flag=] is set, and |worker|'s [=service worker/include updated resources flag=] is unset, then:
+          1. Invoke [=Resolve Job Promise=] with |job| and |registration|.
+          1. Invoke [=Finish Job=] with |job| and abort these steps.
       1. Invoke <a>Install</a> algorithm with |job|, |worker|, and |registration| as its arguments.
   </section>
 
@@ -2509,7 +2529,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and null as the arguments.
           1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
-      1. Set |registration|'s <a>installing worker</a>'s <a>imported scripts updated flag</a>.
       1. If |registration|'s <a>waiting worker</a> is not null, then:
           1. [=Terminate Service Worker|Terminate=] |registration|'s [=waiting worker=].
           1. Run the [=Update Worker State=] algorithm passing |registration|'s [=waiting worker=] and *redundant* as the arguments.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2048,7 +2048,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
                 * |newestWorker| is null.
                 * |resource| is null.
                 * |resource|'s [=response/body=] is not byte-for-byte identical with |response|'s [=response/body=]. 
-            1. [=map/Set=] [=service worker/script resource map=][|request|'s [=request/url=]] to |response|.
+            1. [=map/Set=] |serviceWorker|'s [=service worker/script resource map=][|request|'s [=request/url=]] to |response|.
             1. Set |serviceWorker|'s [=classic scripts imported flag=].
         1. Return |response|.
     </section>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -167,8 +167,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A [=/service worker=] has an associated <dfn export id="dfn-classic-scripts-imported-flag">classic scripts imported flag</dfn>. It is initially unset.
 
-    A [=/service worker=] has an associated <dfn export id="dfn-include-updated-resources-flag">include updated resources flag</dfn>. It is initially unset.
-
     A [=/service worker=] has an associated <dfn export id="dfn-set-of-event-types-to-handle">set of event types to handle</dfn> (a [=ordered set|set=]) whose [=list/item=] is an <a>event listener</a>'s event type. It is initially an empty set.
 
     A [=/service worker=] has an associated <dfn export id="dfn-set-of-extended-events">set of extended events</dfn> (a [=ordered set|set=]) whose [=list/item=] is an {{ExtendableEvent}}. It is initially an empty set.
@@ -2029,25 +2027,19 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       When the <dfn method for="ServiceWorkerGlobalScope" id="importscripts-method"><code>importScripts(|urls|)</code></dfn> method is called on a {{ServiceWorkerGlobalScope}} object, the user agent *must* <a>import scripts into worker global scope</a>, given this {{ServiceWorkerGlobalScope}} object and |urls|, and with the following steps to [=fetching scripts/perform the fetch=] given the [=/request=] |request|:
 
         1. Let |serviceWorker| be |request|'s [=request/client=]'s [=environment settings object/global object=]'s [=ServiceWorkerGlobalScope/service worker=].
-        1. If |serviceWorker|'s [=service worker/script resource map=][|request|'s [=request/url=]] [=map/exists=], return [=service worker/script resource map=][|request|'s [=request/url=]].
-        1. If |serviceWorker|'s [=state=] is *installed*, *activating*, *activated*, or *redundant*, return a [=network error=].
+        1. If |serviceWorker|'s [=service worker/script resource map=][|request|'s [=request/url=]] [=map/exists=], return the [=map/entry=]'s [=map/value=].
+        1. If |serviceWorker|'s [=state=] is not *parsed* or *installing*, return a [=network error=].
         1. Let |registration| be |serviceWorker|'s [=containing service worker registration=].
         1. Set |request|'s [=service-workers mode=] to "`none`".
-        1. Set |request|'s [=request/cache mode=] to "<code>no-cache</code>" if any of the following are true:
+        1. Set |request|'s [=request/cache mode=] to "`no-cache`" if any of the following are true:
             * |registration|'s [=service worker registration/update via cache mode=] is "`none`".
             * The [=current global object=]'s [=force bypass cache for importscripts flag=] is set.
             * |registration|'s [=last update check time=] is not null and the time difference in seconds calculated by the current time minus |registration|’s [=last update check time=] is greater than 86400.
-        1. Let |response| be the result of <a lt="fetch">fetching</a> |request|.
-        1. If |response|’s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|’s [=service worker registration/last update check time=] to the current time.
-        1. [=Extract a MIME type=] from the |response|'s [=unsafe response=]'s [=response/header list=]. If this MIME type (ignoring parameters) is not a [=JavaScript MIME type=], return a [=network error=].
-        1. If |response|'s <a>unsafe response</a>'s [=response/type=] is not "<code>error</code>", and |response|'s [=response/status=] is an <a>ok status</a>, then:
-            1. Let |newestWorker| be the result of running [=Get Newest Worker=] with |registration|.
-            1. Let |resource| be null.
-            1. If |newestWorker| is not null, set |resource| to |newestWorker|'s [=service worker/script resource map=][|request|'s [=request/url=]], or null if it does not [=map/exist=].
-            1. Set |serviceWorker|'s [=service worker/include updated resources flag=] if any of the following are true:
-                * |newestWorker| is null.
-                * |resource| is null.
-                * |resource|'s [=response/body=] is not byte-for-byte identical with |response|'s [=response/body=]. 
+        1. Let |response| be the result of [=fetch|fetching=] |request|.
+        1. Set |response| to |response|'s [=unsafe response=].
+        1. If |response|’s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "`local`", set |registration|’s [=service worker registration/last update check time=] to the current time.
+        1. [=Extract a MIME type=] from the |response|'s [=response/header list=]. If this MIME type (ignoring parameters) is not a [=JavaScript MIME type=], return a [=network error=].
+        1. If |response|'s [=response/type=] is not "`error`", and |response|'s [=response/status=] is an <a>ok status</a>, then:
             1. [=map/Set=] |serviceWorker|'s [=service worker/script resource map=][|request|'s [=request/url=]] to |response|.
             1. Set |serviceWorker|'s [=classic scripts imported flag=].
         1. Return |response|.
@@ -2155,11 +2147,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A <a>job</a> has a <dfn id="dfn-job-worker-type">worker type</dfn> ("<code>classic</code>" or "<code>module</code>").
 
-    A [=job=] has a <dfn export id="dfn-job-script-resource-map">script resource map</dfn> which is an <a>ordered map</a> where the keys are [=/URLs=] and the values are [=/responses=].
-
     A <a>job</a> has an <dfn id="dfn-job-update-via-cache-mode">update via cache mode</dfn>, which is "`imports`", "`all`", or "`none`".
-
-    A [=job=] has a <dfn id="dfn-job-potentially-include-updated-resources-flag">potentially include updated resources flag</dfn>. It is initially unset.
 
     A <a>job</a> has a <dfn id="dfn-job-client">client</dfn> (a [=/service worker client=]). It is initially null.
 
@@ -2383,6 +2371,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |httpsState| be "<code>none</code>".
       1. Let |referrerPolicy| be the empty string.
+      1. Let |hasUpdatedResources| be false.
+      1. Let |updatedResourceMap| be an [=ordered map=] where the keys are [=/URLs=] and the values are [=/responses=].
       1. Switching on |job|'s <a>worker type</a>, run these substeps with the following options:
           <!-- TODO: reorganize algorithm so that the worker environment is created before fetching happens -->
           : "<code>classic</code>"
@@ -2430,15 +2420,28 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Else:
               1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" {{DOMException}}.
               1. Asynchronously complete these steps with a <a>network error</a>.
-          1. Set |job|'s [=job/potentially include updated resources flag=] if any of the following are true:
-              * |newestWorker| is null.
-              * |newestWorker|'s [=classic scripts imported flag=] is set.
-              * |newestWorker|'s [=service worker/script resource map=][|request|'s [=request/url=]]'s [=response/body=] is not byte-for-byte identical with |response|'s [=response/body=].
-          1. Set |job|'s [=job/script resource map=][|request|'s [=request/url=]] to |response|.
+          1. Set |updatedResourceMap|[|request|'s [=request/url=]] to |response|.
           1. If |response|'s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|'s <a>last update check time</a> to the current time.
 
               Issue: The response's cache state concept had been removed from fetch. The fetch issue <a href="https://github.com/whatwg/fetch/issues/376">#376</a> tracks the request to restore the concept or add some similar way to check this state.
 
+          1. If |newestWorker| is null, or |newestWorker|'s [=service worker/script resource map=][|request|'s [=request/url=]]'s [=response/body=] is not byte-for-byte identical with |response|'s [=response/body=], set |hasUpdatedResources| to true.
+          1. Else if |newestWorker|'s [=classic scripts imported flag=] is set, then:
+              1. [=map/For each=] |url| → |storedResponse| of |newestWorker|'s [=service worker/script resource map=]:
+                  1. Let |request| be a new [=/request=] whose [=request/url=] is |url|, [=request/client=] is |job|'s [=job/client=], [=request/destination=] is "`script`", [=request/parser metadata=] is "`not parser-inserted`", [=request/synchronous flag=] is set, and whose [=request/use-URL-credentials flag=] is set.
+                  1. Set |request|'s [=request/cache mode=] to "`no-cache`" if any of the following are true:
+                      * |registration|'s [=service worker registration/update via cache mode=] is "`none`".
+                      * |job|'s [=force bypass cache flag=] is set.
+                      * |registration|'s [=last update check time=] is not null and the time difference in seconds calculated by the current time minus |registration|’s [=last update check time=] is greater than 86400.
+                  1. Let |fetchedResponse| be the result of [=fetch|fetching=] |request|.
+                  1. Set |fetchedResponse| to |fetchedResponse|'s [=unsafe response=].
+                  1. Set |updatedResourceMap|[|request|'s [=request/url=]] to |fetchedResponse|.
+                  1. If |fetchedResponse|'s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|’s [=last update check time=] to the current time.
+                  1. [=Extract a MIME type=] from the |fetchedResponse|'s [=response/header list=]. If this MIME type (ignoring parameters) is not a [=JavaScript MIME type=], asynchronously complete these steps with a [=network error=].
+                  1. If |fetchedResponse|'s [=response/type=] is "`error`", or |fetchedResponse|'s [=response/status=] is not an [=ok status=], asynchronously complete these steps with a [=network error=].
+                  1. If |fetchedResponse|'s [=response/body=] is not byte-for-byte identical with |storedResponse|'s [=response/body=], set |hasUpdatedResources| to true.
+
+                      Note: The control does not break the loop in this step to continue with all the imported scripts to populate the cache.
           1. Return true.
 
           If the algorithm asynchronously completes with null, then:
@@ -2451,12 +2454,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
 
           Else, continue the rest of these steps after the algorithm's asynchronous completion, with |script| being the asynchronous completion value.
-      1. If |job|'s [=job/potentially include updated resources flag=] is unset, then:
+      1. If |hasUpdatedResources| is false, then:
           1. Invoke [=Resolve Job Promise=] with |job| and |registration|.
           1. Invoke [=Finish Job=] with |job| and abort these steps.
       1. Let |worker| be a new [=/service worker=].
       1. Set |worker|'s [=service worker/script url=] to |job|'s [=job/script url=], |worker|'s <a>script resource</a> to |script|, and |worker|'s [=service worker/type=] to |job|'s <a>worker type</a>.
-      1. [=map/For each=] |url| → |response| of |job|'s [=job/script resource map=]:
+      1. [=map/For each=] |url| → |response| of |updatedResourceMap|:
           1. Set |worker|'s [=service worker/script resource map=][|url|] to |response|.
       1. Set |worker|'s <a>script resource</a>'s <a>HTTPS state</a> to |httpsState|.
       1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
@@ -2465,9 +2468,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
           1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
-      1. If |worker|'s [=classic scripts imported flag=] is set, and |worker|'s [=service worker/include updated resources flag=] is unset, then:
-          1. Invoke [=Resolve Job Promise=] with |job| and |registration|.
-          1. Invoke [=Finish Job=] with |job| and abort these steps.
       1. Invoke <a>Install</a> algorithm with |job|, |worker|, and |registration| as its arguments.
   </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2027,7 +2027,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       When the <dfn method for="ServiceWorkerGlobalScope" id="importscripts-method"><code>importScripts(|urls|)</code></dfn> method is called on a {{ServiceWorkerGlobalScope}} object, the user agent *must* <a>import scripts into worker global scope</a>, given this {{ServiceWorkerGlobalScope}} object and |urls|, and with the following steps to [=fetching scripts/perform the fetch=] given the [=/request=] |request|:
 
         1. Let |serviceWorker| be |request|'s [=request/client=]'s [=environment settings object/global object=]'s [=ServiceWorkerGlobalScope/service worker=].
-        1. If |serviceWorker|'s [=service worker/script resource map=][|request|'s [=request/url=]] [=map/exists=], return the [=map/entry=]'s [=map/value=].
+        1. If |serviceWorker|'s [=script resource map=][|request|'s [=request/url=]] [=map/exists=], return the [=map/entry=]'s [=map/value=].
         1. If |serviceWorker|'s [=state=] is not *parsed* or *installing*, return a [=network error=].
         1. Let |registration| be |serviceWorker|'s [=containing service worker registration=].
         1. Set |request|'s [=service-workers mode=] to "`none`".
@@ -2040,7 +2040,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. If |response|’s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "`local`", set |registration|’s [=service worker registration/last update check time=] to the current time.
         1. [=Extract a MIME type=] from the |response|'s [=response/header list=]. If this MIME type (ignoring parameters) is not a [=JavaScript MIME type=], return a [=network error=].
         1. If |response|'s [=response/type=] is not "`error`", and |response|'s [=response/status=] is an <a>ok status</a>, then:
-            1. [=map/Set=] |serviceWorker|'s [=service worker/script resource map=][|request|'s [=request/url=]] to |response|.
+            1. [=map/Set=] |serviceWorker|'s [=script resource map=][|request|'s [=request/url=]] to |response|.
             1. Set |serviceWorker|'s [=classic scripts imported flag=].
         1. Return |response|.
     </section>
@@ -2069,7 +2069,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   <section>
     <h3 id="privacy">Privacy</h3>
 
-    [=/Service workers=] introduce new persistent storage features including <a>scope to registration map</a> (for [=/service worker registrations=] and their [=/service workers=]), [=request response list=] and <a>name to cache map</a> (for caches), and [=service worker/script resource map=] (for script resources). In order to protect users from any potential <a biblio data-biblio-type="informative" lt="unsanctioned-tracking">unsanctioned tracking</a> threat, these persistent storages *should* be cleared when users intend to clear them and *should* maintain and interoperate with existing user controls e.g. purging all existing persistent storages.
+    [=/Service workers=] introduce new persistent storage features including <a>scope to registration map</a> (for [=/service worker registrations=] and their [=/service workers=]), [=request response list=] and <a>name to cache map</a> (for caches), and [=script resource map=] (for script resources). In order to protect users from any potential <a biblio data-biblio-type="informative" lt="unsanctioned-tracking">unsanctioned tracking</a> threat, these persistent storages *should* be cleared when users intend to clear them and *should* maintain and interoperate with existing user controls e.g. purging all existing persistent storages.
   </section>
 </section>
 
@@ -2372,7 +2372,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Let |httpsState| be "<code>none</code>".
       1. Let |referrerPolicy| be the empty string.
       1. Let |hasUpdatedResources| be false.
-      1. Let |updatedResourceMap| be an [=ordered map=] where the keys are [=/URLs=] and the values are [=/responses=].
+      1. Let |updatedResourceMap| be an [=ordered map=] where the [=map/keys=] are [=/URLs=] and the [=map/values=] are [=/responses=].
       1. Switching on |job|'s <a>worker type</a>, run these substeps with the following options:
           <!-- TODO: reorganize algorithm so that the worker environment is created before fetching happens -->
           : "<code>classic</code>"
@@ -2425,9 +2425,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
               Issue: The response's cache state concept had been removed from fetch. The fetch issue <a href="https://github.com/whatwg/fetch/issues/376">#376</a> tracks the request to restore the concept or add some similar way to check this state.
 
-          1. If |newestWorker| is null, or |newestWorker|'s [=service worker/script resource map=][|request|'s [=request/url=]]'s [=response/body=] is not byte-for-byte identical with |response|'s [=response/body=], set |hasUpdatedResources| to true.
+          1. If |newestWorker| is null, or |newestWorker|'s [=script resource map=][|request|'s [=request/url=]]'s [=response/body=] is not byte-for-byte identical with |response|'s [=response/body=], set |hasUpdatedResources| to true.
           1. Else if |newestWorker|'s [=classic scripts imported flag=] is set, then:
-              1. [=map/For each=] |url| → |storedResponse| of |newestWorker|'s [=service worker/script resource map=]:
+              1. [=map/For each=] |url| → |storedResponse| of |newestWorker|'s [=script resource map=]:
                   1. Let |request| be a new [=/request=] whose [=request/url=] is |url|, [=request/client=] is |job|'s [=job/client=], [=request/destination=] is "`script`", [=request/parser metadata=] is "`not parser-inserted`", [=request/synchronous flag=] is set, and whose [=request/use-URL-credentials flag=] is set.
                   1. Set |request|'s [=request/cache mode=] to "`no-cache`" if any of the following are true:
                       * |registration|'s [=service worker registration/update via cache mode=] is "`none`".
@@ -2460,7 +2460,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Let |worker| be a new [=/service worker=].
       1. Set |worker|'s [=service worker/script url=] to |job|'s [=job/script url=], |worker|'s <a>script resource</a> to |script|, and |worker|'s [=service worker/type=] to |job|'s <a>worker type</a>.
       1. [=map/For each=] |url| → |response| of |updatedResourceMap|:
-          1. Set |worker|'s [=service worker/script resource map=][|url|] to |response|.
+          1. Set |worker|'s [=script resource map=][|url|] to |response|.
       1. Set |worker|'s <a>script resource</a>'s <a>HTTPS state</a> to |httpsState|.
       1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
       1. Invoke <a>Run Service Worker</a> algorithm given |worker|, and with the *force bypass cache for importscripts flag* set if |job|'s [=job/force bypass cache flag=] is set.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1177,9 +1177,9 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
-  <meta content="Bikeshed version ae5d415446a9edf0c07d32303ac1d21767d86d57" name="generator">
+  <meta content="Bikeshed version 5afc3ab5248efd53ff0fd6d61ad878a3dc5a357a" name="generator">
   <link href="https://www.w3.org/TR/service-workers/" rel="canonical">
-  <meta content="5230c70eaa3a622f981b8566431d90052a3ac2eb" name="document-revision">
+  <meta content="e2c9db259d6561342eed86fec6f0bbf868884c79" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1426,7 +1426,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-02-23">23 February 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-03-13">13 March 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1747,7 +1747,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <p>A <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource②">script resource</a> has an associated <dfn class="dfn-paneled" data-dfn-for="script resource" data-dfn-type="dfn" data-export="" id="dfn-referrer-policy">referrer policy</dfn> (a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-referrer-policy/#referrer-policy" id="ref-for-referrer-policy">referrer policy</a>). It is initially the empty string.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker②②">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-script-resource-map">script resource map</dfn> which is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">ordered map</a> where the keys are <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①">URLs</a> and the values are <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">responses</a>.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker②③">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-skip-waiting-flag">skip waiting flag</dfn>. Unless stated otherwise it is unset.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker②④">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-imported-scripts-updated-flag">imported scripts updated flag</dfn>. It is initially unset.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker②④">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-classic-scripts-imported-flag">classic scripts imported flag</dfn>. It is initially unset.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker②⑤">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-set-of-event-types-to-handle">set of event types to handle</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">set</a>) whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item" id="ref-for-list-item">item</a> is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-listener" id="ref-for-concept-event-listener">event listener</a>’s event type. It is initially an empty set.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker②⑥">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-set-of-extended-events">set of extended events</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">set</a>) whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item" id="ref-for-list-item①">item</a> is an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent">ExtendableEvent</a></code>. It is initially an empty set.</p>
      <section>
@@ -4073,45 +4073,41 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>Let <var>serviceWorker</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global①⑤">global object</a>'s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker②②">service worker</a>.</p>
        <li data-md="">
-        <p>If <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-imported-scripts-updated-flag" id="ref-for-dfn-imported-scripts-updated-flag">imported scripts updated flag</a> is unset, then:</p>
+        <p>If <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map">script resource map</a>[<var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑦">url</a>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists">exists</a>, return the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry①">entry</a>'s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value①">value</a>.</p>
+       <li data-md="">
+        <p>If <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑤">state</a> is not <em>parsed</em> or <em>installing</em>, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error②">network error</a>.</p>
+       <li data-md="">
+        <p>Let <var>registration</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration①①">containing service worker registration</a>.</p>
+       <li data-md="">
+        <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-service-workers-mode" id="ref-for-request-service-workers-mode①">service-workers mode</a> to "<code>none</code>".</p>
+       <li data-md="">
+        <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode" id="ref-for-concept-request-cache-mode">cache mode</a> to "<code>no-cache</code>" if any of the following are true:</p>
+        <ul>
+         <li data-md="">
+          <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache①">update via cache mode</a> is "<code>none</code>".</p>
+         <li data-md="">
+          <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object" id="ref-for-current-global-object">current global object</a>'s <a data-link-type="dfn" href="#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag" id="ref-for-serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">force bypass cache for importscripts flag</a> is set.</p>
+         <li data-md="">
+          <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time">last update check time</a> is not null and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①">last update check time</a> is greater than 86400.</p>
+        </ul>
+       <li data-md="">
+        <p>Let <var>response</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch⑧">fetching</a> <var>request</var>.</p>
+       <li data-md="">
+        <p>Set <var>response</var> to <var>response</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response" id="ref-for-unsafe-response">unsafe response</a>.</p>
+       <li data-md="">
+        <p>If <var>response</var>’s <a href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time②">last update check time</a> to the current time.</p>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type">Extract a MIME type</a> from the <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list②">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#javascript-mime-type" id="ref-for-javascript-mime-type">JavaScript MIME type</a>, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error③">network error</a>.</p>
+       <li data-md="">
+        <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type" id="ref-for-concept-response-type①">type</a> is not "<code>error</code>", and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status②">status</a> is an <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#ok-status" id="ref-for-ok-status①">ok status</a>, then:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>registration</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration①①">containing service worker registration</a>.</p>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set①">Set</a> <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map①">script resource map</a>[<var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑧">url</a>] to <var>response</var>.</p>
          <li data-md="">
-          <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-service-workers-mode" id="ref-for-request-service-workers-mode①">service-workers mode</a> to "<code>none</code>".</p>
-         <li data-md="">
-          <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode" id="ref-for-concept-request-cache-mode">cache mode</a> to "<code>no-cache</code>" if any of the following are true:</p>
-          <ul>
-           <li data-md="">
-            <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache①">update via cache mode</a> is "<code>none</code>".</p>
-           <li data-md="">
-            <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object" id="ref-for-current-global-object">current global object</a>'s <a data-link-type="dfn" href="#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag" id="ref-for-serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">force bypass cache for importscripts flag</a> is set.</p>
-           <li data-md="">
-            <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time">last update check time</a> is not null and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①">last update check time</a> is greater than 86400.</p>
-          </ul>
-         <li data-md="">
-          <p>Let <var>response</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch⑧">fetching</a> <var>request</var>.</p>
-         <li data-md="">
-          <p>If <var>response</var>’s <a href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time②">last update check time</a> to the current time.</p>
-         <li data-md="">
-          <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type">Extract a MIME type</a> from the <var>response</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response" id="ref-for-unsafe-response">unsafe response</a>'s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list②">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#javascript-mime-type" id="ref-for-javascript-mime-type">JavaScript MIME type</a>, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error②">network error</a>.</p>
-         <li data-md="">
-          <p>If <var>response</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response" id="ref-for-unsafe-response①">unsafe response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type" id="ref-for-concept-response-type①">type</a> is not "<code>error</code>", and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status②">status</a> is an <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#ok-status" id="ref-for-ok-status①">ok status</a>, then:</p>
-          <ol>
-           <li data-md="">
-            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set①">Set</a> <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map">script resource map</a>[<var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑦">url</a>] to <var>response</var>.</p>
-          </ol>
-         <li data-md="">
-          <p>Return <var>response</var>.</p>
+          <p>Set <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-classic-scripts-imported-flag" id="ref-for-dfn-classic-scripts-imported-flag">classic scripts imported flag</a>.</p>
         </ol>
        <li data-md="">
-        <p>Else:</p>
-        <ol>
-         <li data-md="">
-          <p>If <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map①">script resource map</a>[<var>url</var>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists">exists</a>, return <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map②">script resource map</a>[<var>url</var>].</p>
-         <li data-md="">
-          <p>Else, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error③">network error</a>.</p>
-        </ol>
+        <p>Return <var>response</var>.</p>
       </ol>
      </section>
     </section>
@@ -4133,7 +4129,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="6.6" id="privacy"><span class="secno">6.6. </span><span class="content">Privacy</span><a class="self-link" href="#privacy"></a></h3>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑧②">Service workers</a> introduce new persistent storage features including <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map⑤">scope to registration map</a> (for <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration⑤①">service worker registrations</a> and their <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑧③">service workers</a>), <a data-link-type="dfn" href="#dfn-request-response-list" id="ref-for-dfn-request-response-list⑤">request response list</a> and <a data-link-type="dfn" href="#dfn-name-to-cache-map" id="ref-for-dfn-name-to-cache-map④">name to cache map</a> (for caches), and <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map③">script resource map</a> (for script resources). In order to protect users from any potential <a data-link-type="biblio" href="#biblio-unsanctioned-tracking">unsanctioned tracking</a> threat, these persistent storages <em>should</em> be cleared when users intend to clear them and <em>should</em> maintain and interoperate with existing user controls e.g. purging all existing persistent storages.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑧②">Service workers</a> introduce new persistent storage features including <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map⑤">scope to registration map</a> (for <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration⑤①">service worker registrations</a> and their <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑧③">service workers</a>), <a data-link-type="dfn" href="#dfn-request-response-list" id="ref-for-dfn-request-response-list⑤">request response list</a> and <a data-link-type="dfn" href="#dfn-name-to-cache-map" id="ref-for-dfn-name-to-cache-map④">name to cache map</a> (for caches), and <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map②">script resource map</a> (for script resources). In order to protect users from any potential <a data-link-type="biblio" href="#biblio-unsanctioned-tracking">unsanctioned tracking</a> threat, these persistent storages <em>should</em> be cleared when users intend to clear them and <em>should</em> maintain and interoperate with existing user controls e.g. purging all existing persistent storages.</p>
     </section>
    </section>
    <section>
@@ -4549,6 +4545,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>referrerPolicy</var> be the empty string.</p>
       <li data-md="">
+       <p>Let <var>hasUpdatedResources</var> be false.</p>
+      <li data-md="">
+       <p>Let <var>updatedResourceMap</var> be an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map④">ordered map</a> where the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key①">keys</a> are <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①①">URLs</a> and the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value②">values</a> are <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑥">responses</a>.</p>
+      <li data-md="">
        <p>Switching on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type③">worker type</a>, run these substeps with the following options:</p>
        <dl>
         <dt data-md="">"<code>classic</code>"
@@ -4581,7 +4581,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode" id="ref-for-concept-request-redirect-mode">redirect mode</a> to "<code>error</code>".</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①②">Fetch</a> <var>request</var>, and asynchronously wait to run the remaining steps as part of fetch’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#process-response" id="ref-for-process-response①">process response</a> for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑥">response</a> <var>response</var>.</p>
+         <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①②">Fetch</a> <var>request</var>, and asynchronously wait to run the remaining steps as part of fetch’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#process-response" id="ref-for-process-response①">process response</a> for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑦">response</a> <var>response</var>.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type①">Extract a MIME type</a> from the <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list③">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#javascript-mime-type" id="ref-for-javascript-mime-type①">JavaScript MIME type</a>, then:</p>
          <ol>
@@ -4634,8 +4634,47 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <p>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error⑥">network error</a>.</p>
          </ol>
         <li data-md="">
+         <p>Set <var>updatedResourceMap</var>[<var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑨">url</a>] to <var>response</var>.</p>
+        <li data-md="">
          <p>If <var>response</var>’s <a href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑤">last update check time</a> to the current time.</p>
          <p class="issue" id="issue-3c7457a0"><a class="self-link" href="#issue-3c7457a0"></a> The response’s cache state concept had been removed from fetch. The fetch issue <a href="https://github.com/whatwg/fetch/issues/376">#376</a> tracks the request to restore the concept or add some similar way to check this state.</p>
+        <li data-md="">
+         <p>If <var>newestWorker</var> is null, or <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map③">script resource map</a>[<var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①⓪">url</a>]'s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body⑧">body</a> is not byte-for-byte identical with <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body⑨">body</a>, set <var>hasUpdatedResources</var> to true.</p>
+        <li data-md="">
+         <p>Else if <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-classic-scripts-imported-flag" id="ref-for-dfn-classic-scripts-imported-flag①">classic scripts imported flag</a> is set, then:</p>
+         <ol>
+          <li data-md="">
+           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate⑤">For each</a> <var>url</var> → <var>storedResponse</var> of <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map④">script resource map</a>:</p>
+           <ol>
+            <li data-md="">
+             <p>Let <var>request</var> be a new <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①①">url</a> is <var>url</var>, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a> is <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client①⑦">client</a>, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①">destination</a> is "<code>script</code>", <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata">parser metadata</a> is "<code>not parser-inserted</code>", <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#synchronous-flag" id="ref-for-synchronous-flag">synchronous flag</a> is set, and whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag" id="ref-for-concept-request-use-url-credentials-flag">use-URL-credentials flag</a> is set.</p>
+            <li data-md="">
+             <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode" id="ref-for-concept-request-cache-mode②">cache mode</a> to "<code>no-cache</code>" if any of the following are true:</p>
+             <ul>
+              <li data-md="">
+               <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache⑤">update via cache mode</a> is "<code>none</code>".</p>
+              <li data-md="">
+               <p><var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag①">force bypass cache flag</a> is set.</p>
+              <li data-md="">
+               <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑥">last update check time</a> is not null and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑦">last update check time</a> is greater than 86400.</p>
+             </ul>
+            <li data-md="">
+             <p>Let <var>fetchedResponse</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①③">fetching</a> <var>request</var>.</p>
+            <li data-md="">
+             <p>Set <var>fetchedResponse</var> to <var>fetchedResponse</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response" id="ref-for-unsafe-response①">unsafe response</a>.</p>
+            <li data-md="">
+             <p>Set <var>updatedResourceMap</var>[<var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①②">url</a>] to <var>fetchedResponse</var>.</p>
+            <li data-md="">
+             <p>If <var>fetchedResponse</var>’s <a href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑧">last update check time</a> to the current time.</p>
+            <li data-md="">
+             <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type②">Extract a MIME type</a> from the <var>fetchedResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list⑤">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#javascript-mime-type" id="ref-for-javascript-mime-type②">JavaScript MIME type</a>, asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error⑦">network error</a>.</p>
+            <li data-md="">
+             <p>If <var>fetchedResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type" id="ref-for-concept-response-type②">type</a> is "<code>error</code>", or <var>fetchedResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status③">status</a> is not an <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#ok-status" id="ref-for-ok-status②">ok status</a>, asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error⑧">network error</a>.</p>
+            <li data-md="">
+             <p>If <var>fetchedResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①⓪">body</a> is not byte-for-byte identical with <var>storedResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①①">body</a>, set <var>hasUpdatedResources</var> to true.</p>
+             <p class="note" role="note"><span>Note:</span> The control does not break the loop in this step to continue with all the imported scripts to populate the cache.</p>
+           </ol>
+         </ol>
         <li data-md="">
          <p>Return true.</p>
        </ol>
@@ -4651,7 +4690,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        </ol>
        <p>Else, continue the rest of these steps after the algorithm’s asynchronous completion, with <var>script</var> being the asynchronous completion value.</p>
       <li data-md="">
-       <p>If <var>newestWorker</var> is not null, <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url④">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals" id="ref-for-concept-url-equals②">equals</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url①⓪">script url</a>, and <var>script</var>’s <a data-link-type="dfn">source text</a> is a byte-for-byte match with <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑤">script resource</a>'s <a data-link-type="dfn">source text</a>, if <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script" id="ref-for-classic-script">classic script</a>, and <var>script</var>’s <a data-link-type="dfn">module record</a>'s [[ECMAScriptCode]] is a byte-for-byte match with <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑥">script resource</a>'s <a data-link-type="dfn">module record</a>'s [[ECMAScriptCode]] otherwise, then:</p>
+       <p>If <var>hasUpdatedResources</var> is false, then:</p>
        <ol>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise①">Resolve Job Promise</a> with <var>job</var> and <var>registration</var>.</p>
@@ -4659,28 +4698,30 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job⑦">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
-       <p>Else:</p>
+       <p>Let <var>worker</var> be a new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑧⑦">service worker</a>.</p>
+      <li data-md="">
+       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url④">script url</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url①⓪">script url</a>, <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑤">script resource</a> to <var>script</var>, and <var>worker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type①">type</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type④">worker type</a>.</p>
+      <li data-md="">
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate⑥">For each</a> <var>url</var> → <var>response</var> of <var>updatedResourceMap</var>:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>worker</var> be a new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑧⑦">service worker</a>.</p>
+         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map⑤">script resource map</a>[<var>url</var>] to <var>response</var>.</p>
+       </ol>
+      <li data-md="">
+       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑥">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state">HTTPS state</a> to <var>httpsState</var>.</p>
+      <li data-md="">
+       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑦">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy">referrer policy</a> to <var>referrerPolicy</var>.</p>
+      <li data-md="">
+       <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker②">Run Service Worker</a> algorithm given <var>worker</var>, and with the <em>force bypass cache for importscripts flag</em> set if <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag②">force bypass cache flag</a> is set.</p>
+      <li data-md="">
+       <p>If an uncaught runtime script error occurs during the above step, then:</p>
+       <ol>
         <li data-md="">
-         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url⑤">script url</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url①①">script url</a>, <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑦">script resource</a> to <var>script</var>, and <var>worker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type①">type</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type④">worker type</a>.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise⑨">Reject Job Promise</a> with <var>job</var> and <code>TypeError</code>.</p>
         <li data-md="">
-         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑧">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state">HTTPS state</a> to <var>httpsState</var>.</p>
+         <p>If <var>newestWorker</var> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration①">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
         <li data-md="">
-         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑨">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy">referrer policy</a> to <var>referrerPolicy</var>.</p>
-        <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker②">Run Service Worker</a> algorithm given <var>worker</var>, and with the <em>force bypass cache for importscripts flag</em> set if <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag①">force bypass cache flag</a> is set.</p>
-        <li data-md="">
-         <p>If an uncaught runtime script error occurs during the above step, then:</p>
-         <ol>
-          <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise⑨">Reject Job Promise</a> with <var>job</var> and <code>TypeError</code>.</p>
-          <li data-md="">
-           <p>If <var>newestWorker</var> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration①">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
-          <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job⑧">Finish Job</a> with <var>job</var> and abort these steps.</p>
-         </ol>
+         <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job⑧">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#install" id="ref-for-install②">Install</a> algorithm with <var>job</var>, <var>worker</var>, and <var>registration</var> as its arguments.</p>
@@ -4706,11 +4747,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>newestWorker</var> is null, abort these steps.</p>
       <li data-md="">
-       <p>Let <var>job</var> be the result of running <a data-link-type="dfn" href="#create-job" id="ref-for-create-job③">Create Job</a> with <em>update</em>, <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url①③">scope url</a>, <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url⑥">script url</a>, null, and null.</p>
+       <p>Let <var>job</var> be the result of running <a data-link-type="dfn" href="#create-job" id="ref-for-create-job③">Create Job</a> with <em>update</em>, <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url①③">scope url</a>, <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url⑤">script url</a>, null, and null.</p>
       <li data-md="">
        <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type⑤">worker type</a> to <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type②">type</a>.</p>
       <li data-md="">
-       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag②">force bypass cache flag</a> if the <em>force bypass cache flag</em> is set.</p>
+       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag③">force bypass cache flag</a> if the <em>force bypass cache flag</em> is set.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#schedule-job" id="ref-for-schedule-job③">Schedule Job</a> with <var>job</var>.</p>
      </ol>
@@ -4747,7 +4788,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>installingWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker⑦">installing worker</a>.</p>
       <li data-md="">
-       <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker③">Run Service Worker</a> algorithm given <var>installingWorker</var>, and with the <em>force bypass cache for importscripts flag</em> set if <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag③">force bypass cache flag</a> is set.</p>
+       <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker③">Run Service Worker</a> algorithm given <var>installingWorker</var>, and with the <em>force bypass cache for importscripts flag</em> set if <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag④">force bypass cache flag</a> is set.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task" id="ref-for-queue-a-task②②">Queue a task</a> <var>task</var> to run the following substeps:</p>
        <ol>
@@ -4784,8 +4825,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job⑨">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
-       <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker⑨">installing worker</a>’s <a data-link-type="dfn" href="#dfn-imported-scripts-updated-flag" id="ref-for-dfn-imported-scripts-updated-flag①">imported scripts updated flag</a>.</p>
-      <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker③">waiting worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
@@ -4794,7 +4833,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state②">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker⑤">waiting worker</a> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state②">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⓪">installing worker</a> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state②">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker⑨">installing worker</a> as the arguments.</p>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state③">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and null as the arguments.</p>
       <li data-md="">
@@ -4891,7 +4930,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker⑨">waiting worker</a> is null, return.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker③①">active worker</a> is not null and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker③②">active worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑤">state</a> is <em>activating</em>, return.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker③①">active worker</a> is not null and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker③②">active worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑥">state</a> is <em>activating</em>, return.</p>
        <p class="note" role="note"><span>Note:</span> If the existing active worker is still in activating state, the activation of the waiting worker is delayed.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate⑥">Activate</a> with <var>registration</var> if either of the following is true:</p>
@@ -4917,7 +4956,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>Let <var>script</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①⓪">script resource</a>.</p>
+       <p>Let <var>script</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑧">script resource</a>.</p>
       <li data-md="">
        <p class="assertion">Assert: <var>script</var> is not null.</p>
       <li data-md="">
@@ -4956,7 +4995,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Return UTF-8.</p>
         <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url" id="ref-for-api-base-url⑤">API base URL</a>
         <dd data-md="">
-         <p>Return <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url⑦">script url</a>.</p>
+         <p>Return <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url⑥">script url</a>.</p>
         <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②④">origin</a>
         <dd data-md="">
          <p>Return its registering <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client④③">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②⑤">origin</a>.</p>
@@ -4968,11 +5007,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Return <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state" id="ref-for-concept-workerglobalscope-https-state">HTTPS state</a>.</p>
        </dl>
       <li data-md="">
-       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url" id="ref-for-concept-workerglobalscope-url①">url</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url⑧">script url</a>.</p>
+       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url" id="ref-for-concept-workerglobalscope-url①">url</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url⑦">script url</a>.</p>
       <li data-md="">
-       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state" id="ref-for-concept-workerglobalscope-https-state①">HTTPS state</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①①">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state①">HTTPS state</a>.</p>
+       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state" id="ref-for-concept-workerglobalscope-https-state①">HTTPS state</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑨">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state①">HTTPS state</a>.</p>
       <li data-md="">
-       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-referrer-policy" id="ref-for-concept-workerglobalscope-referrer-policy①">referrer policy</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①②">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy①">referrer policy</a>.</p>
+       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-referrer-policy" id="ref-for-concept-workerglobalscope-referrer-policy①">referrer policy</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①⓪">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy①">referrer policy</a>.</p>
       <li data-md="">
        <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type" id="ref-for-concept-workerglobalscope-type">type</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type③">type</a>.</p>
       <li data-md="">
@@ -4982,7 +5021,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker③⑤">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task" id="ref-for-concept-task⑥">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration①③">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue②">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task" id="ref-for-queue-a-task②⑤">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop" id="ref-for-event-loop⑧">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue" id="ref-for-task-queue③">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source" id="ref-for-task-source⑤">task sources</a>.</p>
       <li data-md="">
-       <p>If <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script" id="ref-for-classic-script①">classic script</a>, then <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script" id="ref-for-run-a-classic-script">run the classic script</a> <var>script</var>. Otherwise, it is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script" id="ref-for-module-script">module script</a>; <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script" id="ref-for-run-a-module-script">run the module script</a> <var>script</var>.</p>
+       <p>If <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script" id="ref-for-classic-script">classic script</a>, then <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script" id="ref-for-run-a-classic-script">run the classic script</a> <var>script</var>. Otherwise, it is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script" id="ref-for-module-script">module script</a>; <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script" id="ref-for-run-a-module-script">run the module script</a> <var>script</var>.</p>
        <p class="note" role="note"><span>Note:</span> In addition to the usual possibilities of returning a value or failing due to an exception, this could be prematurely aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker⑦">terminate service worker</a> algorithm.</p>
       <li data-md="">
        <p>If <var>script</var>’s <a data-link-type="dfn" href="#dfn-has-ever-been-evaluated-flag" id="ref-for-dfn-has-ever-been-evaluated-flag">has ever been evaluated flag</a> is unset, then:</p>
@@ -5033,14 +5072,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section class="algorithm" data-algorithm="Handle Fetch">
      <h3 class="heading settled" id="on-fetch-request-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="handle-fetch">Handle Fetch</dfn></span><a class="self-link" href="#on-fetch-request-algorithm"></a></h3>
-     <p>The <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch⑥">Handle Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①③">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨②">service worker</a> context.</p>
+     <p>The <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch⑥">Handle Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①④">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨②">service worker</a> context.</p>
      <dl>
       <dt data-md="">Input
       <dd data-md="">
-       <p><var>request</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a></p>
+       <p><var>request</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">request</a></p>
       <dt data-md="">Output
       <dd data-md="">
-       <p><var>response</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑦">response</a></p>
+       <p><var>response</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑧">response</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -5054,15 +5093,15 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>registration</var> be null.</p>
       <li data-md="">
-       <p>Let <var>client</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a>.</p>
+       <p>Let <var>client</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">client</a>.</p>
       <li data-md="">
        <p>Let <var>reservedClient</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-reserved-client" id="ref-for-concept-request-reserved-client">reserved client</a>.</p>
       <li data-md="">
        <p>Let <var>preloadResponse</var> be a new <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects" id="ref-for-sec-promise-objects③③">promise</a>.</p>
       <li data-md="">
-       <p>Let <var>fetchInstance</var> be the instance of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①④">fetch</a> algorithm representing the ongoing fetch.</p>
+       <p>Let <var>fetchInstance</var> be the instance of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①⑤">fetch</a> algorithm representing the ongoing fetch.</p>
       <li data-md="">
-       <p class="assertion">Assert: <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①">destination</a> is not "<code>serviceworker</code>".</p>
+       <p class="assertion">Assert: <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②">destination</a> is not "<code>serviceworker</code>".</p>
       <li data-md="">
        <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request" id="ref-for-potential-navigation-or-subresource-request①">potential-navigation-or-subresource request</a>, then:</p>
        <ol>
@@ -5083,16 +5122,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Else:</p>
          <ol>
           <li data-md="">
-           <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑧">url</a> is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url③">potentially trustworthy URL</a>, return null.</p>
+           <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①③">url</a> is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url③">potentially trustworthy URL</a>, return null.</p>
          </ol>
         <li data-md="">
          <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request" id="ref-for-navigation-request">navigation request</a> and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate" id="ref-for-navigate③">navigation</a> triggering it was initiated with a shift+reload or equivalent, return null.</p>
         <li data-md="">
-         <p>Set <var>registration</var> to the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration⑨">Match Service Worker Registration</a> algorithm passing <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑨">url</a> as the argument.</p>
+         <p>Set <var>registration</var> to the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration⑨">Match Service Worker Registration</a> algorithm passing <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①④">url</a> as the argument.</p>
         <li data-md="">
          <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker③⑥">active worker</a> is null, return null.</p>
         <li data-md="">
-         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report" id="ref-for-dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker" id="ref-for-concept-environment-active-service-worker⑦">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker③⑦">active worker</a>.</p>
+         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination③">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report" id="ref-for-dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker" id="ref-for-concept-environment-active-service-worker⑦">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker③⑦">active worker</a>.</p>
         <li data-md="">
          <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request" id="ref-for-navigation-request①">navigation request</a>, <var>registration</var>’s <a data-link-type="dfn" href="#service-worker-registration-navigation-preload-enabled-flag" id="ref-for-service-worker-registration-navigation-preload-enabled-flag③">navigation preload enabled flag</a> is set, <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method⑤">method</a> is `<code>GET</code>`, and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker③⑧">active worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle①">set of event types to handle</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> <code>fetch</code>, then:</p>
          <p class="note" role="note"><span>Note:</span> If the above is true except <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker③⑨">active worker</a>'s <a data-link-type="dfn" href="#dfn-set-of-event-types-to-handle" id="ref-for-dfn-set-of-event-types-to-handle②">set of event types to handle</a> <strong>does not</strong> contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer’s intent isn’t clear.</p>
@@ -5111,11 +5150,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <p>Run the following substeps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③③">in parallel</a>:</p>
            <ol>
             <li data-md="">
-             <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①⑤">Fetch</a> <var>preloadRequest</var> and let <var>preloadFetchInstance</var> be the instance of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①⑥">fetch</a> algorithm.</p>
+             <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①⑥">Fetch</a> <var>preloadRequest</var> and let <var>preloadFetchInstance</var> be the instance of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①⑦">fetch</a> algorithm.</p>
              <p>To <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#process-response" id="ref-for-process-response②">process response</a> for <var>navigationPreloadResponse</var>, run these substeps:</p>
              <ol>
               <li data-md="">
-               <p>If <var>navigationPreloadResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type" id="ref-for-concept-response-type②">type</a> is "<code>error</code>", reject <var>preloadResponse</var> with a <code>TypeError</code> and terminate these substeps.</p>
+               <p>If <var>navigationPreloadResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type" id="ref-for-concept-response-type③">type</a> is "<code>error</code>", reject <var>preloadResponse</var> with a <code>TypeError</code> and terminate these substeps.</p>
               <li data-md="">
                <p>Associate <var>preloadResponseObject</var> with <var>navigationPreloadResponse</var>.</p>
               <li data-md="">
@@ -5145,13 +5184,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Return null and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③④">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request②">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request①">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑥">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request②">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request①">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑨">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update">Soft Update</a> algorithm with <var>registration</var>.</p>
         <li data-md="">
          <p>Abort these steps.</p>
        </ol>
        <p class="note" role="note"><span>Note:</span> To avoid unnecessary delays, the Handle Fetch enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
       <li data-md="">
-       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑥">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑦">state</a> to become <em>activated</em>.</p>
+       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑦">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑧">state</a> to become <em>activated</em>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker⑤">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
@@ -5172,7 +5211,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-clientid" id="ref-for-dom-fetchevent-clientid②">clientId</a></code> attribute to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id" id="ref-for-concept-environment-id②">id</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request③">non-subresource request</a> and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination③">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report" id="ref-for-dom-requestdestination-report①">"report"</a></code>, initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-resultingclientid" id="ref-for-dom-fetchevent-resultingclientid②">resultingClientId</a></code> attribute to <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id" id="ref-for-concept-environment-id③">id</a>, and to the empty string otherwise.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request③">non-subresource request</a> and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination④">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report" id="ref-for-dom-requestdestination-report①">"report"</a></code>, initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-resultingclientid" id="ref-for-dom-fetchevent-resultingclientid②">resultingClientId</a></code> attribute to <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id" id="ref-for-concept-environment-id③">id</a>, and to the empty string otherwise.</p>
         <li data-md="">
          <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request" id="ref-for-navigation-request②">navigation request</a>, initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-targetclientid" id="ref-for-dom-fetchevent-targetclientid②">targetClientId</a></code> attribute to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-target-client-id" id="ref-for-concept-request-target-client-id">target client id</a>, and to the empty string otherwise.</p>
         <li data-md="">
@@ -5204,11 +5243,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>respondWithEntered</var> is false, then:</p>
        <ol>
         <li data-md="">
-         <p>If <var>eventCanceled</var> is true, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error⑦">network error</a> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③⑤">in parallel</a>.</p>
+         <p>If <var>eventCanceled</var> is true, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error⑨">network error</a> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③⑤">in parallel</a>.</p>
         <li data-md="">
          <p>Else, return null and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③⑥">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request④">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request②">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑦">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update①">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request④">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request②">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①⓪">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update①">Soft Update</a> algorithm with <var>registration</var>.</p>
         <li data-md="">
          <p>Abort these steps.</p>
        </ol>
@@ -5216,9 +5255,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>handleFetchFailed</var> is true, then:</p>
        <ol>
         <li data-md="">
-         <p>Return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error⑧">network error</a> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③⑦">in parallel</a>.</p>
+         <p>Return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error①⓪">network error</a> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③⑦">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request⑤">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request③">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑧">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update②">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request⑤">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request③">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①①">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update②">Soft Update</a> algorithm with <var>registration</var>.</p>
        </ol>
       <li data-md="">
        <p>Else:</p>
@@ -5226,7 +5265,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Return <var>response</var> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③⑧">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request⑥">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request④">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑨">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update③">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request⑥">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request④">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①②">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update③">Soft Update</a> algorithm with <var>registration</var>.</p>
        </ol>
      </ol>
     </section>
@@ -5257,13 +5296,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Return and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③⑨">in parallel</a>.</p>
         <li data-md="">
-         <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①⓪">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update④">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①③">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update④">Soft Update</a> algorithm with <var>registration</var>.</p>
         <li data-md="">
          <p>Abort these steps.</p>
        </ol>
        <p class="note" role="note"><span>Note:</span> To avoid unnecessary delays, the Handle Functional Event enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
       <li data-md="">
-       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑧">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑨">state</a> to become <em>activated</em>.</p>
+       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑨">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state①⓪">state</a> to become <em>activated</em>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker⑥">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
@@ -5278,7 +5317,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded.</p>
       <li data-md="">
-       <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①①">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update⑤">Soft Update</a> algorithm with <var>registration</var>.</p>
+       <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①④">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update⑤">Soft Update</a> algorithm with <var>registration</var>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle Service Worker Client Unload">
@@ -5319,10 +5358,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate⑤">For each</a> <var>scope</var> → <var>registration</var> of <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map⑦">scope to registration map</a>:</p>
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate⑦">For each</a> <var>scope</var> → <var>registration</var> of <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map⑦">scope to registration map</a>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①①">installing worker</a> <var>installingWorker</var> is not null, then:</p>
+         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⓪">installing worker</a> <var>installingWorker</var> is not null, then:</p>
          <ol>
           <li data-md="">
            <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker①①">waiting worker</a> is null and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker④③">active worker</a> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration③">Clear Registration</a> with <var>registration</var> and continue to the next iteration of the loop.</p>
@@ -5375,7 +5414,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②⑥">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url⑧">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client①⑦">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②⑦">origin</a>, then:</p>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②⑥">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url⑧">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client①⑧">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②⑦">origin</a>, then:</p>
        <ol>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise①⓪">Reject Job Promise</a> with <var>job</var> and "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror" id="ref-for-securityerror⑨">SecurityError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException②⑤">DOMException</a></code>.</p>
@@ -5408,9 +5447,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <dl>
       <dt data-md="">Input
       <dd data-md="">
-       <p><var>scope</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①①">URL</a></p>
+       <p><var>scope</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①②">URL</a></p>
       <dd data-md="">
-       <p><var>updateViaCache</var>, an <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache⑤">update via cache mode</a></p>
+       <p><var>updateViaCache</var>, an <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache⑥">update via cache mode</a></p>
       <dt data-md="">Output
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration⑥③">service worker registration</a></p>
@@ -5421,7 +5460,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>scopeString</var> be <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer⑨">serialized</a> <var>scope</var> with the <em>exclude fragment flag</em> set.</p>
       <li data-md="">
-       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration⑥④">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url①⑥">scope url</a> is set to <var>scope</var> and <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache⑥">update via cache mode</a> is set to <var>updateViaCache</var>.</p>
+       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration⑥④">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url①⑥">scope url</a> is set to <var>scope</var> and <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache⑦">update via cache mode</a> is set to <var>updateViaCache</var>.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set③">Set</a> <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map⑧">scope to registration map</a>[<var>scopeString</var>] to <var>registration</var>.</p>
       <li data-md="">
@@ -5442,12 +5481,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Run the following steps atomically.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①②">installing worker</a> is not null, then:</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①①">installing worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker①⓪">Terminate</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①③">installing worker</a>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker①⓪">Terminate</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①②">installing worker</a>.</p>
         <li data-md="">
-         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state⑧">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①④">installing worker</a> and <em>redundant</em> as the arguments.</p>
+         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state⑧">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①③">installing worker</a> and <em>redundant</em> as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state⑥">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and null as the arguments.</p>
        </ol>
@@ -5492,7 +5531,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration⑥">Clear Registration</a> with <var>registration</var> if no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client④⑧">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use⑨">using</a> <var>registration</var> and all of the following conditions are true:</p>
        <ul>
         <li data-md="">
-         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑤">installing worker</a> is null or the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events①">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑥">installing worker</a> is true.</p>
+         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①④">installing worker</a> is null or the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events①">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑤">installing worker</a> is true.</p>
         <li data-md="">
          <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker①⑥">waiting worker</a> is null or the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events②">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker①⑦">waiting worker</a> is true.</p>
         <li data-md="">
@@ -5521,12 +5560,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>target</var> is "<code>installing</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑦">installing worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑥">installing worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task" id="ref-for-queue-a-task③⓪">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-installing" id="ref-for-dom-serviceworkerregistration-installing②">installing</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker②④">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑧">installing worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑨">installing worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task" id="ref-for-queue-a-task③⓪">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-installing" id="ref-for-dom-serviceworkerregistration-installing②">installing</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker②④">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑦">installing worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑧">installing worker</a> is null.</p>
          </ol>
        </ol>
       <li data-md="">
@@ -5563,14 +5602,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dd data-md="">
        <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨⑤">service worker</a></p>
       <dd data-md="">
-       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨⑥">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state①⓪">state</a></p>
+       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨⑥">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state①①">state</a></p>
       <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
      <ol>
       <li data-md="">
-       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state①①">state</a> to <var>state</var>.</p>
+       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state①②">state</a> to <var>state</var>.</p>
       <li data-md="">
        <p>Let <var>workerObjects</var> be an array containing all the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker②⑦">ServiceWorker</a></code> objects associated with <var>worker</var>.</p>
       <li data-md="">
@@ -5580,12 +5619,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task" id="ref-for-queue-a-task③③">Queue a task</a> to run these substeps:</p>
          <ol>
           <li data-md="">
-           <p>Set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworker-state" id="ref-for-dom-serviceworker-state④">state</a></code> attribute of <var>workerObject</var> to the value (in <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate③">ServiceWorkerState</a></code> enumeration) corresponding to the first matching statement, switching on <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state①②">state</a>:</p>
+           <p>Set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworker-state" id="ref-for-dom-serviceworker-state④">state</a></code> attribute of <var>workerObject</var> to the value (in <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate③">ServiceWorkerState</a></code> enumeration) corresponding to the first matching statement, switching on <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state①③">state</a>:</p>
            <dl>
             <dt data-md=""><em>installing</em>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installing" id="ref-for-dom-serviceworkerstate-installing">"installing"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨⑦">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker②⓪">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil⑥">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall①">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers⑧">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker②①">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects" id="ref-for-sec-promise-objects③④">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨⑧">service worker</a> is not active until all of the core caches are populated.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨⑦">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑨">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil⑥">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall①">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers⑧">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker②⓪">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects" id="ref-for-sec-promise-objects③④">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨⑧">service worker</a> is not active until all of the core caches are populated.</p>
             <dt data-md=""><em>installed</em>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installed" id="ref-for-dom-serviceworkerstate-installed">"installed"</a></code></p>
@@ -5633,7 +5672,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <dl>
       <dt data-md="">Input
       <dd data-md="">
-       <p><var>clientURL</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①②">URL</a></p>
+       <p><var>clientURL</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①③">URL</a></p>
       <dt data-md="">Output
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration⑥⑧">service worker registration</a></p>
@@ -5673,7 +5712,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <dl>
       <dt data-md="">Input
       <dd data-md="">
-       <p><var>scope</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①③">URL</a></p>
+       <p><var>scope</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①④">URL</a></p>
       <dt data-md="">Output
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration⑥⑨">service worker registration</a></p>
@@ -5688,7 +5727,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>registration</var> be null.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate⑥">For each</a> <var>key</var> → <var>value</var> of <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map①①">scope to registration map</a>:</p>
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate⑧">For each</a> <var>key</var> → <var>value</var> of <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map①①">scope to registration map</a>:</p>
        <ol>
         <li data-md="">
          <p>If <var>scopeString</var> matches <var>key</var>, set <var>registration</var> to <var>value</var>.</p>
@@ -5713,7 +5752,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>newestWorker</var> be null.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker②②">installing worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker②③">installing worker</a>.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker②①">installing worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker②②">installing worker</a>.</p>
       <li data-md="">
        <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker②②">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker②③">waiting worker</a>.</p>
       <li data-md="">
@@ -5802,7 +5841,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <dl>
       <dt data-md="">Input
       <dd data-md="">
-       <p><var>request</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">request</a></p>
+       <p><var>request</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤">request</a></p>
       <dd data-md="">
        <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-cachequeryoptions" id="ref-for-dictdef-cachequeryoptions⑥">CacheQueryOptions</a></code> object, optional</p>
       <dd data-md="">
@@ -5832,9 +5871,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①①">For each</a> <var>requestResponse</var> of <var>storage</var>:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>cachedURL</var> to <var>requestResponse</var>’s request’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①⓪">url</a>.</p>
+         <p>Set <var>cachedURL</var> to <var>requestResponse</var>’s request’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①⑤">url</a>.</p>
         <li data-md="">
-         <p>Set <var>requestURL</var> to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①①">url</a>.</p>
+         <p>Set <var>requestURL</var> to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①⑥">url</a>.</p>
         <li data-md="">
          <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-cachequeryoptions-ignoresearch" id="ref-for-dom-cachequeryoptions-ignoresearch">ignoreSearch</a></code> is true, then:</p>
          <ol>
@@ -5844,7 +5883,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <p>Set <var>requestURL</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-query" id="ref-for-concept-url-query①">query</a> to the empty string.</p>
          </ol>
         <li data-md="">
-         <p>If <var>cachedURL</var> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals" id="ref-for-concept-url-equals③">equals</a> <var>requestURL</var> with the <em>exclude fragment flag</em> set, then:</p>
+         <p>If <var>cachedURL</var> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals" id="ref-for-concept-url-equals②">equals</a> <var>requestURL</var> with the <em>exclude fragment flag</em> set, then:</p>
          <ol>
           <li data-md="">
            <p>Add a copy of <var>requestResponse</var>’s request to <var>requests</var>.</p>
@@ -5862,7 +5901,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Increment <var>index</var> by one.</p>
         <li data-md="">
-         <p>If <var>cachedResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list⑤">header list</a> contains no <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header③">header</a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-name" id="ref-for-concept-header-name③">named</a> `<code>Vary</code>`, or <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-cachequeryoptions-ignorevary" id="ref-for-dom-cachequeryoptions-ignorevary">ignoreVary</a></code> is true, then:</p>
+         <p>If <var>cachedResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list⑥">header list</a> contains no <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header③">header</a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-name" id="ref-for-concept-header-name③">named</a> `<code>Vary</code>`, or <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-cachequeryoptions-ignorevary" id="ref-for-dom-cachequeryoptions-ignorevary">ignoreVary</a></code> is true, then:</p>
          <ol>
           <li data-md="">
            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append⑦">Append</a> <var>cachedRequest</var>/<var>cachedResponse</var> to <var>resultList</var>.</p>
@@ -5945,7 +5984,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
             <li data-md="">
              <p>Let <var>r</var> be <var>operation</var>’s <a data-link-type="dfn" href="#dfn-cache-batch-operation-request" id="ref-for-dfn-cache-batch-operation-request⑤">request</a>'s associated <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-request" id="ref-for-concept-request-request①⓪">request</a>.</p>
             <li data-md="">
-             <p>If <var>r</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①②">url</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑥">scheme</a> is not one of "<code>http</code>" and "<code>https</code>", <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw②⓪">throw</a> a <code>TypeError</code>.</p>
+             <p>If <var>r</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①⑦">url</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑥">scheme</a> is not one of "<code>http</code>" and "<code>https</code>", <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw②⓪">throw</a> a <code>TypeError</code>.</p>
             <li data-md="">
              <p>If <var>r</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method⑦">method</a> is not `<code>GET</code>`, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw②①">throw</a> a <code>TypeError</code>.</p>
             <li data-md="">
@@ -5993,17 +6032,17 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <h2 class="heading settled" id="extended-http-headers"><span class="content">Appendix B: Extended HTTP headers</span><a class="self-link" href="#extended-http-headers"></a></h2>
     <section>
      <h3 class="heading settled" id="service-worker-script-request"><span class="content">Service Worker Script Request</span><a class="self-link" href="#service-worker-script-request"></a></h3>
-     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①⑦">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①⓪⑦">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①③">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header④">header</a>:</p>
+     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①⑧">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①⓪⑦">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①①">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header④">header</a>:</p>
      <dl>
       <dt data-md="">`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker"><code>Service-Worker</code><a class="self-link" href="#service-worker"></a></dfn>`
       <dd data-md="">
-       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①⓪⑧">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①④">script resource</a> request.</p>
+       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①⓪⑧">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①②">script resource</a> request.</p>
        <p class="note" role="note"><span>Note:</span> This header helps administrators log the requests and detect threats.</p>
      </dl>
     </section>
     <section>
      <h3 class="heading settled" id="service-worker-script-response"><span class="content">Service Worker Script Response</span><a class="self-link" href="#service-worker-script-response"></a></h3>
-     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①⓪⑨">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①⑤">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header⑤">header</a>:</p>
+     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①⓪⑨">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①③">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header⑤">header</a>:</p>
      <dl>
       <dt data-md="">`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker-allowed"><code>Service-Worker-Allowed</code><a class="self-link" href="#service-worker-allowed"></a></dfn>`
       <dd data-md="">
@@ -6049,7 +6088,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" id="syntax"><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
-     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①①⓪">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①⑥">script resource</a> requests and responses:</p>
+     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①①⓪">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①④">script resource</a> requests and responses:</p>
 <pre>Service-Worker = %x73.63.72.69.70.74 ; "script", case-sensitive
 </pre>
      <p class="note" role="note"><span>Note:</span> The validation of the Service-Worker-Allowed header’s values is done by URL parsing algorithm (in Update algorithm) instead of using ABNF.</p>
@@ -6137,6 +6176,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#global-caches-attribute">caches</a><span>, in §5.3.1</span>
    <li><a href="#cachestorage">CacheStorage</a><span>, in §5.5</span>
    <li><a href="#dom-clients-claim">claim()</a><span>, in §4.3.4</span>
+   <li><a href="#dfn-classic-scripts-imported-flag">classic scripts imported flag</a><span>, in §2.1</span>
    <li><a href="#clear-registration">Clear Registration</a><span>, in §Unnumbered section</span>
    <li><a href="#dfn-job-client">client</a><span>, in §Unnumbered section</span>
    <li><a href="#client">Client</a><span>, in §4.2</span>
@@ -6220,7 +6260,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dom-cachequeryoptions-ignoremethod">ignoreMethod</a><span>, in §5.4</span>
    <li><a href="#dom-cachequeryoptions-ignoresearch">ignoreSearch</a><span>, in §5.4</span>
    <li><a href="#dom-cachequeryoptions-ignorevary">ignoreVary</a><span>, in §5.4</span>
-   <li><a href="#dfn-imported-scripts-updated-flag">imported scripts updated flag</a><span>, in §2.1</span>
    <li><a href="#dom-serviceworkerupdateviacache-imports">"imports"</a><span>, in §3.2</span>
    <li><a href="#dom-serviceworkerupdateviacache-imports">imports</a><span>, in §3.2</span>
    <li><a href="#importscripts-method">importScripts(urls)</a><span>, in §6.3.2</span>
@@ -6531,7 +6570,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
-    <a data-link-type="biblio">[CSP3]</a> defines the following terms:
+    <a data-link-type="biblio">[csp-3]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/webappsec-csp/#enforced">enforced</a>
      <li><a href="https://w3c.github.io/webappsec-csp/#monitored">monitored</a>
@@ -6618,6 +6657,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>
      <li><a href="https://fetch.spec.whatwg.org/#ok-status">ok status</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">opaque filtered response</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata">parser metadata</a>
      <li><a href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">potential-navigation-or-subresource request</a>
      <li><a href="https://fetch.spec.whatwg.org/#process-response">process response</a>
      <li><a href="https://fetch.spec.whatwg.org/#process-response-end-of-body">process response end-of-body</a>
@@ -6634,10 +6674,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://fetch.spec.whatwg.org/#concept-response-status">status</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-body-stream">stream</a>
      <li><a href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a>
+     <li><a href="https://fetch.spec.whatwg.org/#synchronous-flag">synchronous flag</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-target-client-id">target client id</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-fetch-terminate">terminated</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-response-type">type</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-url">url</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag">use-url-credentials flag</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-header-value">value</a>
     </ul>
    <li>
@@ -6874,8 +6916,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
-   <dt id="biblio-csp3">[CSP3]
-   <dd>Mike West. <a href="https://www.w3.org/TR/CSP3/">Content Security Policy Level 3</a>. 13 September 2016. WD. URL: <a href="https://www.w3.org/TR/CSP3/">https://www.w3.org/TR/CSP3/</a>
+   <dt id="biblio-csp-3">[CSP-3]
+   <dd>Content Security Policy Level 3 URL: <a href="https://www.w3.org/TR/CSP3/">https://www.w3.org/TR/CSP3/</a>
    <dt id="biblio-dom">[DOM]
    <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-ecmascript">[ECMASCRIPT]
@@ -7195,10 +7237,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-state">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-state①">(2)</a> <a href="#ref-for-dfn-state②">(3)</a>
     <li><a href="#ref-for-dfn-state③">3.1. ServiceWorker</a>
     <li><a href="#ref-for-dfn-state④">3.2.7. update()</a>
-    <li><a href="#ref-for-dfn-state⑤">Try Activate</a>
-    <li><a href="#ref-for-dfn-state⑥">Handle Fetch</a> <a href="#ref-for-dfn-state⑦">(2)</a>
-    <li><a href="#ref-for-dfn-state⑧">Handle Functional Event</a> <a href="#ref-for-dfn-state⑨">(2)</a>
-    <li><a href="#ref-for-dfn-state①⓪">Update Worker State</a> <a href="#ref-for-dfn-state①①">(2)</a> <a href="#ref-for-dfn-state①②">(3)</a>
+    <li><a href="#ref-for-dfn-state⑤">6.3.2. importScripts(urls)</a>
+    <li><a href="#ref-for-dfn-state⑥">Try Activate</a>
+    <li><a href="#ref-for-dfn-state⑦">Handle Fetch</a> <a href="#ref-for-dfn-state⑧">(2)</a>
+    <li><a href="#ref-for-dfn-state⑨">Handle Functional Event</a> <a href="#ref-for-dfn-state①⓪">(2)</a>
+    <li><a href="#ref-for-dfn-state①①">Update Worker State</a> <a href="#ref-for-dfn-state①②">(2)</a> <a href="#ref-for-dfn-state①③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-script-url">
@@ -7207,9 +7250,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-script-url">3.1.1. scriptURL</a>
     <li><a href="#ref-for-dfn-script-url①">3.2.7. update()</a>
     <li><a href="#ref-for-dfn-script-url②">Register</a>
-    <li><a href="#ref-for-dfn-script-url③">Update</a> <a href="#ref-for-dfn-script-url④">(2)</a> <a href="#ref-for-dfn-script-url⑤">(3)</a>
-    <li><a href="#ref-for-dfn-script-url⑥">Soft Update</a>
-    <li><a href="#ref-for-dfn-script-url⑦">Run Service Worker</a> <a href="#ref-for-dfn-script-url⑧">(2)</a>
+    <li><a href="#ref-for-dfn-script-url③">Update</a> <a href="#ref-for-dfn-script-url④">(2)</a>
+    <li><a href="#ref-for-dfn-script-url⑤">Soft Update</a>
+    <li><a href="#ref-for-dfn-script-url⑥">Run Service Worker</a> <a href="#ref-for-dfn-script-url⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-type">
@@ -7275,11 +7318,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-script-resource">2.1. Service Worker</a> <a href="#ref-for-dfn-script-resource①">(2)</a> <a href="#ref-for-dfn-script-resource②">(3)</a>
     <li><a href="#ref-for-dfn-script-resource③">6.2. Content Security Policy</a> <a href="#ref-for-dfn-script-resource④">(2)</a>
-    <li><a href="#ref-for-dfn-script-resource⑤">Update</a> <a href="#ref-for-dfn-script-resource⑥">(2)</a> <a href="#ref-for-dfn-script-resource⑦">(3)</a> <a href="#ref-for-dfn-script-resource⑧">(4)</a> <a href="#ref-for-dfn-script-resource⑨">(5)</a>
-    <li><a href="#ref-for-dfn-script-resource①⓪">Run Service Worker</a> <a href="#ref-for-dfn-script-resource①①">(2)</a> <a href="#ref-for-dfn-script-resource①②">(3)</a>
-    <li><a href="#ref-for-dfn-script-resource①③">Service Worker Script Request</a> <a href="#ref-for-dfn-script-resource①④">(2)</a>
-    <li><a href="#ref-for-dfn-script-resource①⑤">Service Worker Script Response</a>
-    <li><a href="#ref-for-dfn-script-resource①⑥">Syntax</a>
+    <li><a href="#ref-for-dfn-script-resource⑤">Update</a> <a href="#ref-for-dfn-script-resource⑥">(2)</a> <a href="#ref-for-dfn-script-resource⑦">(3)</a>
+    <li><a href="#ref-for-dfn-script-resource⑧">Run Service Worker</a> <a href="#ref-for-dfn-script-resource⑨">(2)</a> <a href="#ref-for-dfn-script-resource①⓪">(3)</a>
+    <li><a href="#ref-for-dfn-script-resource①①">Service Worker Script Request</a> <a href="#ref-for-dfn-script-resource①②">(2)</a>
+    <li><a href="#ref-for-dfn-script-resource①③">Service Worker Script Response</a>
+    <li><a href="#ref-for-dfn-script-resource①④">Syntax</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-has-ever-been-evaluated-flag">
@@ -7305,8 +7348,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-script-resource-map">
    <b><a href="#dfn-script-resource-map">#dfn-script-resource-map</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-script-resource-map">6.3.2. importScripts(urls)</a> <a href="#ref-for-dfn-script-resource-map①">(2)</a> <a href="#ref-for-dfn-script-resource-map②">(3)</a>
-    <li><a href="#ref-for-dfn-script-resource-map③">6.6. Privacy</a>
+    <li><a href="#ref-for-dfn-script-resource-map">6.3.2. importScripts(urls)</a> <a href="#ref-for-dfn-script-resource-map①">(2)</a>
+    <li><a href="#ref-for-dfn-script-resource-map②">6.6. Privacy</a>
+    <li><a href="#ref-for-dfn-script-resource-map③">Update</a> <a href="#ref-for-dfn-script-resource-map④">(2)</a> <a href="#ref-for-dfn-script-resource-map⑤">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-skip-waiting-flag">
@@ -7317,11 +7361,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-skip-waiting-flag②">Try Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-imported-scripts-updated-flag">
-   <b><a href="#dfn-imported-scripts-updated-flag">#dfn-imported-scripts-updated-flag</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dfn-classic-scripts-imported-flag">
+   <b><a href="#dfn-classic-scripts-imported-flag">#dfn-classic-scripts-imported-flag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-imported-scripts-updated-flag">6.3.2. importScripts(urls)</a>
-    <li><a href="#ref-for-dfn-imported-scripts-updated-flag①">Install</a>
+    <li><a href="#ref-for-dfn-classic-scripts-imported-flag">6.3.2. importScripts(urls)</a>
+    <li><a href="#ref-for-dfn-classic-scripts-imported-flag①">Update</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-set-of-event-types-to-handle">
@@ -7407,13 +7451,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-installing-worker③">3.5. Events</a>
     <li><a href="#ref-for-dfn-installing-worker④">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dfn-installing-worker⑤">4.7. Events</a>
-    <li><a href="#ref-for-dfn-installing-worker⑥">Install</a> <a href="#ref-for-dfn-installing-worker⑦">(2)</a> <a href="#ref-for-dfn-installing-worker⑧">(3)</a> <a href="#ref-for-dfn-installing-worker⑨">(4)</a> <a href="#ref-for-dfn-installing-worker①⓪">(5)</a>
-    <li><a href="#ref-for-dfn-installing-worker①①">Handle User Agent Shutdown</a>
-    <li><a href="#ref-for-dfn-installing-worker①②">Clear Registration</a> <a href="#ref-for-dfn-installing-worker①③">(2)</a> <a href="#ref-for-dfn-installing-worker①④">(3)</a>
-    <li><a href="#ref-for-dfn-installing-worker①⑤">Try Clear Registration</a> <a href="#ref-for-dfn-installing-worker①⑥">(2)</a>
-    <li><a href="#ref-for-dfn-installing-worker①⑦">Update Registration State</a> <a href="#ref-for-dfn-installing-worker①⑧">(2)</a> <a href="#ref-for-dfn-installing-worker①⑨">(3)</a>
-    <li><a href="#ref-for-dfn-installing-worker②⓪">Update Worker State</a> <a href="#ref-for-dfn-installing-worker②①">(2)</a>
-    <li><a href="#ref-for-dfn-installing-worker②②">Get Newest Worker</a> <a href="#ref-for-dfn-installing-worker②③">(2)</a>
+    <li><a href="#ref-for-dfn-installing-worker⑥">Install</a> <a href="#ref-for-dfn-installing-worker⑦">(2)</a> <a href="#ref-for-dfn-installing-worker⑧">(3)</a> <a href="#ref-for-dfn-installing-worker⑨">(4)</a>
+    <li><a href="#ref-for-dfn-installing-worker①⓪">Handle User Agent Shutdown</a>
+    <li><a href="#ref-for-dfn-installing-worker①①">Clear Registration</a> <a href="#ref-for-dfn-installing-worker①②">(2)</a> <a href="#ref-for-dfn-installing-worker①③">(3)</a>
+    <li><a href="#ref-for-dfn-installing-worker①④">Try Clear Registration</a> <a href="#ref-for-dfn-installing-worker①⑤">(2)</a>
+    <li><a href="#ref-for-dfn-installing-worker①⑥">Update Registration State</a> <a href="#ref-for-dfn-installing-worker①⑦">(2)</a> <a href="#ref-for-dfn-installing-worker①⑧">(3)</a>
+    <li><a href="#ref-for-dfn-installing-worker①⑨">Update Worker State</a> <a href="#ref-for-dfn-installing-worker②⓪">(2)</a>
+    <li><a href="#ref-for-dfn-installing-worker②①">Get Newest Worker</a> <a href="#ref-for-dfn-installing-worker②②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-waiting-worker">
@@ -7466,9 +7510,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dfn-last-update-check-time">#dfn-last-update-check-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-last-update-check-time">6.3.2. importScripts(urls)</a> <a href="#ref-for-dfn-last-update-check-time①">(2)</a> <a href="#ref-for-dfn-last-update-check-time②">(3)</a>
-    <li><a href="#ref-for-dfn-last-update-check-time③">Update</a> <a href="#ref-for-dfn-last-update-check-time④">(2)</a> <a href="#ref-for-dfn-last-update-check-time⑤">(3)</a>
-    <li><a href="#ref-for-dfn-last-update-check-time⑥">Handle Fetch</a> <a href="#ref-for-dfn-last-update-check-time⑦">(2)</a> <a href="#ref-for-dfn-last-update-check-time⑧">(3)</a> <a href="#ref-for-dfn-last-update-check-time⑨">(4)</a>
-    <li><a href="#ref-for-dfn-last-update-check-time①⓪">Handle Functional Event</a> <a href="#ref-for-dfn-last-update-check-time①①">(2)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time③">Update</a> <a href="#ref-for-dfn-last-update-check-time④">(2)</a> <a href="#ref-for-dfn-last-update-check-time⑤">(3)</a> <a href="#ref-for-dfn-last-update-check-time⑥">(4)</a> <a href="#ref-for-dfn-last-update-check-time⑦">(5)</a> <a href="#ref-for-dfn-last-update-check-time⑧">(6)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time⑨">Handle Fetch</a> <a href="#ref-for-dfn-last-update-check-time①⓪">(2)</a> <a href="#ref-for-dfn-last-update-check-time①①">(3)</a> <a href="#ref-for-dfn-last-update-check-time①②">(4)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time①③">Handle Functional Event</a> <a href="#ref-for-dfn-last-update-check-time①④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-update-via-cache">
@@ -7478,8 +7522,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-update-via-cache①">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-dfn-update-via-cache②">Start Register</a>
     <li><a href="#ref-for-dfn-update-via-cache③">Register</a>
-    <li><a href="#ref-for-dfn-update-via-cache④">Update</a>
-    <li><a href="#ref-for-dfn-update-via-cache⑤">Set Registration</a> <a href="#ref-for-dfn-update-via-cache⑥">(2)</a>
+    <li><a href="#ref-for-dfn-update-via-cache④">Update</a> <a href="#ref-for-dfn-update-via-cache⑤">(2)</a>
+    <li><a href="#ref-for-dfn-update-via-cache⑥">Set Registration</a> <a href="#ref-for-dfn-update-via-cache⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-uninstalling-flag">
@@ -8894,7 +8938,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-job-script-url">Appendix A: Algorithms</a>
     <li><a href="#ref-for-dfn-job-script-url①">Create Job</a>
     <li><a href="#ref-for-dfn-job-script-url②">Register</a> <a href="#ref-for-dfn-job-script-url③">(2)</a> <a href="#ref-for-dfn-job-script-url④">(3)</a>
-    <li><a href="#ref-for-dfn-job-script-url⑤">Update</a> <a href="#ref-for-dfn-job-script-url⑥">(2)</a> <a href="#ref-for-dfn-job-script-url⑦">(3)</a> <a href="#ref-for-dfn-job-script-url⑧">(4)</a> <a href="#ref-for-dfn-job-script-url⑨">(5)</a> <a href="#ref-for-dfn-job-script-url①⓪">(6)</a> <a href="#ref-for-dfn-job-script-url①①">(7)</a>
+    <li><a href="#ref-for-dfn-job-script-url⑤">Update</a> <a href="#ref-for-dfn-job-script-url⑥">(2)</a> <a href="#ref-for-dfn-job-script-url⑦">(3)</a> <a href="#ref-for-dfn-job-script-url⑧">(4)</a> <a href="#ref-for-dfn-job-script-url⑨">(5)</a> <a href="#ref-for-dfn-job-script-url①⓪">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-worker-type">
@@ -8919,8 +8963,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-job-client">Create Job</a>
     <li><a href="#ref-for-dfn-job-client①">Resolve Job Promise</a> <a href="#ref-for-dfn-job-client②">(2)</a> <a href="#ref-for-dfn-job-client③">(3)</a> <a href="#ref-for-dfn-job-client④">(4)</a> <a href="#ref-for-dfn-job-client⑤">(5)</a> <a href="#ref-for-dfn-job-client⑥">(6)</a> <a href="#ref-for-dfn-job-client⑦">(7)</a> <a href="#ref-for-dfn-job-client⑧">(8)</a>
     <li><a href="#ref-for-dfn-job-client⑨">Reject Job Promise</a> <a href="#ref-for-dfn-job-client①⓪">(2)</a> <a href="#ref-for-dfn-job-client①①">(3)</a> <a href="#ref-for-dfn-job-client①②">(4)</a> <a href="#ref-for-dfn-job-client①③">(5)</a> <a href="#ref-for-dfn-job-client①④">(6)</a>
-    <li><a href="#ref-for-dfn-job-client①⑤">Update</a> <a href="#ref-for-dfn-job-client①⑥">(2)</a>
-    <li><a href="#ref-for-dfn-job-client①⑦">Unregister</a>
+    <li><a href="#ref-for-dfn-job-client①⑤">Update</a> <a href="#ref-for-dfn-job-client①⑥">(2)</a> <a href="#ref-for-dfn-job-client①⑦">(3)</a>
+    <li><a href="#ref-for-dfn-job-client①⑧">Unregister</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="job-referrer">
@@ -8959,9 +9003,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-job-force-bypass-cache-flag">
    <b><a href="#dfn-job-force-bypass-cache-flag">#dfn-job-force-bypass-cache-flag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag">Update</a> <a href="#ref-for-dfn-job-force-bypass-cache-flag①">(2)</a>
-    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag②">Soft Update</a>
-    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag③">Install</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag">Update</a> <a href="#ref-for-dfn-job-force-bypass-cache-flag①">(2)</a> <a href="#ref-for-dfn-job-force-bypass-cache-flag②">(3)</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag③">Soft Update</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag④">Install</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-equivalent">

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -160,7 +160,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A [=/service worker=] has an associated <dfn export id="dfn-skip-waiting-flag">skip waiting flag</dfn>. Unless stated otherwise it is unset.
 
-    A [=/service worker=] has an associated <dfn export id="dfn-imported-scripts-updated-flag">imported scripts updated flag</dfn>. It is initially unset.
+    A [=/service worker=] has an associated <dfn export id="dfn-classic-scripts-imported-flag">classic scripts imported flag</dfn>. It is initially unset.
 
     A [=/service worker=] has an associated <dfn export id="dfn-set-of-event-types-to-handle">set of event types to handle</dfn> (a [=ordered set|set=]) whose [=list/item=] is an <a>event listener</a>'s event type. It is initially an empty set.
 
@@ -1942,22 +1942,22 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       When the <dfn method for="ServiceWorkerGlobalScope" id="importscripts-method"><code>importScripts(|urls|)</code></dfn> method is called on a {{ServiceWorkerGlobalScope}} object, the user agent *must* <a>import scripts into worker global scope</a>, given this {{ServiceWorkerGlobalScope}} object and |urls|, and with the following steps to [=fetching scripts/perform the fetch=] given the [=/request=] |request|:
 
         1. Let |serviceWorker| be |request|'s [=request/client=]'s [=environment settings object/global object=]'s [=ServiceWorkerGlobalScope/service worker=].
-        1. If |serviceWorker|'s <a>imported scripts updated flag</a> is unset, then:
-            1. Let |registration| be |serviceWorker|'s [=containing service worker registration=].
-            1. Set |request|'s [=service-workers mode=] to "`foreign`".
-            1. Set |request|'s [=request/cache mode=] to "<code>no-cache</code>" if any of the following are true:
-                * |registration|'s [=service worker registration/update via cache mode=] is "`none`".
-                * The [=current global object=]'s [=force bypass cache for importscripts flag=] is set.
-                * |registration|'s [=last update check time=] is not null and the time difference in seconds calculated by the current time minus |registration|’s [=last update check time=] is greater than 86400.
-            1. Let |response| be the result of <a lt="fetch">fetching</a> |request|.
-            1. If |response|’s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|’s [=service worker registration/last update check time=] to the current time.
-            1. [=Extract a MIME type=] from the |response|'s [=unsafe response=]'s [=response/header list=]. If this MIME type (ignoring parameters) is not a [=JavaScript MIME type=], return a [=network error=].
-            1. If |response|'s <a>unsafe response</a>'s [=response/type=] is not "<code>error</code>", and |response|'s [=response/status=] is an <a>ok status</a>, then:
-                1. [=map/Set=] <a>script resource map</a>[|request|'s [=request/url=]] to |response|.
-            1. Return |response|.
-        1. Else:
-            1. If <a>script resource map</a>[|url|] [=map/exists=], return <a>script resource map</a>[|url|].
-            1. Else, return a <a>network error</a>.
+        1. If |serviceWorker|'s [=script resource map=][|request|'s [=request/url=]] [=map/exists=], return the [=map/entry=]'s [=map/value=].
+        1. If |serviceWorker|'s [=state=] is not *parsed* or *installing*, return a [=network error=].
+        1. Let |registration| be |serviceWorker|'s [=containing service worker registration=].
+        1. Set |request|'s [=service-workers mode=] to "`none`".
+        1. Set |request|'s [=request/cache mode=] to "`no-cache`" if any of the following are true:
+            * |registration|'s [=service worker registration/update via cache mode=] is "`none`".
+            * The [=current global object=]'s [=force bypass cache for importscripts flag=] is set.
+            * |registration|'s [=last update check time=] is not null and the time difference in seconds calculated by the current time minus |registration|’s [=last update check time=] is greater than 86400.
+        1. Let |response| be the result of [=fetch|fetching=] |request|.
+        1. Set |response| to |response|'s [=unsafe response=].
+        1. If |response|’s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "`local`", set |registration|’s [=service worker registration/last update check time=] to the current time.
+        1. [=Extract a MIME type=] from the |response|'s [=response/header list=]. If this MIME type (ignoring parameters) is not a [=JavaScript MIME type=], return a [=network error=].
+        1. If |response|'s [=response/type=] is not "`error`", and |response|'s [=response/status=] is an <a>ok status</a>, then:
+            1. [=map/Set=] |serviceWorker|'s [=script resource map=][|request|'s [=request/url=]] to |response|.
+            1. Set |serviceWorker|'s [=classic scripts imported flag=].
+        1. Return |response|.
     </section>
   </section>
 
@@ -1984,7 +1984,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   <section>
     <h3 id="privacy">Privacy</h3>
 
-    [=/Service workers=] introduce new persistent storage features including <a>scope to registration map</a> (for [=/service worker registrations=] and their [=/service workers=]), [=request response list=] and <a>name to cache map</a> (for caches), and <a>script resource map</a> (for script resources). In order to protect users from any potential <a biblio data-biblio-type="informative" lt="unsanctioned-tracking">unsanctioned tracking</a> threat, these persistent storages *should* be cleared when users intend to clear them and *should* maintain and interoperate with existing user controls e.g. purging all existing persistent storages.
+    [=/Service workers=] introduce new persistent storage features including <a>scope to registration map</a> (for [=/service worker registrations=] and their [=/service workers=]), [=request response list=] and <a>name to cache map</a> (for caches), and [=script resource map=] (for script resources). In order to protect users from any potential <a biblio data-biblio-type="informative" lt="unsanctioned-tracking">unsanctioned tracking</a> threat, these persistent storages *should* be cleared when users intend to clear them and *should* maintain and interoperate with existing user controls e.g. purging all existing persistent storages.
   </section>
 </section>
 
@@ -2244,6 +2244,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |httpsState| be "<code>none</code>".
       1. Let |referrerPolicy| be the empty string.
+      1. Let |hasUpdatedResources| be false.
+      1. Let |updatedResourceMap| be an [=ordered map=] where the [=map/keys=] are [=/URLs=] and the [=map/values=] are [=/responses=].
       1. Switching on |job|'s <a>worker type</a>, run these substeps with the following options:
           <!-- TODO: reorganize algorithm so that the worker environment is created before fetching happens -->
           : "<code>classic</code>"
@@ -2291,10 +2293,28 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Else:
               1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" {{DOMException}}.
               1. Asynchronously complete these steps with a <a>network error</a>.
+          1. Set |updatedResourceMap|[|request|'s [=request/url=]] to |response|.
           1. If |response|'s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|'s <a>last update check time</a> to the current time.
 
               Issue: The response's cache state concept had been removed from fetch. The fetch issue <a href="https://github.com/whatwg/fetch/issues/376">#376</a> tracks the request to restore the concept or add some similar way to check this state.
 
+          1. If |newestWorker| is null, or |newestWorker|'s [=script resource map=][|request|'s [=request/url=]]'s [=response/body=] is not byte-for-byte identical with |response|'s [=response/body=], set |hasUpdatedResources| to true.
+          1. Else if |newestWorker|'s [=classic scripts imported flag=] is set, then:
+              1. [=map/For each=] |url| → |storedResponse| of |newestWorker|'s [=script resource map=]:
+                  1. Let |request| be a new [=/request=] whose [=request/url=] is |url|, [=request/client=] is |job|'s [=job/client=], [=request/destination=] is "`script`", [=request/parser metadata=] is "`not parser-inserted`", [=request/synchronous flag=] is set, and whose [=request/use-URL-credentials flag=] is set.
+                  1. Set |request|'s [=request/cache mode=] to "`no-cache`" if any of the following are true:
+                      * |registration|'s [=service worker registration/update via cache mode=] is "`none`".
+                      * |job|'s [=force bypass cache flag=] is set.
+                      * |registration|'s [=last update check time=] is not null and the time difference in seconds calculated by the current time minus |registration|’s [=last update check time=] is greater than 86400.
+                  1. Let |fetchedResponse| be the result of [=fetch|fetching=] |request|.
+                  1. Set |fetchedResponse| to |fetchedResponse|'s [=unsafe response=].
+                  1. Set |updatedResourceMap|[|request|'s [=request/url=]] to |fetchedResponse|.
+                  1. If |fetchedResponse|'s <a for="response" href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set |registration|’s [=last update check time=] to the current time.
+                  1. [=Extract a MIME type=] from the |fetchedResponse|'s [=response/header list=]. If this MIME type (ignoring parameters) is not a [=JavaScript MIME type=], asynchronously complete these steps with a [=network error=].
+                  1. If |fetchedResponse|'s [=response/type=] is "`error`", or |fetchedResponse|'s [=response/status=] is not an [=ok status=], asynchronously complete these steps with a [=network error=].
+                  1. If |fetchedResponse|'s [=response/body=] is not byte-for-byte identical with |storedResponse|'s [=response/body=], set |hasUpdatedResources| to true.
+
+                      Note: The control does not break the loop in this step to continue with all the imported scripts to populate the cache.
           1. Return true.
 
           If the algorithm asynchronously completes with null, then:
@@ -2307,20 +2327,20 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. Invoke <a>Finish Job</a> with |job| and abort these steps.
 
           Else, continue the rest of these steps after the algorithm's asynchronous completion, with |script| being the asynchronous completion value.
-
-      1. If |newestWorker| is not null, |newestWorker|'s [=service worker/script url=] [=url/equals=] |job|'s [=job/script url=], and |script|'s [=source text=] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=source text=], if |script| is a [=classic script=], and |script|'s [=module script/module record=]'s \[[ECMAScriptCode]] is a byte-for-byte match with |newestWorker|'s [=script resource=]'s [=module script/module record=]'s \[[ECMAScriptCode]] otherwise, then:
+      1. If |hasUpdatedResources| is false, then:
           1. Invoke [=Resolve Job Promise=] with |job| and |registration|.
+          1. Invoke [=Finish Job=] with |job| and abort these steps.
+      1. Let |worker| be a new [=/service worker=].
+      1. Set |worker|'s [=service worker/script url=] to |job|'s [=job/script url=], |worker|'s <a>script resource</a> to |script|, and |worker|'s [=service worker/type=] to |job|'s <a>worker type</a>.
+      1. [=map/For each=] |url| → |response| of |updatedResourceMap|:
+          1. Set |worker|'s [=script resource map=][|url|] to |response|.
+      1. Set |worker|'s <a>script resource</a>'s <a>HTTPS state</a> to |httpsState|.
+      1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
+      1. Invoke <a>Run Service Worker</a> algorithm given |worker|, and with the *force bypass cache for importscripts flag* set if |job|'s [=job/force bypass cache flag=] is set.
+      1. If an uncaught runtime script error occurs during the above step, then:
+          1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
+          1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
-      1. Else:
-          1. Let |worker| be a new [=/service worker=].
-          1. Set |worker|'s [=service worker/script url=] to |job|'s [=job/script url=], |worker|'s <a>script resource</a> to |script|, and |worker|'s [=service worker/type=] to |job|'s <a>worker type</a>.
-          1. Set |worker|'s <a>script resource</a>'s <a>HTTPS state</a> to |httpsState|.
-          1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
-          1. Invoke <a>Run Service Worker</a> algorithm given |worker|, and with the *force bypass cache for importscripts flag* set if |job|'s [=job/force bypass cache flag=] is set.
-          1. If an uncaught runtime script error occurs during the above step, then:
-              1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
-              1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
-              1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Invoke <a>Install</a> algorithm with |job|, |worker|, and |registration| as its arguments.
   </section>
 
@@ -2382,7 +2402,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>installing</code>" and null as the arguments.
           1. If |newestWorker| is null, invoke <a>Clear Registration</a> algorithm passing |registration| as its argument.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
-      1. Set |registration|'s <a>installing worker</a>'s <a>imported scripts updated flag</a>.
       1. If |registration|'s <a>waiting worker</a> is not null, then:
           1. [=Terminate Service Worker|Terminate=] |registration|'s [=waiting worker=].
           1. Run the [=Update Worker State=] algorithm passing |registration|'s [=waiting worker=] and *redundant* as the arguments.

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1177,9 +1177,9 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
-  <meta content="Bikeshed version ae5d415446a9edf0c07d32303ac1d21767d86d57" name="generator">
+  <meta content="Bikeshed version 5afc3ab5248efd53ff0fd6d61ad878a3dc5a357a" name="generator">
   <link href="https://www.w3.org/TR/service-workers/" rel="canonical">
-  <meta content="5230c70eaa3a622f981b8566431d90052a3ac2eb" name="document-revision">
+  <meta content="e2c9db259d6561342eed86fec6f0bbf868884c79" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1426,7 +1426,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers 1</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-02-23">23 February 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-03-13">13 March 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1737,7 +1737,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <p>A <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource②">script resource</a> has an associated <dfn class="dfn-paneled" data-dfn-for="script resource" data-dfn-type="dfn" data-export="" id="dfn-referrer-policy">referrer policy</dfn> (a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-referrer-policy/#referrer-policy" id="ref-for-referrer-policy">referrer policy</a>). It is initially the empty string.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker②②">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-script-resource-map">script resource map</dfn> which is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">ordered map</a> where the keys are <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①">URLs</a> and the values are <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">responses</a>.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker②③">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-skip-waiting-flag">skip waiting flag</dfn>. Unless stated otherwise it is unset.</p>
-     <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker②④">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-imported-scripts-updated-flag">imported scripts updated flag</dfn>. It is initially unset.</p>
+     <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker②④">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-classic-scripts-imported-flag">classic scripts imported flag</dfn>. It is initially unset.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker②⑤">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-set-of-event-types-to-handle">set of event types to handle</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">set</a>) whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item" id="ref-for-list-item">item</a> is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-listener" id="ref-for-concept-event-listener">event listener</a>’s event type. It is initially an empty set.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker②⑥">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-export="" id="dfn-set-of-extended-events">set of extended events</dfn> (a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">set</a>) whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-item" id="ref-for-list-item①">item</a> is an <code class="idl"><a data-link-type="idl" href="#extendableevent" id="ref-for-extendableevent">ExtendableEvent</a></code>. It is initially an empty set.</p>
      <section>
@@ -3990,45 +3990,41 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <li data-md="">
         <p>Let <var>serviceWorker</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global" id="ref-for-concept-settings-object-global①⑤">global object</a>'s <a data-link-type="dfn" href="#serviceworkerglobalscope-service-worker" id="ref-for-serviceworkerglobalscope-service-worker②②">service worker</a>.</p>
        <li data-md="">
-        <p>If <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-imported-scripts-updated-flag" id="ref-for-dfn-imported-scripts-updated-flag">imported scripts updated flag</a> is unset, then:</p>
+        <p>If <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map">script resource map</a>[<var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑦">url</a>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists">exists</a>, return the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry①">entry</a>'s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value①">value</a>.</p>
+       <li data-md="">
+        <p>If <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑤">state</a> is not <em>parsed</em> or <em>installing</em>, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error②">network error</a>.</p>
+       <li data-md="">
+        <p>Let <var>registration</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration①①">containing service worker registration</a>.</p>
+       <li data-md="">
+        <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-service-workers-mode" id="ref-for-request-service-workers-mode①">service-workers mode</a> to "<code>none</code>".</p>
+       <li data-md="">
+        <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode" id="ref-for-concept-request-cache-mode">cache mode</a> to "<code>no-cache</code>" if any of the following are true:</p>
+        <ul>
+         <li data-md="">
+          <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache①">update via cache mode</a> is "<code>none</code>".</p>
+         <li data-md="">
+          <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object" id="ref-for-current-global-object">current global object</a>'s <a data-link-type="dfn" href="#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag" id="ref-for-serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">force bypass cache for importscripts flag</a> is set.</p>
+         <li data-md="">
+          <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time">last update check time</a> is not null and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①">last update check time</a> is greater than 86400.</p>
+        </ul>
+       <li data-md="">
+        <p>Let <var>response</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch⑧">fetching</a> <var>request</var>.</p>
+       <li data-md="">
+        <p>Set <var>response</var> to <var>response</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response" id="ref-for-unsafe-response">unsafe response</a>.</p>
+       <li data-md="">
+        <p>If <var>response</var>’s <a href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time②">last update check time</a> to the current time.</p>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type">Extract a MIME type</a> from the <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list②">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#javascript-mime-type" id="ref-for-javascript-mime-type">JavaScript MIME type</a>, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error③">network error</a>.</p>
+       <li data-md="">
+        <p>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type" id="ref-for-concept-response-type①">type</a> is not "<code>error</code>", and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status②">status</a> is an <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#ok-status" id="ref-for-ok-status①">ok status</a>, then:</p>
         <ol>
          <li data-md="">
-          <p>Let <var>registration</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration①①">containing service worker registration</a>.</p>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set①">Set</a> <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map①">script resource map</a>[<var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑧">url</a>] to <var>response</var>.</p>
          <li data-md="">
-          <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#request-service-workers-mode" id="ref-for-request-service-workers-mode①">service-workers mode</a> to "<code>foreign</code>".</p>
-         <li data-md="">
-          <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode" id="ref-for-concept-request-cache-mode">cache mode</a> to "<code>no-cache</code>" if any of the following are true:</p>
-          <ul>
-           <li data-md="">
-            <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache①">update via cache mode</a> is "<code>none</code>".</p>
-           <li data-md="">
-            <p>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object" id="ref-for-current-global-object">current global object</a>'s <a data-link-type="dfn" href="#serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag" id="ref-for-serviceworkerglobalscope-force-bypass-cache-for-importscripts-flag">force bypass cache for importscripts flag</a> is set.</p>
-           <li data-md="">
-            <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time">last update check time</a> is not null and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①">last update check time</a> is greater than 86400.</p>
-          </ul>
-         <li data-md="">
-          <p>Let <var>response</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch⑧">fetching</a> <var>request</var>.</p>
-         <li data-md="">
-          <p>If <var>response</var>’s <a href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time②">last update check time</a> to the current time.</p>
-         <li data-md="">
-          <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type">Extract a MIME type</a> from the <var>response</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response" id="ref-for-unsafe-response">unsafe response</a>'s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list②">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#javascript-mime-type" id="ref-for-javascript-mime-type">JavaScript MIME type</a>, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error②">network error</a>.</p>
-         <li data-md="">
-          <p>If <var>response</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response" id="ref-for-unsafe-response①">unsafe response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type" id="ref-for-concept-response-type①">type</a> is not "<code>error</code>", and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status②">status</a> is an <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#ok-status" id="ref-for-ok-status①">ok status</a>, then:</p>
-          <ol>
-           <li data-md="">
-            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set①">Set</a> <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map">script resource map</a>[<var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑦">url</a>] to <var>response</var>.</p>
-          </ol>
-         <li data-md="">
-          <p>Return <var>response</var>.</p>
+          <p>Set <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-classic-scripts-imported-flag" id="ref-for-dfn-classic-scripts-imported-flag">classic scripts imported flag</a>.</p>
         </ol>
        <li data-md="">
-        <p>Else:</p>
-        <ol>
-         <li data-md="">
-          <p>If <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map①">script resource map</a>[<var>url</var>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists">exists</a>, return <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map②">script resource map</a>[<var>url</var>].</p>
-         <li data-md="">
-          <p>Else, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error③">network error</a>.</p>
-        </ol>
+        <p>Return <var>response</var>.</p>
       </ol>
      </section>
     </section>
@@ -4050,7 +4046,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" data-level="6.6" id="privacy"><span class="secno">6.6. </span><span class="content">Privacy</span><a class="self-link" href="#privacy"></a></h3>
-     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑧③">Service workers</a> introduce new persistent storage features including <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map⑤">scope to registration map</a> (for <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration④⑤">service worker registrations</a> and their <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑧④">service workers</a>), <a data-link-type="dfn" href="#dfn-request-response-list" id="ref-for-dfn-request-response-list⑤">request response list</a> and <a data-link-type="dfn" href="#dfn-name-to-cache-map" id="ref-for-dfn-name-to-cache-map④">name to cache map</a> (for caches), and <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map③">script resource map</a> (for script resources). In order to protect users from any potential <a data-link-type="biblio" href="#biblio-unsanctioned-tracking">unsanctioned tracking</a> threat, these persistent storages <em>should</em> be cleared when users intend to clear them and <em>should</em> maintain and interoperate with existing user controls e.g. purging all existing persistent storages.</p>
+     <p><a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑧③">Service workers</a> introduce new persistent storage features including <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map⑤">scope to registration map</a> (for <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration④⑤">service worker registrations</a> and their <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑧④">service workers</a>), <a data-link-type="dfn" href="#dfn-request-response-list" id="ref-for-dfn-request-response-list⑤">request response list</a> and <a data-link-type="dfn" href="#dfn-name-to-cache-map" id="ref-for-dfn-name-to-cache-map④">name to cache map</a> (for caches), and <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map②">script resource map</a> (for script resources). In order to protect users from any potential <a data-link-type="biblio" href="#biblio-unsanctioned-tracking">unsanctioned tracking</a> threat, these persistent storages <em>should</em> be cleared when users intend to clear them and <em>should</em> maintain and interoperate with existing user controls e.g. purging all existing persistent storages.</p>
     </section>
    </section>
    <section>
@@ -4407,6 +4403,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>referrerPolicy</var> be the empty string.</p>
       <li data-md="">
+       <p>Let <var>hasUpdatedResources</var> be false.</p>
+      <li data-md="">
+       <p>Let <var>updatedResourceMap</var> be an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map④">ordered map</a> where the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key①">keys</a> are <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url⑦">URLs</a> and the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value②">values</a> are <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑥">responses</a>.</p>
+      <li data-md="">
        <p>Switching on <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type②">worker type</a>, run these substeps with the following options:</p>
        <dl>
         <dt data-md="">"<code>classic</code>"
@@ -4439,7 +4439,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode" id="ref-for-concept-request-redirect-mode">redirect mode</a> to "<code>error</code>".</p>
         <li data-md="">
-         <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①②">Fetch</a> <var>request</var>, and asynchronously wait to run the remaining steps as part of fetch’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#process-response" id="ref-for-process-response①">process response</a> for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑥">response</a> <var>response</var>.</p>
+         <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①②">Fetch</a> <var>request</var>, and asynchronously wait to run the remaining steps as part of fetch’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#process-response" id="ref-for-process-response①">process response</a> for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑦">response</a> <var>response</var>.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type①">Extract a MIME type</a> from the <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list③">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#javascript-mime-type" id="ref-for-javascript-mime-type①">JavaScript MIME type</a>, then:</p>
          <ol>
@@ -4492,8 +4492,47 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <p>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error⑥">network error</a>.</p>
          </ol>
         <li data-md="">
+         <p>Set <var>updatedResourceMap</var>[<var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑨">url</a>] to <var>response</var>.</p>
+        <li data-md="">
          <p>If <var>response</var>’s <a href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑤">last update check time</a> to the current time.</p>
          <p class="issue" id="issue-3c7457a0"><a class="self-link" href="#issue-3c7457a0"></a> The response’s cache state concept had been removed from fetch. The fetch issue <a href="https://github.com/whatwg/fetch/issues/376">#376</a> tracks the request to restore the concept or add some similar way to check this state.</p>
+        <li data-md="">
+         <p>If <var>newestWorker</var> is null, or <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map③">script resource map</a>[<var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①⓪">url</a>]'s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body⑧">body</a> is not byte-for-byte identical with <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body⑨">body</a>, set <var>hasUpdatedResources</var> to true.</p>
+        <li data-md="">
+         <p>Else if <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-classic-scripts-imported-flag" id="ref-for-dfn-classic-scripts-imported-flag①">classic scripts imported flag</a> is set, then:</p>
+         <ol>
+          <li data-md="">
+           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate⑤">For each</a> <var>url</var> → <var>storedResponse</var> of <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map④">script resource map</a>:</p>
+           <ol>
+            <li data-md="">
+             <p>Let <var>request</var> be a new <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①①">url</a> is <var>url</var>, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a> is <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client①⑨">client</a>, <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①">destination</a> is "<code>script</code>", <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata" id="ref-for-concept-request-parser-metadata">parser metadata</a> is "<code>not parser-inserted</code>", <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#synchronous-flag" id="ref-for-synchronous-flag">synchronous flag</a> is set, and whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag" id="ref-for-concept-request-use-url-credentials-flag">use-URL-credentials flag</a> is set.</p>
+            <li data-md="">
+             <p>Set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode" id="ref-for-concept-request-cache-mode②">cache mode</a> to "<code>no-cache</code>" if any of the following are true:</p>
+             <ul>
+              <li data-md="">
+               <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache④">update via cache mode</a> is "<code>none</code>".</p>
+              <li data-md="">
+               <p><var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag①">force bypass cache flag</a> is set.</p>
+              <li data-md="">
+               <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑥">last update check time</a> is not null and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑦">last update check time</a> is greater than 86400.</p>
+             </ul>
+            <li data-md="">
+             <p>Let <var>fetchedResponse</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①③">fetching</a> <var>request</var>.</p>
+            <li data-md="">
+             <p>Set <var>fetchedResponse</var> to <var>fetchedResponse</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response" id="ref-for-unsafe-response①">unsafe response</a>.</p>
+            <li data-md="">
+             <p>Set <var>updatedResourceMap</var>[<var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①②">url</a>] to <var>fetchedResponse</var>.</p>
+            <li data-md="">
+             <p>If <var>fetchedResponse</var>’s <a href="https://github.com/whatwg/fetch/issues/376">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑧">last update check time</a> to the current time.</p>
+            <li data-md="">
+             <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type" id="ref-for-concept-header-extract-mime-type②">Extract a MIME type</a> from the <var>fetchedResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list⑤">header list</a>. If this MIME type (ignoring parameters) is not a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#javascript-mime-type" id="ref-for-javascript-mime-type②">JavaScript MIME type</a>, asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error⑦">network error</a>.</p>
+            <li data-md="">
+             <p>If <var>fetchedResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type" id="ref-for-concept-response-type②">type</a> is "<code>error</code>", or <var>fetchedResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status③">status</a> is not an <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#ok-status" id="ref-for-ok-status②">ok status</a>, asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error⑧">network error</a>.</p>
+            <li data-md="">
+             <p>If <var>fetchedResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①⓪">body</a> is not byte-for-byte identical with <var>storedResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①①">body</a>, set <var>hasUpdatedResources</var> to true.</p>
+             <p class="note" role="note"><span>Note:</span> The control does not break the loop in this step to continue with all the imported scripts to populate the cache.</p>
+           </ol>
+         </ol>
         <li data-md="">
          <p>Return true.</p>
        </ol>
@@ -4509,7 +4548,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        </ol>
        <p>Else, continue the rest of these steps after the algorithm’s asynchronous completion, with <var>script</var> being the asynchronous completion value.</p>
       <li data-md="">
-       <p>If <var>newestWorker</var> is not null, <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url④">script url</a> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals" id="ref-for-concept-url-equals②">equals</a> <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url①⓪">script url</a>, and <var>script</var>’s <a data-link-type="dfn">source text</a> is a byte-for-byte match with <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑤">script resource</a>'s <a data-link-type="dfn">source text</a>, if <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script" id="ref-for-classic-script">classic script</a>, and <var>script</var>’s <a data-link-type="dfn">module record</a>'s [[ECMAScriptCode]] is a byte-for-byte match with <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑥">script resource</a>'s <a data-link-type="dfn">module record</a>'s [[ECMAScriptCode]] otherwise, then:</p>
+       <p>If <var>hasUpdatedResources</var> is false, then:</p>
        <ol>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#resolve-job-promise" id="ref-for-resolve-job-promise①">Resolve Job Promise</a> with <var>job</var> and <var>registration</var>.</p>
@@ -4517,28 +4556,30 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job⑦">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
-       <p>Else:</p>
+       <p>Let <var>worker</var> be a new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑧⑦">service worker</a>.</p>
+      <li data-md="">
+       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url④">script url</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url①⓪">script url</a>, <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑤">script resource</a> to <var>script</var>, and <var>worker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type①">type</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type③">worker type</a>.</p>
+      <li data-md="">
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate⑥">For each</a> <var>url</var> → <var>response</var> of <var>updatedResourceMap</var>:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>worker</var> be a new <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑧⑦">service worker</a>.</p>
+         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map⑤">script resource map</a>[<var>url</var>] to <var>response</var>.</p>
+       </ol>
+      <li data-md="">
+       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑥">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state">HTTPS state</a> to <var>httpsState</var>.</p>
+      <li data-md="">
+       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑦">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy">referrer policy</a> to <var>referrerPolicy</var>.</p>
+      <li data-md="">
+       <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker②">Run Service Worker</a> algorithm given <var>worker</var>, and with the <em>force bypass cache for importscripts flag</em> set if <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag②">force bypass cache flag</a> is set.</p>
+      <li data-md="">
+       <p>If an uncaught runtime script error occurs during the above step, then:</p>
+       <ol>
         <li data-md="">
-         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url⑤">script url</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-script-url" id="ref-for-dfn-job-script-url①①">script url</a>, <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑦">script resource</a> to <var>script</var>, and <var>worker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type①">type</a> to <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type③">worker type</a>.</p>
+         <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise⑨">Reject Job Promise</a> with <var>job</var> and <code>TypeError</code>.</p>
         <li data-md="">
-         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑧">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state">HTTPS state</a> to <var>httpsState</var>.</p>
+         <p>If <var>newestWorker</var> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration①">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
         <li data-md="">
-         <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑨">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy">referrer policy</a> to <var>referrerPolicy</var>.</p>
-        <li data-md="">
-         <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker②">Run Service Worker</a> algorithm given <var>worker</var>, and with the <em>force bypass cache for importscripts flag</em> set if <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag①">force bypass cache flag</a> is set.</p>
-        <li data-md="">
-         <p>If an uncaught runtime script error occurs during the above step, then:</p>
-         <ol>
-          <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise⑨">Reject Job Promise</a> with <var>job</var> and <code>TypeError</code>.</p>
-          <li data-md="">
-           <p>If <var>newestWorker</var> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration①">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</p>
-          <li data-md="">
-           <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job⑧">Finish Job</a> with <var>job</var> and abort these steps.</p>
-         </ol>
+         <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job⑧">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#install" id="ref-for-install②">Install</a> algorithm with <var>job</var>, <var>worker</var>, and <var>registration</var> as its arguments.</p>
@@ -4564,11 +4605,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>newestWorker</var> is null, abort these steps.</p>
       <li data-md="">
-       <p>Let <var>job</var> be the result of running <a data-link-type="dfn" href="#create-job" id="ref-for-create-job③">Create Job</a> with <em>update</em>, <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url①③">scope url</a>, <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url⑥">script url</a>, null, and null.</p>
+       <p>Let <var>job</var> be the result of running <a data-link-type="dfn" href="#create-job" id="ref-for-create-job③">Create Job</a> with <em>update</em>, <var>registration</var>’s <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url①③">scope url</a>, <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url⑤">script url</a>, null, and null.</p>
       <li data-md="">
        <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-worker-type" id="ref-for-dfn-job-worker-type④">worker type</a> to <var>newestWorker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type②">type</a>.</p>
       <li data-md="">
-       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag②">force bypass cache flag</a> if the <em>force bypass cache flag</em> is set.</p>
+       <p>Set <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag③">force bypass cache flag</a> if the <em>force bypass cache flag</em> is set.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#schedule-job" id="ref-for-schedule-job③">Schedule Job</a> with <var>job</var>.</p>
      </ol>
@@ -4605,7 +4646,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>installingWorker</var> be <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker⑦">installing worker</a>.</p>
       <li data-md="">
-       <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker③">Run Service Worker</a> algorithm given <var>installingWorker</var>, and with the <em>force bypass cache for importscripts flag</em> set if <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag③">force bypass cache flag</a> is set.</p>
+       <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker③">Run Service Worker</a> algorithm given <var>installingWorker</var>, and with the <em>force bypass cache for importscripts flag</em> set if <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-force-bypass-cache-flag" id="ref-for-dfn-job-force-bypass-cache-flag④">force bypass cache flag</a> is set.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task" id="ref-for-queue-a-task②②">Queue a task</a> <var>task</var> to run the following substeps:</p>
        <ol>
@@ -4642,8 +4683,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Invoke <a data-link-type="dfn" href="#finish-job" id="ref-for-finish-job⑨">Finish Job</a> with <var>job</var> and abort these steps.</p>
        </ol>
       <li data-md="">
-       <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker⑨">installing worker</a>’s <a data-link-type="dfn" href="#dfn-imported-scripts-updated-flag" id="ref-for-dfn-imported-scripts-updated-flag①">imported scripts updated flag</a>.</p>
-      <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker③">waiting worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
@@ -4652,7 +4691,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state②">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker⑤">waiting worker</a> and <em>redundant</em> as the arguments.</p>
        </ol>
       <li data-md="">
-       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state②">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⓪">installing worker</a> as the arguments.</p>
+       <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state②">Update Registration State</a> algorithm passing <var>registration</var>, "<code>waiting</code>" and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker⑨">installing worker</a> as the arguments.</p>
       <li data-md="">
        <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state③">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and null as the arguments.</p>
       <li data-md="">
@@ -4749,7 +4788,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker⑨">waiting worker</a> is null, return.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker②⑧">active worker</a> is not null and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker②⑨">active worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑤">state</a> is <em>activating</em>, return.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker②⑧">active worker</a> is not null and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker②⑨">active worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑥">state</a> is <em>activating</em>, return.</p>
        <p class="note" role="note"><span>Note:</span> If the existing active worker is still in activating state, the activation of the waiting worker is delayed.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#activate" id="ref-for-activate⑥">Activate</a> with <var>registration</var> if either of the following is true:</p>
@@ -4775,7 +4814,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>Let <var>script</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①⓪">script resource</a>.</p>
+       <p>Let <var>script</var> be <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑧">script resource</a>.</p>
       <li data-md="">
        <p class="assertion">Assert: <var>script</var> is not null.</p>
       <li data-md="">
@@ -4814,7 +4853,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Return UTF-8.</p>
         <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url" id="ref-for-api-base-url⑤">API base URL</a>
         <dd data-md="">
-         <p>Return <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url⑦">script url</a>.</p>
+         <p>Return <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url⑥">script url</a>.</p>
         <dt data-md="">The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②④">origin</a>
         <dd data-md="">
          <p>Return its registering <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client④②">service worker client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②⑤">origin</a>.</p>
@@ -4826,11 +4865,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Return <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state" id="ref-for-concept-workerglobalscope-https-state">HTTPS state</a>.</p>
        </dl>
       <li data-md="">
-       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url" id="ref-for-concept-workerglobalscope-url①">url</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url⑧">script url</a>.</p>
+       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url" id="ref-for-concept-workerglobalscope-url①">url</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-url" id="ref-for-dfn-script-url⑦">script url</a>.</p>
       <li data-md="">
-       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state" id="ref-for-concept-workerglobalscope-https-state①">HTTPS state</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①①">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state①">HTTPS state</a>.</p>
+       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state" id="ref-for-concept-workerglobalscope-https-state①">HTTPS state</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource⑨">script resource</a>’s <a data-link-type="dfn" href="#dfn-https-state" id="ref-for-dfn-https-state①">HTTPS state</a>.</p>
       <li data-md="">
-       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-referrer-policy" id="ref-for-concept-workerglobalscope-referrer-policy①">referrer policy</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①②">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy①">referrer policy</a>.</p>
+       <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-referrer-policy" id="ref-for-concept-workerglobalscope-referrer-policy①">referrer policy</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①⓪">script resource</a>’s <a data-link-type="dfn" href="#dfn-referrer-policy" id="ref-for-dfn-referrer-policy①">referrer policy</a>.</p>
       <li data-md="">
        <p>Set <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type" id="ref-for-concept-workerglobalscope-type">type</a> to <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-type" id="ref-for-dfn-type③">type</a>.</p>
       <li data-md="">
@@ -4840,7 +4879,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>If <var>serviceWorker</var> is an <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker③②">active worker</a>, and there are any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task" id="ref-for-concept-task⑥">tasks</a> queued in <var>serviceWorker</var>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration①③">containing service worker registration</a>’s <a data-link-type="dfn" href="#dfn-service-worker-registration-task-queue" id="ref-for-dfn-service-worker-registration-task-queue②">task queues</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task" id="ref-for-queue-a-task②⑤">queue</a> them to <var>serviceWorker</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop" id="ref-for-event-loop⑧">event loop</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue" id="ref-for-task-queue③">task queues</a> in the same order using their original <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source" id="ref-for-task-source⑤">task sources</a>.</p>
       <li data-md="">
-       <p>If <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script" id="ref-for-classic-script①">classic script</a>, then <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script" id="ref-for-run-a-classic-script">run the classic script</a> <var>script</var>. Otherwise, it is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script" id="ref-for-module-script">module script</a>; <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script" id="ref-for-run-a-module-script">run the module script</a> <var>script</var>.</p>
+       <p>If <var>script</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script" id="ref-for-classic-script">classic script</a>, then <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script" id="ref-for-run-a-classic-script">run the classic script</a> <var>script</var>. Otherwise, it is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script" id="ref-for-module-script">module script</a>; <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script" id="ref-for-run-a-module-script">run the module script</a> <var>script</var>.</p>
        <p class="note" role="note"><span>Note:</span> In addition to the usual possibilities of returning a value or failing due to an exception, this could be prematurely aborted by the <a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker⑦">terminate service worker</a> algorithm.</p>
       <li data-md="">
        <p>If <var>script</var>’s <a data-link-type="dfn" href="#dfn-has-ever-been-evaluated-flag" id="ref-for-dfn-has-ever-been-evaluated-flag">has ever been evaluated flag</a> is unset, then:</p>
@@ -4891,14 +4930,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section class="algorithm" data-algorithm="Handle Fetch">
      <h3 class="heading settled" id="on-fetch-request-algorithm"><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="handle-fetch">Handle Fetch</dfn></span><a class="self-link" href="#on-fetch-request-algorithm"></a></h3>
-     <p>The <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch⑥">Handle Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①③">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨②">service worker</a> context.</p>
+     <p>The <a data-link-type="dfn" href="#handle-fetch" id="ref-for-handle-fetch⑥">Handle Fetch</a> algorithm is the entry point for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①④">fetch</a> handling handed to the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨②">service worker</a> context.</p>
      <dl>
       <dt data-md="">Input
       <dd data-md="">
-       <p><var>request</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a></p>
+       <p><var>request</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">request</a></p>
       <dt data-md="">Output
       <dd data-md="">
-       <p><var>response</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑦">response</a></p>
+       <p><var>response</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response⑧">response</a></p>
      </dl>
      <ol>
       <li data-md="">
@@ -4912,11 +4951,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>registration</var> be null.</p>
       <li data-md="">
-       <p>Let <var>client</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a>.</p>
+       <p>Let <var>client</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">client</a>.</p>
       <li data-md="">
        <p>Let <var>reservedClient</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-reserved-client" id="ref-for-concept-request-reserved-client">reserved client</a>.</p>
       <li data-md="">
-       <p class="assertion">Assert: <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①">destination</a> is not "<code>serviceworker</code>".</p>
+       <p class="assertion">Assert: <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②">destination</a> is not "<code>serviceworker</code>".</p>
       <li data-md="">
        <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request" id="ref-for-potential-navigation-or-subresource-request①">potential-navigation-or-subresource request</a>, then:</p>
        <ol>
@@ -4937,16 +4976,16 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p>Else:</p>
          <ol>
           <li data-md="">
-           <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑧">url</a> is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url③">potentially trustworthy URL</a>, return null.</p>
+           <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①③">url</a> is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url" id="ref-for-potentially-trustworthy-url③">potentially trustworthy URL</a>, return null.</p>
          </ol>
         <li data-md="">
          <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#navigation-request" id="ref-for-navigation-request">navigation request</a> and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate" id="ref-for-navigate③">navigation</a> triggering it was initiated with a shift+reload or equivalent, return null.</p>
         <li data-md="">
-         <p>Set <var>registration</var> to the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration⑨">Match Service Worker Registration</a> algorithm passing <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url⑨">url</a> as the argument.</p>
+         <p>Set <var>registration</var> to the result of running <a data-link-type="dfn" href="#match-service-worker-registration" id="ref-for-match-service-worker-registration⑨">Match Service Worker Registration</a> algorithm passing <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①④">url</a> as the argument.</p>
         <li data-md="">
          <p>If <var>registration</var> is null or <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker③③">active worker</a> is null, return null.</p>
         <li data-md="">
-         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination②">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report" id="ref-for-dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker" id="ref-for-concept-environment-active-service-worker⑦">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker③④">active worker</a>.</p>
+         <p>If <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination③">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report" id="ref-for-dom-requestdestination-report">"report"</a></code>, set <var>reservedClient</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker" id="ref-for-concept-environment-active-service-worker⑦">active service worker</a> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker③④">active worker</a>.</p>
        </ol>
        <p class="note" role="note"><span>Note:</span> From this point, the <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client④③">service worker client</a> starts to <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use⑤">use</a> its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker" id="ref-for-concept-environment-active-service-worker⑧">active service worker</a>’s <a data-link-type="dfn" href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration①⑤">containing service worker registration</a>.</p>
       <li data-md="">
@@ -4965,13 +5004,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Return null and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel②⑨">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request②">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request①">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑥">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request②">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request①">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑨">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update">Soft Update</a> algorithm with <var>registration</var>.</p>
         <li data-md="">
          <p>Abort these steps.</p>
        </ol>
        <p class="note" role="note"><span>Note:</span> To avoid unnecessary delays, the Handle Fetch enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
       <li data-md="">
-       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑥">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑦">state</a> to become <em>activated</em>.</p>
+       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑦">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑧">state</a> to become <em>activated</em>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker⑤">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
@@ -4986,7 +5025,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-request" id="ref-for-dom-fetchevent-request②">request</a></code> attribute to a new <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request" id="ref-for-request①④">Request</a></code> object associated with <var>request</var> and a new associated <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#headers" id="ref-for-headers②">Headers</a></code> object whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-headers-guard" id="ref-for-concept-headers-guard②">guard</a> is "<code>immutable</code>".</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request③">non-subresource request</a> and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination③">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report" id="ref-for-dom-requestdestination-report①">"report"</a></code>, initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-clientid" id="ref-for-dom-fetchevent-clientid②">clientId</a></code> attribute to the empty string, and to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id" id="ref-for-concept-environment-id②">id</a> otherwise.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request③">non-subresource request</a> and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination④">destination</a> is not <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#dom-requestdestination-report" id="ref-for-dom-requestdestination-report①">"report"</a></code>, initialize <var>e</var>’s <code class="idl"><a data-link-type="idl" href="#dom-fetchevent-clientid" id="ref-for-dom-fetchevent-clientid②">clientId</a></code> attribute to the empty string, and to <var>client</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id" id="ref-for-concept-environment-id②">id</a> otherwise.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-dispatch" id="ref-for-concept-event-dispatch⑥">Dispatch</a> <var>e</var> at <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-service-worker-global-object" id="ref-for-dfn-service-worker-global-object④">global object</a>.</p>
         <li data-md="">
@@ -5014,11 +5053,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>respondWithEntered</var> is false, then:</p>
        <ol>
         <li data-md="">
-         <p>If <var>eventCanceled</var> is true, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error⑦">network error</a> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③⓪">in parallel</a>.</p>
+         <p>If <var>eventCanceled</var> is true, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error⑨">network error</a> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③⓪">in parallel</a>.</p>
         <li data-md="">
          <p>Else, return null and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③①">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request④">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request②">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑦">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update①">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request④">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request②">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①⓪">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update①">Soft Update</a> algorithm with <var>registration</var>.</p>
         <li data-md="">
          <p>Abort these steps.</p>
        </ol>
@@ -5026,9 +5065,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>handleFetchFailed</var> is true, then:</p>
        <ol>
         <li data-md="">
-         <p>Return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error⑧">network error</a> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③②">in parallel</a>.</p>
+         <p>Return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error" id="ref-for-concept-network-error①⓪">network error</a> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③②">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request⑤">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request③">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑧">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update②">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request⑤">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request③">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①①">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update②">Soft Update</a> algorithm with <var>registration</var>.</p>
        </ol>
       <li data-md="">
        <p>Else:</p>
@@ -5036,7 +5075,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Return <var>response</var> and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③③">in parallel</a>.</p>
         <li data-md="">
-         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request⑥">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request④">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time⑨">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update③">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#non-subresource-request" id="ref-for-non-subresource-request⑥">non-subresource request</a>, or <var>request</var> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#subresource-request" id="ref-for-subresource-request④">subresource request</a> and the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①②">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update③">Soft Update</a> algorithm with <var>registration</var>.</p>
        </ol>
      </ol>
     </section>
@@ -5067,13 +5106,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Return and continue running these steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel" id="ref-for-in-parallel③④">in parallel</a>.</p>
         <li data-md="">
-         <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①⓪">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update④">Soft Update</a> algorithm with <var>registration</var>.</p>
+         <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①③">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update④">Soft Update</a> algorithm with <var>registration</var>.</p>
         <li data-md="">
          <p>Abort these steps.</p>
        </ol>
        <p class="note" role="note"><span>Note:</span> To avoid unnecessary delays, the Handle Functional Event enforces early return when no event listeners have been deterministically added in the service worker’s global during the very first script execution.</p>
       <li data-md="">
-       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑧">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑨">state</a> to become <em>activated</em>.</p>
+       <p>If <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state⑨">state</a> is <em>activating</em>, wait for <var>activeWorker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state①⓪">state</a> to become <em>activated</em>.</p>
       <li data-md="">
        <p>Invoke <a data-link-type="dfn" href="#run-service-worker" id="ref-for-run-service-worker⑥">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</p>
       <li data-md="">
@@ -5088,7 +5127,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Wait for <var>task</var> to have executed or been discarded.</p>
       <li data-md="">
-       <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①①">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update⑤">Soft Update</a> algorithm with <var>registration</var>.</p>
+       <p>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a data-link-type="dfn" href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time①④">last update check time</a> is greater than 86400, invoke <a data-link-type="dfn" href="#soft-update" id="ref-for-soft-update⑤">Soft Update</a> algorithm with <var>registration</var>.</p>
      </ol>
     </section>
     <section class="algorithm" data-algorithm="Handle Service Worker Client Unload">
@@ -5129,10 +5168,10 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate⑤">For each</a> <var>scope</var> → <var>registration</var> of <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map⑦">scope to registration map</a>:</p>
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate⑦">For each</a> <var>scope</var> → <var>registration</var> of <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map⑦">scope to registration map</a>:</p>
        <ol>
         <li data-md="">
-         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①①">installing worker</a> <var>installingWorker</var> is not null, then:</p>
+         <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⓪">installing worker</a> <var>installingWorker</var> is not null, then:</p>
          <ol>
           <li data-md="">
            <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker①①">waiting worker</a> is null and <var>registration</var>’s <a data-link-type="dfn" href="#dfn-active-worker" id="ref-for-dfn-active-worker③⑧">active worker</a> is null, invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration③">Clear Registration</a> with <var>registration</var> and continue to the next iteration of the loop.</p>
@@ -5185,7 +5224,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      </dl>
      <ol>
       <li data-md="">
-       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②⑥">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url⑧">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client①⑨">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②⑦">origin</a>, then:</p>
+       <p>If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②⑥">origin</a> of <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-scope-url" id="ref-for-dfn-job-scope-url⑧">scope url</a> is not <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client" id="ref-for-dfn-job-client②⓪">client</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin" id="ref-for-concept-settings-object-origin②⑦">origin</a>, then:</p>
        <ol>
         <li data-md="">
          <p>Invoke <a data-link-type="dfn" href="#reject-job-promise" id="ref-for-reject-job-promise①⓪">Reject Job Promise</a> with <var>job</var> and "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror" id="ref-for-securityerror⑨">SecurityError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException②②">DOMException</a></code>.</p>
@@ -5218,9 +5257,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <dl>
       <dt data-md="">Input
       <dd data-md="">
-       <p><var>scope</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url⑦">URL</a></p>
+       <p><var>scope</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url⑧">URL</a></p>
       <dd data-md="">
-       <p><var>updateViaCache</var>, an <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache④">update via cache mode</a></p>
+       <p><var>updateViaCache</var>, an <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache⑤">update via cache mode</a></p>
       <dt data-md="">Output
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration⑤⑥">service worker registration</a></p>
@@ -5231,7 +5270,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>scopeString</var> be <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer" id="ref-for-concept-url-serializer⑨">serialized</a> <var>scope</var> with the <em>exclude fragment flag</em> set.</p>
       <li data-md="">
-       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration⑤⑦">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url①⑥">scope url</a> is set to <var>scope</var> and <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache⑤">update via cache mode</a> is set to <var>updateViaCache</var>.</p>
+       <p>Let <var>registration</var> be a new <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration⑤⑦">service worker registration</a> whose <a data-link-type="dfn" href="#dfn-scope-url" id="ref-for-dfn-scope-url①⑥">scope url</a> is set to <var>scope</var> and <a data-link-type="dfn" href="#dfn-update-via-cache" id="ref-for-dfn-update-via-cache⑥">update via cache mode</a> is set to <var>updateViaCache</var>.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set③">Set</a> <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map⑧">scope to registration map</a>[<var>scopeString</var>] to <var>registration</var>.</p>
       <li data-md="">
@@ -5252,12 +5291,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Run the following steps atomically.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①②">installing worker</a> is not null, then:</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①①">installing worker</a> is not null, then:</p>
        <ol>
         <li data-md="">
-         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker①⓪">Terminate</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①③">installing worker</a>.</p>
+         <p><a data-link-type="dfn" href="#terminate-service-worker" id="ref-for-terminate-service-worker①⓪">Terminate</a> <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①②">installing worker</a>.</p>
         <li data-md="">
-         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state⑧">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①④">installing worker</a> and <em>redundant</em> as the arguments.</p>
+         <p>Run the <a data-link-type="dfn" href="#update-worker-state" id="ref-for-update-worker-state⑧">Update Worker State</a> algorithm passing <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①③">installing worker</a> and <em>redundant</em> as the arguments.</p>
         <li data-md="">
          <p>Run the <a data-link-type="dfn" href="#update-registration-state" id="ref-for-update-registration-state⑥">Update Registration State</a> algorithm passing <var>registration</var>, "<code>installing</code>" and null as the arguments.</p>
        </ol>
@@ -5302,7 +5341,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>Invoke <a data-link-type="dfn" href="#clear-registration" id="ref-for-clear-registration⑥">Clear Registration</a> with <var>registration</var> if no <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client④⑦">service worker client</a> is <a data-link-type="dfn" href="#dfn-use" id="ref-for-dfn-use⑨">using</a> <var>registration</var> and all of the following conditions are true:</p>
        <ul>
         <li data-md="">
-         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑤">installing worker</a> is null or the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events①">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑥">installing worker</a> is true.</p>
+         <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①④">installing worker</a> is null or the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events①">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑤">installing worker</a> is true.</p>
         <li data-md="">
          <p><var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker①⑥">waiting worker</a> is null or the result of running <a data-link-type="dfn" href="#service-worker-has-no-pending-events" id="ref-for-service-worker-has-no-pending-events②">Service Worker Has No Pending Events</a> with <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker①⑦">waiting worker</a> is true.</p>
         <li data-md="">
@@ -5331,12 +5370,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p>If <var>target</var> is "<code>installing</code>", then:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑦">installing worker</a> to <var>source</var>.</p>
+         <p>Set <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑥">installing worker</a> to <var>source</var>.</p>
         <li data-md="">
          <p>For each <var>registrationObject</var> in <var>registrationObjects</var>:</p>
          <ol>
           <li data-md="">
-           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task" id="ref-for-queue-a-task②⑨">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-installing" id="ref-for-dom-serviceworkerregistration-installing②">installing</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker②④">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑧">installing worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑨">installing worker</a> is null.</p>
+           <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task" id="ref-for-queue-a-task②⑨">Queue a task</a> to set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerregistration-installing" id="ref-for-dom-serviceworkerregistration-installing②">installing</a></code> attribute of <var>registrationObject</var> to the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker②④">ServiceWorker</a></code> object that represents <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑦">installing worker</a>, or null if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑧">installing worker</a> is null.</p>
          </ol>
        </ol>
       <li data-md="">
@@ -5373,14 +5412,14 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <dd data-md="">
        <p><var>worker</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨⑤">service worker</a></p>
       <dd data-md="">
-       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨⑥">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state①⓪">state</a></p>
+       <p><var>state</var>, a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨⑥">service worker</a>'s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state①①">state</a></p>
       <dt data-md="">Output
       <dd data-md="">
        <p>None</p>
      </dl>
      <ol>
       <li data-md="">
-       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state①①">state</a> to <var>state</var>.</p>
+       <p>Set <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state①②">state</a> to <var>state</var>.</p>
       <li data-md="">
        <p>Let <var>workerObjects</var> be an array containing all the <code class="idl"><a data-link-type="idl" href="#serviceworker" id="ref-for-serviceworker②⑦">ServiceWorker</a></code> objects associated with <var>worker</var>.</p>
       <li data-md="">
@@ -5390,12 +5429,12 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task" id="ref-for-queue-a-task③②">Queue a task</a> to run these substeps:</p>
          <ol>
           <li data-md="">
-           <p>Set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworker-state" id="ref-for-dom-serviceworker-state④">state</a></code> attribute of <var>workerObject</var> to the value (in <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate③">ServiceWorkerState</a></code> enumeration) corresponding to the first matching statement, switching on <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state①②">state</a>:</p>
+           <p>Set the <code class="idl"><a data-link-type="idl" href="#dom-serviceworker-state" id="ref-for-dom-serviceworker-state④">state</a></code> attribute of <var>workerObject</var> to the value (in <code class="idl"><a data-link-type="idl" href="#enumdef-serviceworkerstate" id="ref-for-enumdef-serviceworkerstate③">ServiceWorkerState</a></code> enumeration) corresponding to the first matching statement, switching on <var>worker</var>’s <a data-link-type="dfn" href="#dfn-state" id="ref-for-dfn-state①③">state</a>:</p>
            <dl>
             <dt data-md=""><em>installing</em>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installing" id="ref-for-dom-serviceworkerstate-installing">"installing"</a></code></p>
-             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨⑦">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker②⓪">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil⑥">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall①">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers⑧">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker②①">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects" id="ref-for-sec-promise-objects③⓪">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨⑧">service worker</a> is not active until all of the core caches are populated.</p>
+             <p class="note" role="note"><span>Note:</span> The <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨⑦">service worker</a> in this state is considered an <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker①⑨">installing worker</a>. During this state, <code class="idl"><a data-link-type="idl" href="#dom-extendableevent-waituntil" id="ref-for-dom-extendableevent-waituntil⑥">waitUntil()</a></code> can be called inside the <code class="idl"><a data-link-type="idl" href="#dom-serviceworkerglobalscope-oninstall" id="ref-for-dom-serviceworkerglobalscope-oninstall①">oninstall</a></code> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers" id="ref-for-event-handlers⑧">event handler</a> to extend the life of the <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker②⓪">installing worker</a> until the passed <a data-link-type="dfn" href="http://tc39.github.io/ecma262/#sec-promise-objects" id="ref-for-sec-promise-objects③⓪">promise</a> resolves successfully. This is primarily used to ensure that the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker⑨⑧">service worker</a> is not active until all of the core caches are populated.</p>
             <dt data-md=""><em>installed</em>
             <dd data-md="">
              <p><code class="idl"><a data-link-type="idl" href="#dom-serviceworkerstate-installed" id="ref-for-dom-serviceworkerstate-installed">"installed"</a></code></p>
@@ -5443,7 +5482,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <dl>
       <dt data-md="">Input
       <dd data-md="">
-       <p><var>clientURL</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url⑧">URL</a></p>
+       <p><var>clientURL</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url⑨">URL</a></p>
       <dt data-md="">Output
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration⑥①">service worker registration</a></p>
@@ -5483,7 +5522,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <dl>
       <dt data-md="">Input
       <dd data-md="">
-       <p><var>scope</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url⑨">URL</a></p>
+       <p><var>scope</var>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①⓪">URL</a></p>
       <dt data-md="">Output
       <dd data-md="">
        <p><var>registration</var>, a <a data-link-type="dfn" href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration⑥②">service worker registration</a></p>
@@ -5498,7 +5537,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>registration</var> be null.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate⑥">For each</a> <var>key</var> → <var>value</var> of <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map①①">scope to registration map</a>:</p>
+       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-iterate" id="ref-for-map-iterate⑧">For each</a> <var>key</var> → <var>value</var> of <a data-link-type="dfn" href="#dfn-scope-to-registration-map" id="ref-for-dfn-scope-to-registration-map①①">scope to registration map</a>:</p>
        <ol>
         <li data-md="">
          <p>If <var>scopeString</var> matches <var>key</var>, set <var>registration</var> to <var>value</var>.</p>
@@ -5523,7 +5562,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
       <li data-md="">
        <p>Let <var>newestWorker</var> be null.</p>
       <li data-md="">
-       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker②②">installing worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker②③">installing worker</a>.</p>
+       <p>If <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker②①">installing worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-installing-worker" id="ref-for-dfn-installing-worker②②">installing worker</a>.</p>
       <li data-md="">
        <p>Else if <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker②②">waiting worker</a> is not null, set <var>newestWorker</var> to <var>registration</var>’s <a data-link-type="dfn" href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker②③">waiting worker</a>.</p>
       <li data-md="">
@@ -5612,7 +5651,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <dl>
       <dt data-md="">Input
       <dd data-md="">
-       <p><var>request</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">request</a></p>
+       <p><var>request</var>, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request⑤">request</a></p>
       <dd data-md="">
        <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-cachequeryoptions" id="ref-for-dictdef-cachequeryoptions⑥">CacheQueryOptions</a></code> object, optional</p>
       <dd data-md="">
@@ -5642,9 +5681,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①①">For each</a> <var>requestResponse</var> of <var>storage</var>:</p>
        <ol>
         <li data-md="">
-         <p>Set <var>cachedURL</var> to <var>requestResponse</var>’s request’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①⓪">url</a>.</p>
+         <p>Set <var>cachedURL</var> to <var>requestResponse</var>’s request’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①⑤">url</a>.</p>
         <li data-md="">
-         <p>Set <var>requestURL</var> to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①①">url</a>.</p>
+         <p>Set <var>requestURL</var> to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①⑥">url</a>.</p>
         <li data-md="">
          <p>If <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-cachequeryoptions-ignoresearch" id="ref-for-dom-cachequeryoptions-ignoresearch">ignoreSearch</a></code> is true, then:</p>
          <ol>
@@ -5654,7 +5693,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
            <p>Set <var>requestURL</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-query" id="ref-for-concept-url-query①">query</a> to the empty string.</p>
          </ol>
         <li data-md="">
-         <p>If <var>cachedURL</var> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals" id="ref-for-concept-url-equals③">equals</a> <var>requestURL</var> with the <em>exclude fragment flag</em> set, then:</p>
+         <p>If <var>cachedURL</var> <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-equals" id="ref-for-concept-url-equals②">equals</a> <var>requestURL</var> with the <em>exclude fragment flag</em> set, then:</p>
          <ol>
           <li data-md="">
            <p>Add a copy of <var>requestResponse</var>’s request to <var>requests</var>.</p>
@@ -5672,7 +5711,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
         <li data-md="">
          <p>Increment <var>index</var> by one.</p>
         <li data-md="">
-         <p>If <var>cachedResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list⑤">header list</a> contains no <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header②">header</a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-name" id="ref-for-concept-header-name②">named</a> `<code>Vary</code>`, or <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-cachequeryoptions-ignorevary" id="ref-for-dom-cachequeryoptions-ignorevary">ignoreVary</a></code> is true, then:</p>
+         <p>If <var>cachedResponse</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list" id="ref-for-concept-response-header-list⑥">header list</a> contains no <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header②">header</a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-name" id="ref-for-concept-header-name②">named</a> `<code>Vary</code>`, or <var>options</var>.<code class="idl"><a data-link-type="idl" href="#dom-cachequeryoptions-ignorevary" id="ref-for-dom-cachequeryoptions-ignorevary">ignoreVary</a></code> is true, then:</p>
          <ol>
           <li data-md="">
            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append⑦">Append</a> <var>cachedRequest</var>/<var>cachedResponse</var> to <var>resultList</var>.</p>
@@ -5755,7 +5794,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
             <li data-md="">
              <p>Let <var>r</var> be <var>operation</var>’s <a data-link-type="dfn" href="#dfn-cache-batch-operation-request" id="ref-for-dfn-cache-batch-operation-request⑤">request</a>'s associated <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-request" id="ref-for-concept-request-request①⓪">request</a>.</p>
             <li data-md="">
-             <p>If <var>r</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①②">url</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑥">scheme</a> is not one of "<code>http</code>" and "<code>https</code>", <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw②⓪">throw</a> a <code>TypeError</code>.</p>
+             <p>If <var>r</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url①⑦">url</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme⑥">scheme</a> is not one of "<code>http</code>" and "<code>https</code>", <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw②⓪">throw</a> a <code>TypeError</code>.</p>
             <li data-md="">
              <p>If <var>r</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method⑥">method</a> is not `<code>GET</code>`, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw②①">throw</a> a <code>TypeError</code>.</p>
             <li data-md="">
@@ -5803,17 +5842,17 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <h2 class="heading settled" id="extended-http-headers"><span class="content">Appendix B: Extended HTTP headers</span><a class="self-link" href="#extended-http-headers"></a></h2>
     <section>
      <h3 class="heading settled" id="service-worker-script-request"><span class="content">Service Worker Script Request</span><a class="self-link" href="#service-worker-script-request"></a></h3>
-     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①④">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①⓪⑦">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①③">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header③">header</a>:</p>
+     <p>An HTTP request to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch" id="ref-for-concept-fetch①⑤">fetch</a> a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①⓪⑦">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①①">script resource</a> will include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header③">header</a>:</p>
      <dl>
       <dt data-md="">`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker"><code>Service-Worker</code><a class="self-link" href="#service-worker"></a></dfn>`
       <dd data-md="">
-       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①⓪⑧">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①④">script resource</a> request.</p>
+       <p>Indicates this request is a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①⓪⑧">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①②">script resource</a> request.</p>
        <p class="note" role="note"><span>Note:</span> This header helps administrators log the requests and detect threats.</p>
      </dl>
     </section>
     <section>
      <h3 class="heading settled" id="service-worker-script-response"><span class="content">Service Worker Script Response</span><a class="self-link" href="#service-worker-script-response"></a></h3>
-     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①⓪⑨">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①⑤">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header④">header</a>:</p>
+     <p>An HTTP response to a <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①⓪⑨">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①③">script resource</a> request can include the following <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header④">header</a>:</p>
      <dl>
       <dt data-md="">`<dfn data-dfn-type="dfn" data-noexport="" id="service-worker-allowed"><code>Service-Worker-Allowed</code><a class="self-link" href="#service-worker-allowed"></a></dfn>`
       <dd data-md="">
@@ -5859,7 +5898,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     </section>
     <section>
      <h3 class="heading settled" id="syntax"><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
-     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①①⓪">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①⑥">script resource</a> requests and responses:</p>
+     <p><a data-link-type="biblio" href="#biblio-rfc5234">ABNF</a> for the values of the headers used by the <a data-link-type="dfn" href="#dfn-service-worker" id="ref-for-dfn-service-worker①①⓪">service worker</a>'s <a data-link-type="dfn" href="#dfn-script-resource" id="ref-for-dfn-script-resource①④">script resource</a> requests and responses:</p>
 <pre>Service-Worker = %x73.63.72.69.70.74 ; "script", case-sensitive
 </pre>
      <p class="note" role="note"><span>Note:</span> The validation of the Service-Worker-Allowed header’s values is done by URL parsing algorithm (in Update algorithm) instead of using ABNF.</p>
@@ -5947,6 +5986,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#global-caches-attribute">caches</a><span>, in §5.3.1</span>
    <li><a href="#cachestorage">CacheStorage</a><span>, in §5.5</span>
    <li><a href="#dom-clients-claim">claim()</a><span>, in §4.3.4</span>
+   <li><a href="#dfn-classic-scripts-imported-flag">classic scripts imported flag</a><span>, in §2.1</span>
    <li><a href="#clear-registration">Clear Registration</a><span>, in §Unnumbered section</span>
    <li><a href="#dfn-job-client">client</a><span>, in §Unnumbered section</span>
    <li><a href="#client">Client</a><span>, in §4.2</span>
@@ -6025,7 +6065,6 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <li><a href="#dom-cachequeryoptions-ignoremethod">ignoreMethod</a><span>, in §5.4</span>
    <li><a href="#dom-cachequeryoptions-ignoresearch">ignoreSearch</a><span>, in §5.4</span>
    <li><a href="#dom-cachequeryoptions-ignorevary">ignoreVary</a><span>, in §5.4</span>
-   <li><a href="#dfn-imported-scripts-updated-flag">imported scripts updated flag</a><span>, in §2.1</span>
    <li><a href="#dom-serviceworkerupdateviacache-imports">"imports"</a><span>, in §3.2</span>
    <li><a href="#dom-serviceworkerupdateviacache-imports">imports</a><span>, in §3.2</span>
    <li><a href="#importscripts-method">importScripts(urls)</a><span>, in §6.3.2</span>
@@ -6305,7 +6344,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
-    <a data-link-type="biblio">[CSP3]</a> defines the following terms:
+    <a data-link-type="biblio">[csp-3]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/webappsec-csp/#enforced">enforced</a>
      <li><a href="https://w3c.github.io/webappsec-csp/#monitored">monitored</a>
@@ -6389,6 +6428,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://fetch.spec.whatwg.org/#non-subresource-request">non-subresource request</a>
      <li><a href="https://fetch.spec.whatwg.org/#ok-status">ok status</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">opaque filtered response</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata">parser metadata</a>
      <li><a href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">potential-navigation-or-subresource request</a>
      <li><a href="https://fetch.spec.whatwg.org/#process-response">process response</a>
      <li><a href="https://fetch.spec.whatwg.org/#process-response-end-of-body">process response end-of-body</a>
@@ -6404,9 +6444,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
      <li><a href="https://fetch.spec.whatwg.org/#concept-response-status">status</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-body-stream">stream</a>
      <li><a href="https://fetch.spec.whatwg.org/#subresource-request">subresource request</a>
+     <li><a href="https://fetch.spec.whatwg.org/#synchronous-flag">synchronous flag</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-fetch-terminate">terminated</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-response-type">type</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-url">url</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag">use-url-credentials flag</a>
     </ul>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
@@ -6639,8 +6681,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
-   <dt id="biblio-csp3">[CSP3]
-   <dd>Mike West. <a href="https://www.w3.org/TR/CSP3/">Content Security Policy Level 3</a>. 13 September 2016. WD. URL: <a href="https://www.w3.org/TR/CSP3/">https://www.w3.org/TR/CSP3/</a>
+   <dt id="biblio-csp-3">[CSP-3]
+   <dd>Content Security Policy Level 3 URL: <a href="https://www.w3.org/TR/CSP3/">https://www.w3.org/TR/CSP3/</a>
    <dt id="biblio-dom">[DOM]
    <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-ecmascript">[ECMASCRIPT]
@@ -6940,10 +6982,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-state">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-state①">(2)</a> <a href="#ref-for-dfn-state②">(3)</a>
     <li><a href="#ref-for-dfn-state③">3.1. ServiceWorker</a>
     <li><a href="#ref-for-dfn-state④">3.2.6. update()</a>
-    <li><a href="#ref-for-dfn-state⑤">Try Activate</a>
-    <li><a href="#ref-for-dfn-state⑥">Handle Fetch</a> <a href="#ref-for-dfn-state⑦">(2)</a>
-    <li><a href="#ref-for-dfn-state⑧">Handle Functional Event</a> <a href="#ref-for-dfn-state⑨">(2)</a>
-    <li><a href="#ref-for-dfn-state①⓪">Update Worker State</a> <a href="#ref-for-dfn-state①①">(2)</a> <a href="#ref-for-dfn-state①②">(3)</a>
+    <li><a href="#ref-for-dfn-state⑤">6.3.2. importScripts(urls)</a>
+    <li><a href="#ref-for-dfn-state⑥">Try Activate</a>
+    <li><a href="#ref-for-dfn-state⑦">Handle Fetch</a> <a href="#ref-for-dfn-state⑧">(2)</a>
+    <li><a href="#ref-for-dfn-state⑨">Handle Functional Event</a> <a href="#ref-for-dfn-state①⓪">(2)</a>
+    <li><a href="#ref-for-dfn-state①①">Update Worker State</a> <a href="#ref-for-dfn-state①②">(2)</a> <a href="#ref-for-dfn-state①③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-script-url">
@@ -6952,9 +6995,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-script-url">3.1.1. scriptURL</a>
     <li><a href="#ref-for-dfn-script-url①">3.2.6. update()</a>
     <li><a href="#ref-for-dfn-script-url②">Register</a>
-    <li><a href="#ref-for-dfn-script-url③">Update</a> <a href="#ref-for-dfn-script-url④">(2)</a> <a href="#ref-for-dfn-script-url⑤">(3)</a>
-    <li><a href="#ref-for-dfn-script-url⑥">Soft Update</a>
-    <li><a href="#ref-for-dfn-script-url⑦">Run Service Worker</a> <a href="#ref-for-dfn-script-url⑧">(2)</a>
+    <li><a href="#ref-for-dfn-script-url③">Update</a> <a href="#ref-for-dfn-script-url④">(2)</a>
+    <li><a href="#ref-for-dfn-script-url⑤">Soft Update</a>
+    <li><a href="#ref-for-dfn-script-url⑥">Run Service Worker</a> <a href="#ref-for-dfn-script-url⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-type">
@@ -7020,11 +7063,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <ul>
     <li><a href="#ref-for-dfn-script-resource">2.1. Service Worker</a> <a href="#ref-for-dfn-script-resource①">(2)</a> <a href="#ref-for-dfn-script-resource②">(3)</a>
     <li><a href="#ref-for-dfn-script-resource③">6.2. Content Security Policy</a> <a href="#ref-for-dfn-script-resource④">(2)</a>
-    <li><a href="#ref-for-dfn-script-resource⑤">Update</a> <a href="#ref-for-dfn-script-resource⑥">(2)</a> <a href="#ref-for-dfn-script-resource⑦">(3)</a> <a href="#ref-for-dfn-script-resource⑧">(4)</a> <a href="#ref-for-dfn-script-resource⑨">(5)</a>
-    <li><a href="#ref-for-dfn-script-resource①⓪">Run Service Worker</a> <a href="#ref-for-dfn-script-resource①①">(2)</a> <a href="#ref-for-dfn-script-resource①②">(3)</a>
-    <li><a href="#ref-for-dfn-script-resource①③">Service Worker Script Request</a> <a href="#ref-for-dfn-script-resource①④">(2)</a>
-    <li><a href="#ref-for-dfn-script-resource①⑤">Service Worker Script Response</a>
-    <li><a href="#ref-for-dfn-script-resource①⑥">Syntax</a>
+    <li><a href="#ref-for-dfn-script-resource⑤">Update</a> <a href="#ref-for-dfn-script-resource⑥">(2)</a> <a href="#ref-for-dfn-script-resource⑦">(3)</a>
+    <li><a href="#ref-for-dfn-script-resource⑧">Run Service Worker</a> <a href="#ref-for-dfn-script-resource⑨">(2)</a> <a href="#ref-for-dfn-script-resource①⓪">(3)</a>
+    <li><a href="#ref-for-dfn-script-resource①①">Service Worker Script Request</a> <a href="#ref-for-dfn-script-resource①②">(2)</a>
+    <li><a href="#ref-for-dfn-script-resource①③">Service Worker Script Response</a>
+    <li><a href="#ref-for-dfn-script-resource①④">Syntax</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-has-ever-been-evaluated-flag">
@@ -7050,8 +7093,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-script-resource-map">
    <b><a href="#dfn-script-resource-map">#dfn-script-resource-map</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-script-resource-map">6.3.2. importScripts(urls)</a> <a href="#ref-for-dfn-script-resource-map①">(2)</a> <a href="#ref-for-dfn-script-resource-map②">(3)</a>
-    <li><a href="#ref-for-dfn-script-resource-map③">6.6. Privacy</a>
+    <li><a href="#ref-for-dfn-script-resource-map">6.3.2. importScripts(urls)</a> <a href="#ref-for-dfn-script-resource-map①">(2)</a>
+    <li><a href="#ref-for-dfn-script-resource-map②">6.6. Privacy</a>
+    <li><a href="#ref-for-dfn-script-resource-map③">Update</a> <a href="#ref-for-dfn-script-resource-map④">(2)</a> <a href="#ref-for-dfn-script-resource-map⑤">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-skip-waiting-flag">
@@ -7062,11 +7106,11 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-skip-waiting-flag②">Try Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-imported-scripts-updated-flag">
-   <b><a href="#dfn-imported-scripts-updated-flag">#dfn-imported-scripts-updated-flag</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="dfn-classic-scripts-imported-flag">
+   <b><a href="#dfn-classic-scripts-imported-flag">#dfn-classic-scripts-imported-flag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-imported-scripts-updated-flag">6.3.2. importScripts(urls)</a>
-    <li><a href="#ref-for-dfn-imported-scripts-updated-flag①">Install</a>
+    <li><a href="#ref-for-dfn-classic-scripts-imported-flag">6.3.2. importScripts(urls)</a>
+    <li><a href="#ref-for-dfn-classic-scripts-imported-flag①">Update</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-set-of-event-types-to-handle">
@@ -7147,13 +7191,13 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-installing-worker③">3.5. Events</a>
     <li><a href="#ref-for-dfn-installing-worker④">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dfn-installing-worker⑤">4.7. Events</a>
-    <li><a href="#ref-for-dfn-installing-worker⑥">Install</a> <a href="#ref-for-dfn-installing-worker⑦">(2)</a> <a href="#ref-for-dfn-installing-worker⑧">(3)</a> <a href="#ref-for-dfn-installing-worker⑨">(4)</a> <a href="#ref-for-dfn-installing-worker①⓪">(5)</a>
-    <li><a href="#ref-for-dfn-installing-worker①①">Handle User Agent Shutdown</a>
-    <li><a href="#ref-for-dfn-installing-worker①②">Clear Registration</a> <a href="#ref-for-dfn-installing-worker①③">(2)</a> <a href="#ref-for-dfn-installing-worker①④">(3)</a>
-    <li><a href="#ref-for-dfn-installing-worker①⑤">Try Clear Registration</a> <a href="#ref-for-dfn-installing-worker①⑥">(2)</a>
-    <li><a href="#ref-for-dfn-installing-worker①⑦">Update Registration State</a> <a href="#ref-for-dfn-installing-worker①⑧">(2)</a> <a href="#ref-for-dfn-installing-worker①⑨">(3)</a>
-    <li><a href="#ref-for-dfn-installing-worker②⓪">Update Worker State</a> <a href="#ref-for-dfn-installing-worker②①">(2)</a>
-    <li><a href="#ref-for-dfn-installing-worker②②">Get Newest Worker</a> <a href="#ref-for-dfn-installing-worker②③">(2)</a>
+    <li><a href="#ref-for-dfn-installing-worker⑥">Install</a> <a href="#ref-for-dfn-installing-worker⑦">(2)</a> <a href="#ref-for-dfn-installing-worker⑧">(3)</a> <a href="#ref-for-dfn-installing-worker⑨">(4)</a>
+    <li><a href="#ref-for-dfn-installing-worker①⓪">Handle User Agent Shutdown</a>
+    <li><a href="#ref-for-dfn-installing-worker①①">Clear Registration</a> <a href="#ref-for-dfn-installing-worker①②">(2)</a> <a href="#ref-for-dfn-installing-worker①③">(3)</a>
+    <li><a href="#ref-for-dfn-installing-worker①④">Try Clear Registration</a> <a href="#ref-for-dfn-installing-worker①⑤">(2)</a>
+    <li><a href="#ref-for-dfn-installing-worker①⑥">Update Registration State</a> <a href="#ref-for-dfn-installing-worker①⑦">(2)</a> <a href="#ref-for-dfn-installing-worker①⑧">(3)</a>
+    <li><a href="#ref-for-dfn-installing-worker①⑨">Update Worker State</a> <a href="#ref-for-dfn-installing-worker②⓪">(2)</a>
+    <li><a href="#ref-for-dfn-installing-worker②①">Get Newest Worker</a> <a href="#ref-for-dfn-installing-worker②②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-waiting-worker">
@@ -7203,9 +7247,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
    <b><a href="#dfn-last-update-check-time">#dfn-last-update-check-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-last-update-check-time">6.3.2. importScripts(urls)</a> <a href="#ref-for-dfn-last-update-check-time①">(2)</a> <a href="#ref-for-dfn-last-update-check-time②">(3)</a>
-    <li><a href="#ref-for-dfn-last-update-check-time③">Update</a> <a href="#ref-for-dfn-last-update-check-time④">(2)</a> <a href="#ref-for-dfn-last-update-check-time⑤">(3)</a>
-    <li><a href="#ref-for-dfn-last-update-check-time⑥">Handle Fetch</a> <a href="#ref-for-dfn-last-update-check-time⑦">(2)</a> <a href="#ref-for-dfn-last-update-check-time⑧">(3)</a> <a href="#ref-for-dfn-last-update-check-time⑨">(4)</a>
-    <li><a href="#ref-for-dfn-last-update-check-time①⓪">Handle Functional Event</a> <a href="#ref-for-dfn-last-update-check-time①①">(2)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time③">Update</a> <a href="#ref-for-dfn-last-update-check-time④">(2)</a> <a href="#ref-for-dfn-last-update-check-time⑤">(3)</a> <a href="#ref-for-dfn-last-update-check-time⑥">(4)</a> <a href="#ref-for-dfn-last-update-check-time⑦">(5)</a> <a href="#ref-for-dfn-last-update-check-time⑧">(6)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time⑨">Handle Fetch</a> <a href="#ref-for-dfn-last-update-check-time①⓪">(2)</a> <a href="#ref-for-dfn-last-update-check-time①①">(3)</a> <a href="#ref-for-dfn-last-update-check-time①②">(4)</a>
+    <li><a href="#ref-for-dfn-last-update-check-time①③">Handle Functional Event</a> <a href="#ref-for-dfn-last-update-check-time①④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-update-via-cache">
@@ -7214,8 +7258,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-update-via-cache">3.2.5. updateViaCache</a>
     <li><a href="#ref-for-dfn-update-via-cache①">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-dfn-update-via-cache②">Register</a>
-    <li><a href="#ref-for-dfn-update-via-cache③">Update</a>
-    <li><a href="#ref-for-dfn-update-via-cache④">Set Registration</a> <a href="#ref-for-dfn-update-via-cache⑤">(2)</a>
+    <li><a href="#ref-for-dfn-update-via-cache③">Update</a> <a href="#ref-for-dfn-update-via-cache④">(2)</a>
+    <li><a href="#ref-for-dfn-update-via-cache⑤">Set Registration</a> <a href="#ref-for-dfn-update-via-cache⑥">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-uninstalling-flag">
@@ -8524,7 +8568,7 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-job-script-url">Appendix A: Algorithms</a>
     <li><a href="#ref-for-dfn-job-script-url①">Create Job</a>
     <li><a href="#ref-for-dfn-job-script-url②">Register</a> <a href="#ref-for-dfn-job-script-url③">(2)</a> <a href="#ref-for-dfn-job-script-url④">(3)</a>
-    <li><a href="#ref-for-dfn-job-script-url⑤">Update</a> <a href="#ref-for-dfn-job-script-url⑥">(2)</a> <a href="#ref-for-dfn-job-script-url⑦">(3)</a> <a href="#ref-for-dfn-job-script-url⑧">(4)</a> <a href="#ref-for-dfn-job-script-url⑨">(5)</a> <a href="#ref-for-dfn-job-script-url①⓪">(6)</a> <a href="#ref-for-dfn-job-script-url①①">(7)</a>
+    <li><a href="#ref-for-dfn-job-script-url⑤">Update</a> <a href="#ref-for-dfn-job-script-url⑥">(2)</a> <a href="#ref-for-dfn-job-script-url⑦">(3)</a> <a href="#ref-for-dfn-job-script-url⑧">(4)</a> <a href="#ref-for-dfn-job-script-url⑨">(5)</a> <a href="#ref-for-dfn-job-script-url①⓪">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-worker-type">
@@ -8550,8 +8594,8 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
     <li><a href="#ref-for-dfn-job-client①">Resolve Job Promise</a> <a href="#ref-for-dfn-job-client②">(2)</a> <a href="#ref-for-dfn-job-client③">(3)</a> <a href="#ref-for-dfn-job-client④">(4)</a> <a href="#ref-for-dfn-job-client⑤">(5)</a> <a href="#ref-for-dfn-job-client⑥">(6)</a> <a href="#ref-for-dfn-job-client⑦">(7)</a> <a href="#ref-for-dfn-job-client⑧">(8)</a>
     <li><a href="#ref-for-dfn-job-client⑨">Reject Job Promise</a> <a href="#ref-for-dfn-job-client①⓪">(2)</a> <a href="#ref-for-dfn-job-client①①">(3)</a> <a href="#ref-for-dfn-job-client①②">(4)</a> <a href="#ref-for-dfn-job-client①③">(5)</a> <a href="#ref-for-dfn-job-client①④">(6)</a>
     <li><a href="#ref-for-dfn-job-client①⑤">Register</a> <a href="#ref-for-dfn-job-client①⑥">(2)</a>
-    <li><a href="#ref-for-dfn-job-client①⑦">Update</a> <a href="#ref-for-dfn-job-client①⑧">(2)</a>
-    <li><a href="#ref-for-dfn-job-client①⑨">Unregister</a>
+    <li><a href="#ref-for-dfn-job-client①⑦">Update</a> <a href="#ref-for-dfn-job-client①⑧">(2)</a> <a href="#ref-for-dfn-job-client①⑨">(3)</a>
+    <li><a href="#ref-for-dfn-job-client②⓪">Unregister</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-promise">
@@ -8582,9 +8626,9 @@ self<span class="p">.</span>addEventListener<span class="p">(</span><span class=
   <aside class="dfn-panel" data-for="dfn-job-force-bypass-cache-flag">
    <b><a href="#dfn-job-force-bypass-cache-flag">#dfn-job-force-bypass-cache-flag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag">Update</a> <a href="#ref-for-dfn-job-force-bypass-cache-flag①">(2)</a>
-    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag②">Soft Update</a>
-    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag③">Install</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag">Update</a> <a href="#ref-for-dfn-job-force-bypass-cache-flag①">(2)</a> <a href="#ref-for-dfn-job-force-bypass-cache-flag②">(3)</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag③">Soft Update</a>
+    <li><a href="#ref-for-dfn-job-force-bypass-cache-flag④">Install</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-job-equivalent">


### PR DESCRIPTION
This change includes/considers the following:
 - Include imported scripts to byte-check (for classic scripts).
 - Compare responses' body instead of source text as per https://github.com/whatwg/html/issues/3316.
 - Handle duplicate importScripts() as per https://github.com/w3c/ServiceWorker/issues/1041.
 - Replace *imported scripts updated flag* referenced in importScripts()
   by using service worker's state item.
 - Have Update's perform the fetch steps cover module scripts.
 - Avoid dobule-download of imported scripts pointed out in https://github.com/w3c/ServiceWorker/pull/1023#discussion_r92201798.

This change basically makes it check out if the main script resource is
identical to the existing resource. If so, it returns; otherwise, it
creates a new service worker and evalute it to check out if any imported
scripts are changed. It continues with Install only when any of the
resources has been changed. With the change, importScripts() returns
resources from the cache for any duplicated requests including the
request for the main script.

Fixes #1041, #1212, #1023.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/pull/1283.html" title="Last updated on Mar 13, 2018, 6:51 AM GMT (c34985f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1283/b695958...c34985f.html" title="Last updated on Mar 13, 2018, 6:51 AM GMT (c34985f)">Diff</a>