### PR TITLE
Add Client.frameType back

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1087,11 +1087,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
         1. Let |promise| be a new <a>promise</a>.
         1. [=Queue a task=] to run the following steps on the [=context object=]'s associated [=Client/service worker client=]'s [=responsible event loop=] using the [=user interaction task source=]:
-            1. Run the [=focusing steps=] with the current [=/browsing context=].
-            1. Let |frameType| be the result of running [=Get Frame Type=] with the current [=/browsing context=].
-            1. Let |visibilityState| be the current [=/browsing context=]'s [=active document=]'s {{Document/visibilityState}} attribute value.
-            1. Let |focusState| be the result of running the [=has focus steps=] with the current [=/browsing context=]'s [=active document=].
-            1. Let |ancestorOriginsList| be the current [=/browsing context=]'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
+            1. Run the [=focusing steps=] with the [=context object=]'s [=WindowClient/browsing context=].
+            1. Let |frameType| be the result of running [=Get Frame Type=] with the [=context object=]'s [=WindowClient/browsing context=].
+            1. Let |visibilityState| be the [=context object=]'s [=WindowClient/browsing context=]'s [=active document=]'s {{Document/visibilityState}} attribute value.
+            1. Let |focusState| be the result of running the [=has focus steps=] with the [=context object=]'s [=WindowClient/browsing context=]'s [=active document=].
+            1. Let |ancestorOriginsList| be the [=context object=]'s [=WindowClient/browsing context=]'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
             1. [=Queue a task=] to run the following steps on |serviceWorkerEventLoop| using the [=DOM manipulation task source=]:
                 1. Let |windowClient| be the result of running [=Create Window Client=] with the [=context object=]'s associated [=Client/service worker client=], |frameType|, |visibilityState|, |focusState|, and |ancestorOriginsList|.
                 1. If |windowClient|'s [=focus state=] is true, resolve |promise| with |windowClient|.
@@ -1111,7 +1111,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
         1. Let |promise| be a new <a>promise</a>.
         1. [=Queue a task=] to run the following steps on the [=context object=]'s associated [=Client/service worker client=]'s [=responsible event loop=] using the [=user interaction task source=]:
-            1. Let |browsingContext| be the current [=/browsing context=].
+            1. Let |browsingContext| be the [=context object=]'s [=WindowClient/browsing context=].
             1. If |browsingContext| has [=discard a document|discarded=] its {{Document}}, [=queue a task=] to reject |promise| with a `TypeError`, on |serviceWorkerEventLoop| using the [=DOM manipulation task source=], and abort these steps.
             1. *HandleNavigate*: [=Navigate=] |browsingContext| to |url| with [=exceptions enabled flag|exceptions enabled=]. The [=source browsing context=] must be |browsingContext|.
             1. If the algorithm steps invoked in the step labeled *HandleNavigate* [=throws=] an exception, [=queue a task=] to reject |promise| with the exception, on |serviceWorkerEventLoop| using the [=DOM manipulation task source=], and abort these steps.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -973,6 +973,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       [Exposed=ServiceWorker]
       interface Client {
         readonly attribute USVString url;
+        readonly attribute FrameType frameType;
         readonly attribute DOMString id;
         readonly attribute ClientType type;
         void postMessage(any message, optional sequence&lt;object&gt; transfer = []);
@@ -986,9 +987,18 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         [NewObject] Promise&lt;WindowClient&gt; focus();
         [NewObject] Promise&lt;WindowClient?&gt; navigate(USVString url);
       };
+
+      enum FrameType {
+        "auxiliary",
+        "top-level",
+        "nested",
+        "none"
+      };
     </pre>
 
-    A {{Client}} object has an associated <dfn for="Client">service worker client</dfn> (a [=/service worker client=]).
+    A {{Client}} object has an associated <dfn id="dfn-service-worker-client-service-worker-client" for="Client">service worker client</dfn> (a [=/service worker client=]).
+
+    A {{Client}} object has an associated <dfn id="dfn-service-worker-client-frame-type" for="Client">frame type</dfn>, which is one of "auxiliary", "top-level", "nested", and "none". Unless stated otherwise it is "none".
 
     A {{WindowClient}} object has an associated <dfn id="dfn-service-worker-client-browsing-context" for="WindowClient">browsing context</dfn>, which is its [=Client/service worker client=]'s [=environment settings object/global object=]'s [=/browsing context=].
 
@@ -1002,6 +1012,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       <h4 id="client-url">{{Client/url}}</h4>
 
       The <dfn attribute for="Client"><code>url</code></dfn> attribute *must* return the <a>context object</a>'s associated [=Client/service worker client=]'s <a lt="URL serializer">serialized</a> <a>creation URL</a>.
+    </section>
+
+    <section>
+      <h4 id="client-frametype">{{Client/frameType}}</h4>
+
+      The <dfn attribute for="Client"><code>frameType</code></dfn> attribute *must* return the [=context object=]'s [=frame type=].
     </section>
 
     <section>
@@ -1068,54 +1084,45 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       The <dfn method for="WindowClient"><code>focus()</code></dfn> method *must* run these steps:
 
         1. If this algorithm is not <a>triggered by user activation</a>, return a <a>promise</a> rejected with an "{{InvalidAccessError}}" {{DOMException}}.
+        1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
         1. Let |promise| be a new <a>promise</a>.
-        1. Run these substeps <a>in parallel</a>:
-            1. Let |browsingContext| be the <a>context object</a>'s associated [=Client/service worker client=]'s [=environment settings object/global object=]'s [=/browsing context=].
-            1. Let |visibilityState| be null.
-            1. Let |focusState| be false.
-            1. Let |ancestorOriginsList| be the empty list.
-            1. <a>Queue a task</a> |task| to run the following substeps on the <a>context object</a>'s associated [=Client/service worker client=]'s <a>responsible event loop</a> using the <a>user interaction task source</a>:
-                1. Run the <a>focusing steps</a> with |browsingContext|.
-                1. Set |visibilityState| to |browsingContext|'s <a>active document</a>'s {{Document/visibilityState}} attribute value.
-                1. Set |focusState| to the result of running the <a>has focus steps</a> with |browsingContext|'s <a>active document</a> as the argument.
-                1. Set |ancestorOriginsList| to |browsingContext|'s <a>active document</a>'s <a>relevant global object</a>'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
-            1. Wait for |task| to have executed.
-            1. Let |windowClient| be the result of running <a>Create Window Client</a> algorithm with the <a>context object</a>'s associated [=Client/service worker client=], |visibilityState|, |focusState|, and |ancestorOriginsList| as the arguments.
-            1. If |windowClient|'s <a>focus state</a> is true, resolve |promise| with |windowClient|.
-            1. Else, reject |promise| with a <code>TypeError</code>.
+        1. [=Queue a task=] to run the following steps on the [=context object=]'s associated [=Client/service worker client=]'s [=responsible event loop=] using the [=user interaction task source=]:
+            1. Run the [=focusing steps=] with the current [=/browsing context=].
+            1. Let |frameType| be the result of running [=Get Frame Type=] with the current [=/browsing context=].
+            1. Let |visibilityState| be the current [=/browsing context=]'s [=active document=]'s {{Document/visibilityState}} attribute value.
+            1. Let |focusState| be the result of running the [=has focus steps=] with the current [=/browsing context=]'s [=active document=].
+            1. Let |ancestorOriginsList| be the current [=/browsing context=]'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
+            1. [=Queue a task=] to run the following steps on |serviceWorkerEventLoop| using the [=DOM manipulation task source=]:
+                1. Let |windowClient| be the result of running [=Create Window Client=] with the [=context object=]'s associated [=Client/service worker client=], |frameType|, |visibilityState|, |focusState|, and |ancestorOriginsList|.
+                1. If |windowClient|'s [=focus state=] is true, resolve |promise| with |windowClient|.
+                1. Else, reject |promise| with a `TypeError`.
         1. Return |promise|.
     </section>
 
     <section algorithm="client-navigate">
       <h4 id="client-navigate">{{WindowClient/navigate(url)}}</h4>
 
