### PR TITLE
Fix syntax error in IDL

### DIFF
--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -302,7 +302,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         // event
         attribute EventHandler onstatechange;
       };
-      ServiceWorker implements AbstractWorker;
+      ServiceWorker includes AbstractWorker;
 
       enum ServiceWorkerState {
         "installing",


### PR DESCRIPTION
`AbstractWorker` is an `interface mixin`, not an `interface`, so needs to be pull in via `includes` not `implements`.

Found while authoring https://github.com/web-platform-tests/wpt/pull/11960