### PR TITLE
Fix environment reference

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -230,7 +230,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   <section dfn-for="service worker client">
     <h3 id="service-worker-client-concept">Service Worker Client</h3>
 
-    A <dfn export id="dfn-service-worker-client" for="">service worker client</dfn> is an [=environment=].
+    A <dfn export id="dfn-service-worker-client" for="">service worker client</dfn> is an [=/environment=].
 
     A [=/service worker client=] has an associated <dfn export>discarded flag</dfn>. It is initially unset.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1213,7 +1213,7 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
-  <meta content="Bikeshed version c03af8da7325f5ae3f9ca742161b5d270bbce12f" name="generator">
+  <meta content="Bikeshed version 10ff3eb4050069e20bb9b943c8b76fe5bfe3a48f" name="generator">
   <link href="https://www.w3.org/TR/service-workers/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1472,7 +1472,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-03-07">7 March 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2019-05-03">3 May 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1839,7 +1839,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     </section>
     <section>
      <h3 class="heading settled" data-level="2.3" id="service-worker-client-concept"><span class="secno">2.3. </span><span class="content">Service Worker Client</span><a class="self-link" href="#service-worker-client-concept"></a></h3>
-     <p>A <dfn class="dfn-paneled" data-dfn-for data-dfn-type="dfn" data-export id="dfn-service-worker-client">service worker client</dfn> is an <a data-link-type="dfn" href="https://w3c.github.io/FileAPI/#blob-url-entry-environment" id="ref-for-blob-url-entry-environment">environment</a>.</p>
+     <p>A <dfn class="dfn-paneled" data-dfn-for data-dfn-type="dfn" data-export id="dfn-service-worker-client">service worker client</dfn> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment" id="ref-for-environment">environment</a>.</p>
      <p>A <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client③">service worker client</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker client" data-dfn-type="dfn" data-export id="service-worker-client-discarded-flag">discarded flag</dfn>. It is initially unset.</p>
      <p>Each <a data-link-type="dfn" href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client④">service worker client</a> has the following <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-discarding-steps" id="ref-for-environment-discarding-steps">environment discarding steps</a>:</p>
      <ol>
@@ -7507,12 +7507,6 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-header-value①">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-blob-url-entry-environment">
-   <a href="https://w3c.github.io/FileAPI/#blob-url-entry-environment">https://w3c.github.io/FileAPI/#blob-url-entry-environment</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-blob-url-entry-environment">2.3. Service Worker Client</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-abstractworker">
    <a href="https://html.spec.whatwg.org/multipage/workers.html#abstractworker">https://html.spec.whatwg.org/multipage/workers.html#abstractworker</a><b>Referenced in:</b>
    <ul>
@@ -7795,6 +7789,12 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-manipulation-task-source②①">Update Worker State</a>
     <li><a href="#ref-for-dom-manipulation-task-source②②">Notify Controller Change</a>
     <li><a href="#ref-for-dom-manipulation-task-source②③">Resolve Get Client Promise</a> <a href="#ref-for-dom-manipulation-task-source②④">(2)</a> <a href="#ref-for-dom-manipulation-task-source②⑤">(3)</a> <a href="#ref-for-dom-manipulation-task-source②⑥">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-environment">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">https://html.spec.whatwg.org/multipage/webappapis.html#environment</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-environment">2.3. Service Worker Client</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-environment-discarding-steps">
@@ -9193,11 +9193,6 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
      <li><span class="dfn-paneled" id="term-for-concept-header-value" style="color:initial">value</span>
     </ul>
    <li>
-    <a data-link-type="biblio">[FileAPI]</a> defines the following terms:
-    <ul>
-     <li><span class="dfn-paneled" id="term-for-blob-url-entry-environment" style="color:initial">environment</span>
-    </ul>
-   <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-abstractworker" style="color:initial">AbstractWorker</span>
@@ -9234,6 +9229,7 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
      <li><span class="dfn-paneled" id="term-for-dom-messageevent-data" style="color:initial">data</span>
      <li><span class="dfn-paneled" id="term-for-discard-a-document" style="color:initial">discard a document</span>
      <li><span class="dfn-paneled" id="term-for-dom-manipulation-task-source" style="color:initial">dom manipulation task source</span>
+     <li><span class="dfn-paneled" id="term-for-environment" style="color:initial">environment</span>
      <li><span class="dfn-paneled" id="term-for-environment-discarding-steps" style="color:initial">environment discarding steps</span>
      <li><span class="dfn-paneled" id="term-for-environment-settings-object" style="color:initial">environment settings object</span>
      <li><span class="dfn-paneled" id="term-for-event-handlers" style="color:initial">event handler</span>
@@ -9437,8 +9433,6 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
    <dd><a href="https://tc39.github.io/ecma262/">ECMAScript Language Specification</a>. URL: <a href="https://tc39.github.io/ecma262/">https://tc39.github.io/ecma262/</a>
    <dt id="biblio-fetch">[FETCH]
    <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
-   <dt id="biblio-fileapi">[FileAPI]
-   <dd>Marijn Kruisselbrink; Arun Ranganathan. <a href="https://www.w3.org/TR/FileAPI/">File API</a>. 6 November 2018. WD. URL: <a href="https://www.w3.org/TR/FileAPI/">https://www.w3.org/TR/FileAPI/</a>
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-infra">[INFRA]
@@ -9466,7 +9460,7 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-webidl">[WebIDL]
-   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dd>Boris Zbarsky. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>


### PR DESCRIPTION
As asked in https://github.com/w3c/ServiceWorker/commit/b67c4450e04e12e12777eebbb27c368a25263bc7#r33398873, the `environment` was referenced to `FileAPI` and it's good to refer to the `environment` in html spec directly.

cc @mkruisselbrink


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/CYBAI/ServiceWorker/pull/1404.html" title="Last updated on May 4, 2019, 4:14 AM UTC (08350b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1404/13c1a67...CYBAI:08350b2.html" title="Last updated on May 4, 2019, 4:14 AM UTC (08350b2)">Diff</a>