-      The <dfn method for="WindowClient"><code>navigate()</code></dfn> method *must* run these steps:
+      The <dfn method for="WindowClient"><code>navigate(url)</code></dfn> method *must* run these steps:
 
         1. Let |url| be the result of <a lt="URL parser">parsing</a> |url| with the <a>context object</a>'s <a>relevant settings object</a>'s <a>API base URL</a>.
         1. If |url| is failure, return a <a>promise</a> rejected with a <code>TypeError</code>.
         1. If |url| is <code>about:blank</code>, return a <a>promise</a> rejected with a <code>TypeError</code>.
         1. If the <a>context object</a>'s associated [=Client/service worker client=]'s <a>active service worker</a> is not the <a>context object</a>'s <a>relevant global object</a>'s [=ServiceWorkerGlobalScope/service worker=], return a <a>promise</a> rejected with a <code>TypeError</code>.
+        1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
         1. Let |promise| be a new <a>promise</a>.
-        1. Run these substeps <a>in parallel</a>:
-            1. Let |browsingContext| be the <a>context object</a>'s associated [=Client/service worker client=]'s [=environment settings object/global object=]'s [=/browsing context=].
-            1. If |browsingContext| has <a lt="discard a document">discarded</a> its {{Document}}, reject |promise| with a <code>TypeError</code> and abort these steps.
-            1. Let |navigateFailed| be false.
-            1. Let |visibilityState| be null.
-            1. Let |focusState| be false.
-            1. Let |ancestorOriginsList| be the empty list.
-            1. <a>Queue a task</a> |task| to run the following substeps on the <a>context object</a>'s associated [=Client/service worker client=]'s <a>responsible event loop</a> using the <a>user interaction task source</a>:
-                1. *HandleNavigate*: <a>Navigate</a> |browsingContext| to |url| with <a lt="exceptions enabled flag">exceptions enabled</a>. The <a>source browsing context</a> must be |browsingContext|.
-                1. If the algorithm steps invoked in the step labeled *HandleNavigate* <a>throws</a> an exception, set |navigateFailed| to true.
-                1. Set |visibilityState| to |browsingContext|'s <a>active document</a>'s {{Document/visibilityState}} attribute value.
-                1. Set |focusState| to the result of running the <a>has focus steps</a> with |browsingContext|'s <a>active document</a> as the argument.
-                1. Set |ancestorOriginsList| to |browsingContext|'s <a>active document</a>'s <a>relevant global object</a>'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
-            1. Wait for |task| to have executed (including its asynchronous steps).
-            1. If |navigateFailed| is true, reject |promise| with a <code>TypeError</code> and abort these steps.
-            1. If |browsingContext|'s {{Window}} object's <a>environment settings object</a>'s <a>creation URL</a>'s [=url/origin=] is not the <a lt="same origin">same</a> as the [=ServiceWorkerGlobalScope/service worker=]'s [=environment settings object/origin=], then:
-                1. Resolve |promise| with null.
-                1. Abort these steps.
-            1. Let |windowClient| be the result of running <a>Create Window Client</a> algorithm with |browsingContext|'s {{Window}} object's <a>environment settings object</a>, |visibilityState|, |focusState|, and |ancestorOriginsList| as the arguments.
-            1. Resolve |promise| with |windowClient|.
+        1. [=Queue a task=] to run the following steps on the [=context object=]'s associated [=Client/service worker client=]'s [=responsible event loop=] using the [=user interaction task source=]:
+            1. Let |browsingContext| be the current [=/browsing context=].
+            1. If |browsingContext| has [=discard a document|discarded=] its {{Document}}, [=queue a task=] to reject |promise| with a `TypeError`, on |serviceWorkerEventLoop| using the [=DOM manipulation task source=], and abort these steps.
+            1. *HandleNavigate*: [=Navigate=] |browsingContext| to |url| with [=exceptions enabled flag|exceptions enabled=]. The [=source browsing context=] must be |browsingContext|.
+            1. If the algorithm steps invoked in the step labeled *HandleNavigate* [=throws=] an exception, [=queue a task=] to reject |promise| with the exception, on |serviceWorkerEventLoop| using the [=DOM manipulation task source=], and abort these steps.
+            1. Let |frameType| be the result of running [=Get Frame Type=] with |browsingContext|.
+            1. Let |visibilityState| be |browsingContext|'s <a>active document</a>'s {{Document/visibilityState}} attribute value.
+            1. Let |focusState| be the result of running the [=has focus steps=] with |browsingContext|'s [=active document=].
+            1. Let |ancestorOriginsList| be |browsingContext|'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
+            1. [=Queue a task=] to run the following steps on |serviceWorkerEventLoop| using the [=DOM manipulation task source=]:
+                1. If |browsingContext|'s {{Window}} object's <a>environment settings object</a>'s <a>creation URL</a>'s [=url/origin=] is not the <a lt="same origin">same</a> as the [=ServiceWorkerGlobalScope/service worker=]'s [=environment settings object/origin=], resolve |promise| with null and abort these steps.
+                1. Let |windowClient| be the result of running [=Create Window Client=] with the [=context object=]'s [=Client/service worker client=], |frameType|, |visibilityState|, |focusState|, and |ancestorOriginsList|.
+                1. Resolve |promise| with |windowClient|.
         1. Return |promise|.
     </section>
   </section>
