### PR TITLE
Make Run Service Worker return after initial script evaluation.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2675,11 +2675,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. For each |eventType| of |settingsObject|'s [=environment settings object/global object=]'s associated list of <a>event listeners</a>' event types:
               1. [=set/Append=] |eventType| to |workerGlobalScope|'s associated [=ServiceWorkerGlobalScope/service worker=]'s <a>set of event types to handle</a>.
 
-          Note: If the global object's associated list of event listeners does not have any event listener added at this moment, the service worker's set of event types to handle remains an empty set. The user agents are encouraged to show a warning that the event listeners must be added on the very first evaluation of the worker script.
+             Note: If the global object's associated list of event listeners does not have any event listener added at this moment, the service worker's set of event types to handle remains an empty set. The user agents are encouraged to show a warning that the event listeners must be added on the very first evaluation of the worker script.
 
           1. Set |script|'s <a>has ever been evaluated flag</a>.
-      1. Run the <a>responsible event loop</a> specified by |settingsObject| until it is destroyed.
-      1. Empty |workerGlobalScope|'s <a>list of active timers</a>.
+      1. Run the following substeps [=in parallel=]:
+          1. Run the [=responsible event loop=] specified by |settingsObject| until it is destroyed.
+          1. Empty |workerGlobalScope|'s [=list of active timers=].
   </section>
 
   <section algorithm>


### PR DESCRIPTION
Otherwise Run Service Worker would not return until the worker
thread was terminated.

Also fix formatting so steps for 17 are numbered 17.1 and 17.2
instead of 17.1 and 17.1.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mattto/ServiceWorker/pull/1340.html" title="Last updated on Aug 8, 2018, 3:37 AM GMT (a138ce9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1340/8e6e33b...mattto:a138ce9.html" title="Last updated on Aug 8, 2018, 3:37 AM GMT (a138ce9)">Diff</a>