### PR TITLE
Resolve the skipWaiting() promise after activation completes.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2578,7 +2578,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Run the [=Update Worker State=] algorithm passing |registration|'s [=active worker=] and *redundant* as the arguments.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>active</code>" and |registration|'s <a>waiting worker</a> as the arguments.
       1. Run the <a>Update Registration State</a> algorithm passing |registration|, "<code>waiting</code>" and null as the arguments.
-      1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>active worker</a> and *activating* as the arguments.
+      1. Run the [=Update Worker State=] algorithm passing |registration|'s <a>active worker</a> and *activating* as the arguments.
 
           Note: Once an active worker is activating, neither a runtime script error nor a force termination of the active worker prevents the active worker from getting activated.
 
@@ -2604,7 +2604,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. <span id="activate-settle-step">*WaitForAsynchronousExtensions*: Wait, [=in parallel=], until |e|'s [=ExtendableEvent/pending promises count=] is zero.</span>
       1. Wait for |task| to have executed or been discarded, or the script to have been aborted by the <a lt="terminate service worker">termination</a> of |activeWorker|.
       1. Wait for the step labeled *WaitForAsynchronousExtensions* to complete.
-      1. Run the <a>Update Worker State</a> algorithm passing |registration|'s <a>active worker</a> and *activated* as the arguments.
+      1. Run the [=Update Worker State=] algorithm passing |registration|'s <a>active worker</a> and *activated* as the arguments.
+      1. Wait for all the tasks queued by [=Update Worker State=] invoked in this algorithm to have executed.
   </section>
 
   <section algorithm>


### PR DESCRIPTION
The Activate algorithm's final step was to run Update Worker State
to make the worker `activated`. However Update Worker State
just queues a task to do so. So the task would run after
skipWaiting() resolved its promise, which wasn't the intent of
the spec.

Fixes #1187.