@@ -1193,6 +1200,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
                     1. [=Queue a task=] |task| to run the following substeps on |browsingContext|'s [=event loop=] using the [=user interaction task source=]:
                         1. If |browsingContext| has been [=a browsing context is discarded|discarded=], then set |isClientEnumerable| to false and abort these steps.
                         1. If |client| is a window client and |client|'s [=responsible document=] is not |browsingContext|'s [=active document=], then set |isClientEnumerable| to false and abort these steps.
+                        1. Set |windowData|["`frameType`"] to the result of running [=Get Frame Type=] with |browsingContext|.
                         1. Set |windowData|["`visibilityState`"] to |browsingContext|'s [=active document=]'s {{Document/visibilityState}} attribute value.
                         1. Set |windowData|["`focusState`"] to the result of running the [=has focus steps=] with |browsingContext|'s [=active document=] as the argument.
                         1. If |client| is a [=window client=], then set |windowData|["`ancestorOriginsList`"] to |browsingContext|'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
@@ -1204,10 +1212,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
                         1. Add |windowData| to |matchedWindowData|.
                 1. Else if |options|["{{ClientQueryOptions/type}}"] is {{ClientType/"worker"}} or {{ClientType/"all"}} and |client| is a [=dedicated worker client=], or |options|["{{ClientQueryOptions/type}}"] is {{ClientType/"sharedworker"}} or {{ClientType/"all"}} and |client| is a [=shared worker client=], then:
                     1. Add |client| to |matchedClients|.
-            1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to run the following steps:
+            1. [=Queue a task=] to run the following steps on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=]:
                 1. Let |clientObjects| be a new [=list=].
                 1. [=list/For each=] |windowData| in |matchedWindowData|:
-                    1. Let |windowClient| be the result of running [=Create Window Client=] algorithm with |windowData|["`client`"], |windowData|["`visibilityState`"], |windowData|["`focusState`"], and |windowData|["`ancestorOriginsList`"] as the arguments.
+                    1. Let |windowClient| be the result of running [=Create Window Client=] algorithm with |windowData|["`client`"], |windowData|["`frameType`"], |windowData|["`visibilityState`"], |windowData|["`focusState`"], and |windowData|["`ancestorOriginsList`"] as the arguments.
                     1. [=Append=] |windowClient| to |clientObjects|.
                 1. [=list/For each=] |client| in |matchedClients|:
                     1. Let |clientObject| be the result of running [=Create Client=] algorithm with |client| as the argument.
@@ -1231,26 +1239,21 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. If |url| is failure, return a <a>promise</a> rejected with a <code>TypeError</code>.
         1. If |url| is <code>about:blank</code>, return a <a>promise</a> rejected with a <code>TypeError</code>.
         1. If this algorithm is not <a>triggered by user activation</a>, return a <a>promise</a> rejected with an "{{InvalidAccessError}}" {{DOMException}}.
+        1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
         1. Let |promise| be a new <a>promise</a>.
         1. Run these substeps <a>in parallel</a>:
-            1. Let |newContext| be a new <a>top-level browsing context</a>.
-            1. Let |openWindowFailed| to false.
-            1. Let |visibilityState| be null.
-            1. Let |focusState| be false.
-            1. Let |ancestorOriginsList| be the empty list.
-            1. <a>Queue a task</a> |task| to run the following substeps on |newContext|'s {{Window}} object's <a>environment settings object</a>'s <a>responsible event loop</a> using the <a>user interaction task source</a>:
-                1. *HandleNavigate*: <a>Navigate</a> |newContext| to |url| with <a lt="exceptions enabled flag">exceptions enabled</a> and <a>replacement enabled</a>.
-                1. If the algorithm steps invoked in the step labeled *HandleNavigate* <a>throws</a> an exception, set |openWindowFailed| to true.
-                1. Set |visibilityState| to |newContext|'s <a>active document</a>'s {{Document/visibilityState}} attribute value.
-                1. Set |focusState| to the result of running the <a>has focus steps</a> with |newContext|'s <a>active document</a> as the argument.
-                1. Set |ancestorOriginsList| to |newContext|'s <a>active document</a>'s <a>relevant global object</a>'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
-            1. Wait for |task| to have executed (including its asynchronous steps).
-            1. If |openWindowFailed| is true, reject |promise| with a <code>TypeError</code> and abort these steps.
-            1. If |newContext|'s {{Window}} object's <a>environment settings object</a>'s <a>creation URL</a>'s [=environment settings object/origin=] is not the <a lt="same origin">same</a> as the [=ServiceWorkerGlobalScope/service worker=]'s [=environment settings object/origin=], then:
-                1. Resolve |promise| with null.
-                1. Abort these steps.
-            1. Let |client| be the result of running <a>Create Window Client</a> algorithm with |newContext|'s {{Window}} object's <a>environment settings object</a>, |visibilityState|, |focusState|, and |ancestorOriginsList| as the arguments.
-            1. Resolve |promise| with |client|.
+            1. Let |newContext| be a new [=top-level browsing context=].
+            1. [=Queue a task=] to run the following steps on |newContext|'s {{Window}} object's [=environment settings object=]'s [=responsible event loop=] using the [=user interaction task source=]:
+                1. *HandleNavigate*: [=Navigate=] |newContext| to |url| with [=exceptions enabled flag|exceptions enabled=] and [=replacement enabled=].
+                1. If the algorithm steps invoked in the step labeled *HandleNavigate* [=throws=] an exception, [=queue a task=] to reject |promise| with the exception, on |serviceWorkerEventLoop| using the [=DOM manipulation task source=], and abort these steps.
+                1. Let |frameType| be the result of running [=Get Frame Type=] with |newContext|.
+                1. Let |visibilityState| be |newContext|'s <a>active document</a>'s {{Document/visibilityState}} attribute value.
+                1. Let |focusState| be the result of running the <a>has focus steps</a> with |newContext|'s <a>active document</a> as the argument.
+                1. Let |ancestorOriginsList| be |newContext|'s <a>active document</a>'s <a>relevant global object</a>'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
+                1. [=Queue a task=] to run the following steps on |serviceWorkerEventLoop| using the [=DOM manipulation task source=]:
+                    1. If |newContext|'s {{Window}} object's [=environment settings object=]'s [=creation URL=]'s [=environment settings object/origin=] is not the [=same origin|same=] as the [=ServiceWorkerGlobalScope/service worker=]'s [=environment settings object/origin=], resolve |promise| with null and abort these steps.
+                    1. Let |client| be the result of running [=Create Window Client=] with |newContext|'s {{Window}} object's [=environment settings object=], |frameType|, |visibilityState|, |focusState|, and |ancestorOriginsList| as the arguments.
+                    1. Resolve |promise| with |client|.
         1. Return |promise|.
     </section>
 
