### PR TITLE
Refinements and description of Service-Worker-Allowed.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2124,6 +2124,26 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   </section>
 
   <section>
+    <h3 id="path-restriction">Path restriction</h3>
+
+    *This section is non-normative.*
+
+    In addition to the [[#origin-restriction|origin restriction]], service workers are restricted by the [=url/path=] of the service worker script. For example, a service worker script at <code>https://www.example.com/~bob/sw.js</code> can be registered for the [=scope=] <code>https://www.example.com/~bob</code> but not for the scope <code>https://www.example.com</code> or <code>https://www.example.com/~alice</code>. This provides some protection for sites that host multiple-user content in separated directories on the same origin. However, the path restriction is not considered a hard security boundary, as only origins are. Sites are encouraged to use different origins to securely isolate segments of the site if appropriate.
+
+    Servers can break the path restriction by setting a [=Service-Worker-Allowed=] header on the service worker script.
+  </section>
+
+  <section>
+    <h3 id="script-request">Service worker script request</h3>
+
+    *This section is non-normative.*
+
+    To further defend against malicious registration of a service worker on a site, this specification requires that:
+    * The [=Service-Worker=] header is present on service worker script requests, and
+    * Service worker scripts are served with a [=JavaScript MIME type=].
+  </section>
+
+  <section>
     <h3 id="implementer-concerns">Implementer Concerns</h3>
 
     *This section is non-normative.*
@@ -2474,7 +2494,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. Asynchronously complete these steps with a [=network error=].
           1. Let |serviceWorkerAllowed| be the result of [=extracting header list values=] given \`<code>Service-Worker-Allowed</code>\` and |response|'s [=response/header list=].
 
-              Note: See the definition of the Service-Worker-Allowed header in Appendix B: Extended HTTP headers.
+              Note: See the definition of the [=Service-Worker-Allowed=] header in Appendix B: Extended HTTP headers.
 
           1. Set |httpsState| to |response|'s [=response/HTTPS state=].
           1. Set |referrerPolicy| to the result of <a>parse a referrer policy from a <code>Referrer-Policy</code> header</a> of |response|.
@@ -2486,9 +2506,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. Set |maxScopeString| to "<code>/</code>" concatenated with the strings, except the last string that denotes the script's file name, in |job|'s [=job/script url=]'s [=url/path=] (including empty strings), separated from each other by "<code>/</code>".
           1. Else:
               1. Let |maxScope| be the result of <a lt="URL parser">parsing</a> |serviceWorkerAllowed| with |job|'s [=job/script url=].
-              1. Set |maxScopeString| to "<code>/</code>" concatenated with the strings in |maxScope|'s [=url/path=] (including empty strings), separated from each other by "<code>/</code>".
+              1. If |maxScope|'s [=url/origin=] is |job|'s [=job/script url=]'s [=url/origin=]:
+                1. Set |maxScopeString| to "<code>/</code>" concatenated with the strings in |maxScope|'s [=url/path=] (including empty strings), separated from each other by "<code>/</code>".
           1. Let |scopeString| be "<code>/</code>" concatenated with the strings in |scopeURL|'s [=url/path=] (including empty strings), separated from each other by "<code>/</code>".
-          1. If |scopeString| starts with |maxScopeString|, do nothing.
+          1. If |maxScopeString| is not null and |scopeString| starts with |maxScopeString|, do nothing.
           1. Else:
               1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" {{DOMException}}.
               1. Asynchronously complete these steps with a <a>network error</a>.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2128,9 +2128,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     *This section is non-normative.*
 
-    In addition to the [[#origin-restriction|origin restriction]], service workers are restricted by the [=url/path=] of the service worker script. For example, a service worker script at <code>https://www.example.com/~bob/sw.js</code> can be registered for the [=scope=] <code>https://www.example.com/~bob</code> but not for the scope <code>https://www.example.com</code> or <code>https://www.example.com/~alice</code>. This provides some protection for sites that host multiple-user content in separated directories on the same origin. However, the path restriction is not considered a hard security boundary, as only origins are. Sites are encouraged to use different origins to securely isolate segments of the site if appropriate.
+    In addition to the [[#origin-restriction|origin restriction]], service workers are restricted by the [=url/path=] of the service worker script. For example, a service worker script at <code>https://www.example.com/~bob/sw.js</code> can be registered for the [=scope=] <code>https://www.example.com/~bob/</code> but not for the scope <code>https://www.example.com/</code> or <code>https://www.example.com/~alice/</code>. This provides some protection for sites that host multiple-user content in separated directories on the same origin. However, the path restriction is not considered a hard security boundary, as only origins are. Sites are encouraged to use different origins to securely isolate segments of the site if appropriate.
 
-    Servers can break the path restriction by setting a [=Service-Worker-Allowed=] header on the service worker script.
+    Servers can remove the path restriction by setting a [=Service-Worker-Allowed=] header on the service worker script.
   </section>
 
   <section>
@@ -2506,11 +2506,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. Set |maxScopeString| to "<code>/</code>" concatenated with the strings, except the last string that denotes the script's file name, in |job|'s [=job/script url=]'s [=url/path=] (including empty strings), separated from each other by "<code>/</code>".
           1. Else:
               1. Let |maxScope| be the result of <a lt="URL parser">parsing</a> |serviceWorkerAllowed| with |job|'s [=job/script url=].
-              1. If |maxScope|'s [=url/origin=] is |job|'s [=job/script url=]'s [=url/origin=]:
+              1. If |maxScope|'s [=url/origin=] is |job|'s [=job/script url=]'s [=url/origin=], then:
                 1. Set |maxScopeString| to "<code>/</code>" concatenated with the strings in |maxScope|'s [=url/path=] (including empty strings), separated from each other by "<code>/</code>".
           1. Let |scopeString| be "<code>/</code>" concatenated with the strings in |scopeURL|'s [=url/path=] (including empty strings), separated from each other by "<code>/</code>".
-          1. If |maxScopeString| is not null and |scopeString| starts with |maxScopeString|, do nothing.
-          1. Else:
+          1. If |maxScopeString| is null or |scopeString| does not start with |maxScopeString|, then:
               1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" {{DOMException}}.
               1. Asynchronously complete these steps with a <a>network error</a>.
           1. Let |url| be |request|'s [=request/url=].


### PR DESCRIPTION
* Require Service-Worker-Allowed to be same-origin to the script URL
  (#1307)
* Add non-normative explanation of Service-Worker-Allowed (#1405) and
  other mitigations. The text is highly inspired by
  https://infrequently.org/2014/12/psa-service-workers-are-coming/.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mattto/ServiceWorker/pull/1409.html" title="Last updated on May 29, 2019, 12:56 AM UTC (0eadf93)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1409/86d9414...mattto:0eadf93.html" title="Last updated on May 29, 2019, 12:56 AM UTC (0eadf93)">Diff</a>