### PR TITLE
WindowOrWorkerGlobalScope is a mixin

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1604,7 +1604,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <h3 id="self-caches">{{WindowOrWorkerGlobalScope/caches|self.caches}}</h3>
 
     <pre class="idl">
-      partial interface WindowOrWorkerGlobalScope {
+      partial interface mixin WindowOrWorkerGlobalScope {
         [SecureContext, SameObject] readonly attribute CacheStorage caches;
       };
     </pre>


### PR DESCRIPTION
...and so extensions should use [`partial interface mixin`](https://heycam.github.io/webidl/#partial-interface-mixin) rather than `partial interface`.

See also https://github.com/whatwg/html/pull/3650


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/ServiceWorker/pull/1309.html" title="Last updated on May 4, 2018, 3:54 AM GMT (c5fa3a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1309/9a6b738...saschanaz:c5fa3a3.html" title="Last updated on May 4, 2018, 3:54 AM GMT (c5fa3a3)">Diff</a>