@@ -3148,6 +3151,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       : Input
       :: |client|, a [=/service worker client=]
+      :: |frameType|, a string
       :: |visibilityState|, a string
       :: |focusState|, a boolean
       :: |ancestorOriginsList|, a list
@@ -3156,10 +3160,63 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       1. Let |windowClient| be a new {{WindowClient}} object.
       1. Set |windowClient|'s [=Client/service worker client=] to |client|.
-      1. Set |windowClient|'s <a>visibility state</a> to |visibilityState|.
-      1. Set |windowClient|'s <a>focus state</a> to |focusState|.
+      1. Set |windowClient|'s [=frame type=] to |frameType|.
+      1. Set |windowClient|'s [=visibility state=] to |visibilityState|.
+      1. Set |windowClient|'s [=focus state=] to |focusState|.
       1. Set |windowClient|'s [=WindowClient/ancestor origins array=] to a [=frozen array type|frozen array=] created from |ancestorOriginsList|.
       1. Return |windowClient|.
+  </section>
+
+  <section algorithm>
+    <h3 id="get-frametype-algorithm"><dfn>Get Frame Type</dfn></h3>
+
+      : Input
+      :: |browsingContext|, a [=/browsing context=]
+      : Output
+      :: <var ignore="">frameType</var>, a string
+
+      1. Return the value by switching on the type of |browsingContext|:
+          : [=Nested browsing context=]
+          :: "nested"
+
+          : [=Auxiliary browsing context=]
+          :: "auxiliary"
+
+          : Otherwise
+          :: "top-level"
+  </section>
+
+  <section algorithm>
+    <h3 id="resolve-get-client-promise-algorithm"><dfn>Resolve Get Client Promise</dfn></h3>
+
+      : Input
+      :: |client|, a [=/service worker client=]
+      :: |promise|, a [=promise=]
+
+      : Output
+      :: none
+
+      1. If |client| is an [=environment settings object=], then:
+          1. If |client| is not a [=secure context=], [=queue a task=] to reject |promise| with a "{{SecurityError}}" {{DOMException}}, on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], and abort these steps.
+      1. Else:
+          1. If |client|’s [=creation URL=] is not a [=potentially trustworthy URL=], [=queue a task=] to reject |promise| with a "{{SecurityError}}" {{DOMException}}, on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], and abort these steps.
+      1. If |client| is an [=environment settings object=] and is not a [=window client=], then:
+          1. Let |clientObject| be the result of running [=Create Client=] algorithm with |client| as the argument.
+          1. [=Queue a task=] to resolve |promise| with |clientObject|, on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], and abort these steps.
+      1. Else:
+          1. Let |browsingContext| be null.
+          1. If |client| is an [=environment settings object=], set |browsingContext| to |client|'s [=environment settings object/global object=]'s [=/browsing context=].
+          1. Else, set |browsingContext| to |client|’s [=environment/target browsing context=].
+          1. [=Queue a task=] to run the following steps on |browsingContext|'s [=event loop=] using the [=user interaction task source=]:
+              1. Let |frameType| be the result of running [=Get Frame Type=] with |browsingContext|.
+              1. Let |visibilityState| be |browsingContext|'s [=active document=]'s {{Document/visibilityState}} attribute value.
+              1. Let |focusState| be the result of running the [=has focus steps=] with |browsingContext|'s [=active document=] as the argument.
+              1. Let |ancestorOriginsList| be the empty list.
+              1. If |client| is a [=window client=], set |ancestorOriginsList| to |browsingContext|'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
+              1. [=Queue a task=] to run the following steps on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=]:
+                  1. If |client|'s [=discarded flag=] is set, resolve |promise| with undefined and abort these steps.
+                  1. Let |windowClient| be the result of running [=Create Window Client=] with |client|, |frameType|, |visibilityState|, |focusState|, and |ancestorOriginsList|.
+                  1. Resolve |promise| with |windowClient|.
   </section>
 
   <section algorithm>
@@ -3249,40 +3306,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. [=Throw=] the exception.
 
           Note: When an exception is [=throw|thrown=], the implementation does undo (roll back) any changes made to the cache storage during the batch operation job.
-  </section>
-
-  <section algorithm>
-    <h3 id="resolve-get-client-promise-algorithm"><dfn>Resolve Get Client Promise</dfn></h3>
-
-      : Input
-      :: |client|, a [=/service worker client=]
-      :: |promise|, a [=promise=]
-
-      : Output
-      :: none
-
-      1. If |client| is an [=environment settings object=], then:
-          1. If |client| is not a [=secure context=], reject |promise| with a "{{SecurityError}}" {{DOMException}} and abort these steps.
-      1. Else:
-          1. If |client|’s [=creation URL=] is not a [=potentially trustworthy URL=], reject |promise| with a "{{SecurityError}}" {{DOMException}} and abort these steps.
-      1. If |client| is an [=environment settings object=] and is not a [=window client=], then:
-          1. Let |clientObject| be the result of running [=Create Client=] algorithm with |client| as the argument.
-          1. Resolve |promise| with |clientObject| and abort these steps.
-      1. Else:
-          1. Let |browsingContext| be null.
-          1. Let |visibilityState| be null.
-          1. Let |focusState| be false.
-          1. Let |ancestorOriginsList| be the empty list.
-          1. If |client| is an [=environment settings object=], set |browsingContext| to |client|'s [=environment settings object/global object=]'s [=/browsing context=].
-          1. Else, set |browsingContext| to |client|’s [=environment/target browsing context=].
-          1. [=Queue a task=] |task| to run the following substeps on |browsingContext|'s [=event loop=] using the [=user interaction task source=]:
-              1. Set |visibilityState| to |browsingContext|'s [=active document=]'s {{Document/visibilityState}} attribute value.
-              1. Set |focusState| to the result of running the [=has focus steps=] with |browsingContext|'s [=active document=] as the argument.
-              1. If |client| is a [=window client=], set |ancestorOriginsList| to |browsingContext|'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
-          1. Wait for |task| to have executed.
-          1. If |client|'s [=discarded flag=] is set, resolve |promise| with undefined and abort these steps.
-          1. Let |windowClient| be the result of running [=Create Window Client=] algorithm with |client|, |visibilityState|, |focusState|, and |ancestorOriginsList| as the arguments.
-          1. Resolve |promise| with |windowClient|.
   </section>
 </section>
 

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -911,6 +911,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       [Exposed=ServiceWorker]
       interface Client {
         readonly attribute USVString url;
+        readonly attribute FrameType frameType;
         readonly attribute DOMString id;
         readonly attribute ClientType type;
         void postMessage(any message, optional sequence&lt;object&gt; transfer = []);
@@ -924,9 +925,18 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         [NewObject] Promise&lt;WindowClient&gt; focus();
         [NewObject] Promise&lt;WindowClient?&gt; navigate(USVString url);
       };
