### PR TITLE
Add trailing '/' to example of max scope

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3442,9 +3442,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       <pre highlight="js">
         // Maximum allowed scope defaults to the path the script sits in
-        // "/js" in this example
+        // "/js/" in this example
         navigator.serviceWorker.register("/js/sw.js").then(() => {
-          console.log("Install succeeded with the default scope '/js'.");
+          console.log("Install succeeded with the default scope '/js/'.");
         });
       </pre>
     </div>

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -3234,9 +3234,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       <pre highlight="js">
         // Maximum allowed scope defaults to the path the script sits in
-        // "/js" in this example
+        // "/js/" in this example
         navigator.serviceWorker.register("/js/sw.js").then(() => {
-          console.log("Install succeeded with the default scope '/js'.");
+          console.log("Install succeeded with the default scope '/js/'.");
         });
       </pre>
     </div>


### PR DESCRIPTION
In the "Service-Worker-Allowed" section of the docs, there's an example of what the default scope would be for a service worker that's registered at `/js/sw.js`. The examples incorrectly state that the default scope would be `/js`, when it's actually `/js/`. (`/js` is one level higher than the default, maximum allowed scope of `/js/`.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeffposnick/ServiceWorker/pull/1422.html" title="Last updated on Jun 7, 2019, 6:20 AM UTC (c0b48e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1422/f03b6d1...jeffposnick:c0b48e1.html" title="Last updated on Jun 7, 2019, 6:20 AM UTC (c0b48e1)">Diff</a>