+
+      enum FrameType {
+        "auxiliary",
+        "top-level",
+        "nested",
+        "none"
+      };
     </pre>
 
-    A {{Client}} object has an associated <dfn for="Client">service worker client</dfn> (a [=/service worker client=]).
+    A {{Client}} object has an associated <dfn id="dfn-service-worker-client-service-worker-client" for="Client">service worker client</dfn> (a [=/service worker client=]).
+
+    A {{Client}} object has an associated <dfn id="dfn-service-worker-client-frame-type" for="Client">frame type</dfn>, which is one of "auxiliary", "top-level", "nested", and "none". Unless stated otherwise it is "none".
 
     A {{WindowClient}} object has an associated <dfn id="dfn-service-worker-client-browsing-context" for="WindowClient">browsing context</dfn>, which is its [=Client/service worker client=]'s [=environment settings object/global object=]'s [=/browsing context=].
 
@@ -940,6 +950,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       <h4 id="client-url">{{Client/url}}</h4>
 
       The <dfn attribute for="Client"><code>url</code></dfn> attribute *must* return the <a>context object</a>'s associated [=Client/service worker client=]'s <a lt="URL serializer">serialized</a> <a>creation URL</a>.
+    </section>
+
+    <section>
+      <h4 id="client-frametype">{{Client/frameType}}</h4>
+
+      The <dfn attribute for="Client"><code>frameType</code></dfn> attribute *must* return the [=context object=]'s [=frame type=].
     </section>
 
     <section>
@@ -1006,54 +1022,45 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       The <dfn method for="WindowClient"><code>focus()</code></dfn> method *must* run these steps:
 
         1. If this algorithm is not <a>triggered by user activation</a>, return a <a>promise</a> rejected with an "{{InvalidAccessError}}" {{DOMException}}.
+        1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
         1. Let |promise| be a new <a>promise</a>.
-        1. Run these substeps <a>in parallel</a>:
-            1. Let |browsingContext| be the <a>context object</a>'s associated [=Client/service worker client=]'s [=environment settings object/global object=]'s [=/browsing context=].
-            1. Let |visibilityState| be null.
-            1. Let |focusState| be false.
-            1. Let |ancestorOriginsList| be the empty list.
-            1. <a>Queue a task</a> |task| to run the following substeps on the <a>context object</a>'s associated [=Client/service worker client=]'s <a>responsible event loop</a> using the <a>user interaction task source</a>:
-                1. Run the <a>focusing steps</a> with |browsingContext|.
-                1. Set |visibilityState| to |browsingContext|'s <a>active document</a>'s {{Document/visibilityState}} attribute value.
-                1. Set |focusState| to the result of running the <a>has focus steps</a> with |browsingContext|'s <a>active document</a> as the argument.
-                1. Set |ancestorOriginsList| to |browsingContext|'s <a>active document</a>'s <a>relevant global object</a>'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
-            1. Wait for |task| to have executed.
-            1. Let |windowClient| be the result of running <a>Create Window Client</a> algorithm with the <a>context object</a>'s associated [=Client/service worker client=], |visibilityState|, |focusState|, and |ancestorOriginsList| as the arguments.
-            1. If |windowClient|'s <a>focus state</a> is true, resolve |promise| with |windowClient|.
-            1. Else, reject |promise| with a <code>TypeError</code>.
+        1. [=Queue a task=] to run the following steps on the [=context object=]'s associated [=Client/service worker client=]'s [=responsible event loop=] using the [=user interaction task source=]:
+            1. Run the [=focusing steps=] with the current [=/browsing context=].
+            1. Let |frameType| be the result of running [=Get Frame Type=] with the current [=/browsing context=].
+            1. Let |visibilityState| be the current [=/browsing context=]'s [=active document=]'s {{Document/visibilityState}} attribute value.
+            1. Let |focusState| be the result of running the [=has focus steps=] with the current [=/browsing context=]'s [=active document=].
+            1. Let |ancestorOriginsList| be the current [=/browsing context=]'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
+            1. [=Queue a task=] to run the following steps on |serviceWorkerEventLoop| using the [=DOM manipulation task source=]:
+                1. Let |windowClient| be the result of running [=Create Window Client=] with the [=context object=]'s associated [=Client/service worker client=], |frameType|, |visibilityState|, |focusState|, and |ancestorOriginsList|.
+                1. If |windowClient|'s [=focus state=] is true, resolve |promise| with |windowClient|.
+                1. Else, reject |promise| with a `TypeError`.
         1. Return |promise|.
     </section>
 
     <section algorithm="client-navigate">
       <h4 id="client-navigate">{{WindowClient/navigate(url)}}</h4>
 
-      The <dfn method for="WindowClient"><code>navigate()</code></dfn> method *must* run these steps:
+      The <dfn method for="WindowClient"><code>navigate(url)</code></dfn> method *must* run these steps:
 
         1. Let |url| be the result of <a lt="URL parser">parsing</a> |url| with the <a>context object</a>'s <a>relevant settings object</a>'s <a>API base URL</a>.
         1. If |url| is failure, return a <a>promise</a> rejected with a <code>TypeError</code>.
         1. If |url| is <code>about:blank</code>, return a <a>promise</a> rejected with a <code>TypeError</code>.
         1. If the <a>context object</a>'s associated [=Client/service worker client=]'s <a>active service worker</a> is not the <a>context object</a>'s <a>relevant global object</a>'s [=ServiceWorkerGlobalScope/service worker=], return a <a>promise</a> rejected with a <code>TypeError</code>.
+        1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
         1. Let |promise| be a new <a>promise</a>.
-        1. Run these substeps <a>in parallel</a>:
-            1. Let |browsingContext| be the <a>context object</a>'s associated [=Client/service worker client=]'s [=environment settings object/global object=]'s [=/browsing context=].
-            1. If |browsingContext| has <a lt="discard a document">discarded</a> its {{Document}}, reject |promise| with a <code>TypeError</code> and abort these steps.
-            1. Let |navigateFailed| be false.
-            1. Let |visibilityState| be null.
-            1. Let |focusState| be false.
-            1. Let |ancestorOriginsList| be the empty list.
-            1. <a>Queue a task</a> |task| to run the following substeps on the <a>context object</a>'s associated [=Client/service worker client=]'s <a>responsible event loop</a> using the <a>user interaction task source</a>:
-                1. *HandleNavigate*: <a>Navigate</a> |browsingContext| to |url| with <a lt="exceptions enabled flag">exceptions enabled</a>. The <a>source browsing context</a> must be |browsingContext|.
-                1. If the algorithm steps invoked in the step labeled *HandleNavigate* <a>throws</a> an exception, set |navigateFailed| to true.
-                1. Set |visibilityState| to |browsingContext|'s <a>active document</a>'s {{Document/visibilityState}} attribute value.
-                1. Set |focusState| to the result of running the <a>has focus steps</a> with |browsingContext|'s <a>active document</a> as the argument.
-                1. Set |ancestorOriginsList| to |browsingContext|'s <a>active document</a>'s <a>relevant global object</a>'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
-            1. Wait for |task| to have executed (including its asynchronous steps).
-            1. If |navigateFailed| is true, reject |promise| with a <code>TypeError</code> and abort these steps.
-            1. If |browsingContext|'s {{Window}} object's <a>environment settings object</a>'s <a>creation URL</a>'s [=url/origin=] is not the <a lt="same origin">same</a> as the [=ServiceWorkerGlobalScope/service worker=]'s [=environment settings object/origin=], then:
-                1. Resolve |promise| with null.
-                1. Abort these steps.
-            1. Let |windowClient| be the result of running <a>Create Window Client</a> algorithm with |browsingContext|'s {{Window}} object's <a>environment settings object</a>, |visibilityState|, |focusState|, and |ancestorOriginsList| as the arguments.
-            1. Resolve |promise| with |windowClient|.
+        1. [=Queue a task=] to run the following steps on the [=context object=]'s associated [=Client/service worker client=]'s [=responsible event loop=] using the [=user interaction task source=]:
+            1. Let |browsingContext| be the current [=/browsing context=].
+            1. If |browsingContext| has [=discard a document|discarded=] its {{Document}}, [=queue a task=] to reject |promise| with a `TypeError`, on |serviceWorkerEventLoop| using the [=DOM manipulation task source=], and abort these steps.
+            1. *HandleNavigate*: [=Navigate=] |browsingContext| to |url| with [=exceptions enabled flag|exceptions enabled=]. The [=source browsing context=] must be |browsingContext|.
+            1. If the algorithm steps invoked in the step labeled *HandleNavigate* [=throws=] an exception, [=queue a task=] to reject |promise| with the exception, on |serviceWorkerEventLoop| using the [=DOM manipulation task source=], and abort these steps.
+            1. Let |frameType| be the result of running [=Get Frame Type=] with |browsingContext|.
+            1. Let |visibilityState| be |browsingContext|'s <a>active document</a>'s {{Document/visibilityState}} attribute value.
+            1. Let |focusState| be the result of running the [=has focus steps=] with |browsingContext|'s [=active document=].
+            1. Let |ancestorOriginsList| be |browsingContext|'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
+            1. [=Queue a task=] to run the following steps on |serviceWorkerEventLoop| using the [=DOM manipulation task source=]:
+                1. If |browsingContext|'s {{Window}} object's <a>environment settings object</a>'s <a>creation URL</a>'s [=url/origin=] is not the <a lt="same origin">same</a> as the [=ServiceWorkerGlobalScope/service worker=]'s [=environment settings object/origin=], resolve |promise| with null and abort these steps.
+                1. Let |windowClient| be the result of running [=Create Window Client=] with the [=context object=]'s [=Client/service worker client=], |frameType|, |visibilityState|, |focusState|, and |ancestorOriginsList|.
+                1. Resolve |promise| with |windowClient|.
         1. Return |promise|.
     </section>
   </section>
@@ -1131,6 +1138,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
                     1. [=Queue a task=] |task| to run the following substeps on |browsingContext|'s [=event loop=] using the [=user interaction task source=]:
                         1. If |browsingContext| has been [=a browsing context is discarded|discarded=], then set |isClientEnumerable| to false and abort these steps.
                         1. If |client| is a window client and |client|'s [=responsible document=] is not |browsingContext|'s [=active document=], then set |isClientEnumerable| to false and abort these steps.
+                        1. Set |windowData|["`frameType`"] to the result of running [=Get Frame Type=] with |browsingContext|.
                         1. Set |windowData|["`visibilityState`"] to |browsingContext|'s [=active document=]'s {{Document/visibilityState}} attribute value.
                         1. Set |windowData|["`focusState`"] to the result of running the [=has focus steps=] with |browsingContext|'s [=active document=] as the argument.
                         1. If |client| is a [=window client=], then set |windowData|["`ancestorOriginsList`"] to |browsingContext|'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
@@ -1142,10 +1150,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
                         1. Add |windowData| to |matchedWindowData|.
                 1. Else if |options|["{{ClientQueryOptions/type}}"] is {{ClientType/"worker"}} or {{ClientType/"all"}} and |client| is a [=dedicated worker client=], or |options|["{{ClientQueryOptions/type}}"] is {{ClientType/"sharedworker"}} or {{ClientType/"all"}} and |client| is a [=shared worker client=], then:
                     1. Add |client| to |matchedClients|.
-            1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to run the following steps:
+            1. [=Queue a task=] to run the following steps on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=]:
                 1. Let |clientObjects| be a new [=list=].
                 1. [=list/For each=] |windowData| in |matchedWindowData|:
-                    1. Let |windowClient| be the result of running [=Create Window Client=] algorithm with |windowData|["`client`"], |windowData|["`visibilityState`"], |windowData|["`focusState`"], and |windowData|["`ancestorOriginsList`"] as the arguments.
+                    1. Let |windowClient| be the result of running [=Create Window Client=] algorithm with |windowData|["`client`"], |windowData|["`frameType`"], |windowData|["`visibilityState`"], |windowData|["`focusState`"], and |windowData|["`ancestorOriginsList`"] as the arguments.
                     1. [=Append=] |windowClient| to |clientObjects|.
                 1. [=list/For each=] |client| in |matchedClients|:
                     1. Let |clientObject| be the result of running [=Create Client=] algorithm with |client| as the argument.
@@ -1169,26 +1177,21 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. If |url| is failure, return a <a>promise</a> rejected with a <code>TypeError</code>.
         1. If |url| is <code>about:blank</code>, return a <a>promise</a> rejected with a <code>TypeError</code>.
         1. If this algorithm is not <a>triggered by user activation</a>, return a <a>promise</a> rejected with an "{{InvalidAccessError}}" {{DOMException}}.
+        1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
         1. Let |promise| be a new <a>promise</a>.
         1. Run these substeps <a>in parallel</a>:
-            1. Let |newContext| be a new <a>top-level browsing context</a>.
-            1. Let |openWindowFailed| to false.
-            1. Let |visibilityState| be null.
-            1. Let |focusState| be false.
-            1. Let |ancestorOriginsList| be the empty list.
-            1. <a>Queue a task</a> |task| to run the following substeps on |newContext|'s {{Window}} object's <a>environment settings object</a>'s <a>responsible event loop</a> using the <a>user interaction task source</a>:
-                1. *HandleNavigate*: <a>Navigate</a> |newContext| to |url| with <a lt="exceptions enabled flag">exceptions enabled</a> and <a>replacement enabled</a>.
-                1. If the algorithm steps invoked in the step labeled *HandleNavigate* <a>throws</a> an exception, set |openWindowFailed| to true.
-                1. Set |visibilityState| to |newContext|'s <a>active document</a>'s {{Document/visibilityState}} attribute value.
-                1. Set |focusState| to the result of running the <a>has focus steps</a> with |newContext|'s <a>active document</a> as the argument.
-                1. Set |ancestorOriginsList| to |newContext|'s <a>active document</a>'s <a>relevant global object</a>'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
-            1. Wait for |task| to have executed (including its asynchronous steps).
-            1. If |openWindowFailed| is true, reject |promise| with a <code>TypeError</code> and abort these steps.
-            1. If |newContext|'s {{Window}} object's <a>environment settings object</a>'s <a>creation URL</a>'s [=environment settings object/origin=] is not the <a lt="same origin">same</a> as the [=ServiceWorkerGlobalScope/service worker=]'s [=environment settings object/origin=], then:
-                1. Resolve |promise| with null.
-                1. Abort these steps.
-            1. Let |client| be the result of running <a>Create Window Client</a> algorithm with |newContext|'s {{Window}} object's <a>environment settings object</a>, |visibilityState|, |focusState|, and |ancestorOriginsList| as the arguments.
-            1. Resolve |promise| with |client|.
+            1. Let |newContext| be a new [=top-level browsing context=].
+            1. [=Queue a task=] to run the following steps on |newContext|'s {{Window}} object's [=environment settings object=]'s [=responsible event loop=] using the [=user interaction task source=]:
+                1. *HandleNavigate*: [=Navigate=] |newContext| to |url| with [=exceptions enabled flag|exceptions enabled=] and [=replacement enabled=].
+                1. If the algorithm steps invoked in the step labeled *HandleNavigate* [=throws=] an exception, [=queue a task=] to reject |promise| with the exception, on |serviceWorkerEventLoop| using the [=DOM manipulation task source=], and abort these steps.
+                1. Let |frameType| be the result of running [=Get Frame Type=] with |newContext|.
+                1. Let |visibilityState| be |newContext|'s <a>active document</a>'s {{Document/visibilityState}} attribute value.
+                1. Let |focusState| be the result of running the <a>has focus steps</a> with |newContext|'s <a>active document</a> as the argument.
+                1. Let |ancestorOriginsList| be |newContext|'s <a>active document</a>'s <a>relevant global object</a>'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
+                1. [=Queue a task=] to run the following steps on |serviceWorkerEventLoop| using the [=DOM manipulation task source=]:
+                    1. If |newContext|'s {{Window}} object's [=environment settings object=]'s [=creation URL=]'s [=environment settings object/origin=] is not the [=same origin|same=] as the [=ServiceWorkerGlobalScope/service worker=]'s [=environment settings object/origin=], resolve |promise| with null and abort these steps.
+                    1. Let |client| be the result of running [=Create Window Client=] with |newContext|'s {{Window}} object's [=environment settings object=], |frameType|, |visibilityState|, |focusState|, and |ancestorOriginsList| as the arguments.
+                    1. Resolve |promise| with |client|.
         1. Return |promise|.
     </section>
 
@@ -2995,6 +2998,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       : Input
       :: |client|, a [=/service worker client=]
+      :: |frameType|, a string
       :: |visibilityState|, a string
       :: |focusState|, a boolean
       :: |ancestorOriginsList|, a list
@@ -3003,10 +3007,63 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       1. Let |windowClient| be a new {{WindowClient}} object.
       1. Set |windowClient|'s [=Client/service worker client=] to |client|.
-      1. Set |windowClient|'s <a>visibility state</a> to |visibilityState|.
-      1. Set |windowClient|'s <a>focus state</a> to |focusState|.
+      1. Set |windowClient|'s [=frame type=] to |frameType|.
+      1. Set |windowClient|'s [=visibility state=] to |visibilityState|.
+      1. Set |windowClient|'s [=focus state=] to |focusState|.
       1. Set |windowClient|'s [=WindowClient/ancestor origins array=] to a [=frozen array type|frozen array=] created from |ancestorOriginsList|.
       1. Return |windowClient|.
+  </section>
+
+  <section algorithm>
+    <h3 id="get-frametype-algorithm"><dfn>Get Frame Type</dfn></h3>
+
+      : Input
+      :: |browsingContext|, a [=/browsing context=]
+      : Output
+      :: <var ignore="">frameType</var>, a string
+
+      1. Return the value by switching on the type of |browsingContext|:
+          : [=Nested browsing context=]
+          :: "nested"
+
+          : [=Auxiliary browsing context=]
+          :: "auxiliary"
+
+          : Otherwise
+          :: "top-level"
+  </section>
+
+  <section algorithm>
+    <h3 id="resolve-get-client-promise-algorithm"><dfn>Resolve Get Client Promise</dfn></h3>
+
+      : Input
+      :: |client|, a [=/service worker client=]
+      :: |promise|, a [=promise=]
+
+      : Output
+      :: none
+
+      1. If |client| is an [=environment settings object=], then:
+          1. If |client| is not a [=secure context=], [=queue a task=] to reject |promise| with a "{{SecurityError}}" {{DOMException}}, on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], and abort these steps.
+      1. Else:
+          1. If |client|’s [=creation URL=] is not a [=potentially trustworthy URL=], [=queue a task=] to reject |promise| with a "{{SecurityError}}" {{DOMException}}, on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], and abort these steps.
+      1. If |client| is an [=environment settings object=] and is not a [=window client=], then:
+          1. Let |clientObject| be the result of running [=Create Client=] algorithm with |client| as the argument.
+          1. [=Queue a task=] to resolve |promise| with |clientObject|, on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], and abort these steps.
+      1. Else:
+          1. Let |browsingContext| be null.
+          1. If |client| is an [=environment settings object=], set |browsingContext| to |client|'s [=environment settings object/global object=]'s [=/browsing context=].
+          1. Else, set |browsingContext| to |client|’s [=environment/target browsing context=].
+          1. [=Queue a task=] to run the following steps on |browsingContext|'s [=event loop=] using the [=user interaction task source=]:
+              1. Let |frameType| be the result of running [=Get Frame Type=] with |browsingContext|.
+              1. Let |visibilityState| be |browsingContext|'s [=active document=]'s {{Document/visibilityState}} attribute value.
+              1. Let |focusState| be the result of running the [=has focus steps=] with |browsingContext|'s [=active document=] as the argument.
+              1. Let |ancestorOriginsList| be the empty list.
+              1. If |client| is a [=window client=], set |ancestorOriginsList| to |browsingContext|'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
+              1. [=Queue a task=] to run the following steps on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=]:
+                  1. If |client|'s [=discarded flag=] is set, resolve |promise| with undefined and abort these steps.
+                  1. Let |windowClient| be the result of running [=Create Window Client=] with |client|, |frameType|, |visibilityState|, |focusState|, and |ancestorOriginsList|.
+                  1. Resolve |promise| with |windowClient|.
   </section>
 
   <section algorithm>
@@ -3096,40 +3153,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. [=Throw=] the exception.
 
           Note: When an exception is [=throw|thrown=], the implementation does undo (roll back) any changes made to the cache storage during the batch operation job.
-  </section>
-
-  <section algorithm>
-    <h3 id="resolve-get-client-promise-algorithm"><dfn>Resolve Get Client Promise</dfn></h3>
-
-      : Input
-      :: |client|, a [=/service worker client=]
-      :: |promise|, a [=promise=]
-
-      : Output
-      :: none
-
-      1. If |client| is an [=environment settings object=], then:
-          1. If |client| is not a [=secure context=], reject |promise| with a "{{SecurityError}}" {{DOMException}} and abort these steps.
-      1. Else:
-          1. If |client|’s [=creation URL=] is not a [=potentially trustworthy URL=], reject |promise| with a "{{SecurityError}}" {{DOMException}} and abort these steps.
-      1. If |client| is an [=environment settings object=] and is not a [=window client=], then:
-          1. Let |clientObject| be the result of running [=Create Client=] algorithm with |client| as the argument.
-          1. Resolve |promise| with |clientObject| and abort these steps.
-      1. Else:
-          1. Let |browsingContext| be null.
-          1. Let |visibilityState| be null.
-          1. Let |focusState| be false.
-          1. Let |ancestorOriginsList| be the empty list.
-          1. If |client| is an [=environment settings object=], set |browsingContext| to |client|'s [=environment settings object/global object=]'s [=/browsing context=].
-          1. Else, set |browsingContext| to |client|’s [=environment/target browsing context=].
-          1. [=Queue a task=] |task| to run the following substeps on |browsingContext|'s [=event loop=] using the [=user interaction task source=]:
-              1. Set |visibilityState| to |browsingContext|'s [=active document=]'s {{Document/visibilityState}} attribute value.
-              1. Set |focusState| to the result of running the [=has focus steps=] with |browsingContext|'s [=active document=] as the argument.
-              1. If |client| is a [=window client=], set |ancestorOriginsList| to |browsingContext|'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
-          1. Wait for |task| to have executed.
-          1. If |client|'s [=discarded flag=] is set, resolve |promise| with undefined and abort these steps.
-          1. Let |windowClient| be the result of running [=Create Window Client=] algorithm with |client|, |visibilityState|, |focusState|, and |ancestorOriginsList| as the arguments.
-          1. Resolve |promise| with |windowClient|.
   </section>
 </section>
 

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -1025,11 +1025,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
         1. Let |promise| be a new <a>promise</a>.
         1. [=Queue a task=] to run the following steps on the [=context object=]'s associated [=Client/service worker client=]'s [=responsible event loop=] using the [=user interaction task source=]:
-            1. Run the [=focusing steps=] with the current [=/browsing context=].
-            1. Let |frameType| be the result of running [=Get Frame Type=] with the current [=/browsing context=].
-            1. Let |visibilityState| be the current [=/browsing context=]'s [=active document=]'s {{Document/visibilityState}} attribute value.
-            1. Let |focusState| be the result of running the [=has focus steps=] with the current [=/browsing context=]'s [=active document=].
-            1. Let |ancestorOriginsList| be the current [=/browsing context=]'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
+            1. Run the [=focusing steps=] with the [=context object=]'s [=WindowClient/browsing context=].
+            1. Let |frameType| be the result of running [=Get Frame Type=] with the [=context object=]'s [=WindowClient/browsing context=].
+            1. Let |visibilityState| be the [=context object=]'s [=WindowClient/browsing context=]'s [=active document=]'s {{Document/visibilityState}} attribute value.
+            1. Let |focusState| be the result of running the [=has focus steps=] with the [=context object=]'s [=WindowClient/browsing context=]'s [=active document=].
+            1. Let |ancestorOriginsList| be the [=context object=]'s [=WindowClient/browsing context=]'s [=active document=]'s [=relevant global object=]'s {{Location}} object's [=Location/ancestor origins list=]'s associated list.
             1. [=Queue a task=] to run the following steps on |serviceWorkerEventLoop| using the [=DOM manipulation task source=]:
                 1. Let |windowClient| be the result of running [=Create Window Client=] with the [=context object=]'s associated [=Client/service worker client=], |frameType|, |visibilityState|, |focusState|, and |ancestorOriginsList|.
                 1. If |windowClient|'s [=focus state=] is true, resolve |promise| with |windowClient|.
@@ -1049,7 +1049,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
         1. Let |promise| be a new <a>promise</a>.
         1. [=Queue a task=] to run the following steps on the [=context object=]'s associated [=Client/service worker client=]'s [=responsible event loop=] using the [=user interaction task source=]:
-            1. Let |browsingContext| be the current [=/browsing context=].
+            1. Let |browsingContext| be the [=context object=]'s [=WindowClient/browsing context=].
             1. If |browsingContext| has [=discard a document|discarded=] its {{Document}}, [=queue a task=] to reject |promise| with a `TypeError`, on |serviceWorkerEventLoop| using the [=DOM manipulation task source=], and abort these steps.
             1. *HandleNavigate*: [=Navigate=] |browsingContext| to |url| with [=exceptions enabled flag|exceptions enabled=]. The [=source browsing context=] must be |browsingContext|.
             1. If the algorithm steps invoked in the step labeled *HandleNavigate* [=throws=] an exception, [=queue a task=] to reject |promise| with the exception, on |serviceWorkerEventLoop| using the [=DOM manipulation task source=], and abort these steps.


### PR DESCRIPTION
This change adds Client.frameType back with the reasons:
 - Implementations maintain it.
 - It can be accessed outside of fetch event handlers

This change also improved the steps of the algorithms that Create Window Client
invokes by removing unnecessary parallel steps.

Fixes: https://github.com/w3c/ServiceWorker/issues/732.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/pull/1329.html" title="Last updated on Jun 26, 2018, 5:35 AM GMT (3c7ff5c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1329/ff36205...3c7ff5c.html" title="Last updated on Jun 26, 2018, 5:35 AM GMT (3c7ff5c)">Diff</a>