### PR TITLE
One ServiceWorker object per service worker per realm

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -338,6 +338,20 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     A {{ServiceWorker}} object has an associated {{ServiceWorkerState}} object which is itself associated with [=/service worker=]'s <a>state</a>.
 
     <section>
+      <h4 id="service-worker-creation">Getting {{ServiceWorker}} instances</h4>
+
+      An [=environment settings object=] has a <dfn for="environment settings object">service worker object map</dfn>, a [=/map=] where the [=map/keys=] are [=/service workers=] and the [=map/values=] are {{ServiceWorker}} objects.
+
+      <section algorithm="service-worker-creation-algorithm">
+        To <dfn lt="get the service worker object|getting the service worker object">get the service worker object</dfn> representing |serviceWorker| (a [=/service worker=]) in |environment| (an [=environment settings object=]), run these steps:
+
+          1. Let |objectMap| be |environment|'s [=environment settings object/service worker object map=].
+          1. If |objectMap|[|serviceWorker|] does not [=map/exist=], then set |objectMap|[|serviceWorker|] to a new {{ServiceWorker}} in |environment|'s [=environment settings object/Realm=], and associate it with |serviceWorker|.
+          1. Return |objectMap|[|serviceWorker|].
+      </section>
+    </section>
+
+    <section>
       <h4 id="service-worker-url">{{ServiceWorker/scriptURL}}</h4>
 
       The <dfn attribute for="ServiceWorker"><code>scriptURL</code></dfn> attribute *must* return the [=/service worker=]'s <a lt="URL serializer">serialized</a> [=service worker/script url=].
@@ -378,13 +392,14 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Let |serviceWorker| be the [=/service worker=] represented by the <a>context object</a>.
         1. If the result of running the [=Should Skip Event=] algorithm with "message" and |serviceWorker|, is true, then return.
         1. Invoke <a>Run Service Worker</a> algorithm with |serviceWorker| as the argument.
-        1. Let |incumbentSettings| be the <a>incumbent settings object</a>, and |incumbentGlobal| its [=environment settings object/global object=].
+        1. Let |incumbentSettings| be the [=incumbent settings object=].
+        1. Let |incumbentGlobal| be |incumbentSettings|'s [=environment settings object/global object=].
         1. Let |serializeWithTransferResult| be <a abstract-op>StructuredSerializeWithTransfer</a>(|message|, |options|.transfer). Rethrow any exceptions.
         1. [=Queue a task=] on the [=DOM manipulation task source=] to run the following steps:
             1. Let |source| be determined by switching on the type of |incumbentGlobal|:
                 <dl class="switch">
                     <dt>{{ServiceWorkerGlobalScope}}</dt>
-                    <dd>a new {{ServiceWorker}} object that represents |incumbentGlobal|'s [=ServiceWorkerGlobalScope/service worker=].</dd>
+                    <dd>The result of [=getting the service worker object=] that represents |incumbentGlobal|'s [=ServiceWorkerGlobalScope/service worker=] in the [=relevant settings object=] of |serviceWorker|'s [=service worker/global object=].</dd>
 
                     <dt>{{Window}}</dt>
                     <dd>a new {{WindowClient}} object that represents |incumbentGlobal|'s [=relevant settings object=].</dd>
@@ -461,7 +476,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       <dfn attribute for="ServiceWorkerRegistration"><code>installing</code></dfn> attribute *must* return the value to which it was last set.
 
-      Note: The {{ServiceWorker}} objects returned from this attribute getter that represent the same [=/service worker=] are the same objects.
+      Note: Within a [=environment settings object/Realm=], there is only one {{ServiceWorker}} object per associated [=/service worker=].
     </section>
 
     <section algorithm="navigator-service-worker-waiting">
@@ -469,7 +484,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       <dfn attribute for="ServiceWorkerRegistration"><code>waiting</code></dfn> attribute *must* return the value to which it was last set.
 
-      Note: The {{ServiceWorker}} objects returned from this attribute getter that represent the same [=/service worker=] are the same objects.
+      Note: Within a [=environment settings object/Realm=], there is only one {{ServiceWorker}} object per associated [=/service worker=].
     </section>
 
     <section algorithm="navigator-service-worker-active">
@@ -477,7 +492,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       <dfn attribute for="ServiceWorkerRegistration"><code>active</code></dfn> attribute *must* return the value to which it was last set.
 
-      Note: The {{ServiceWorker}} objects returned from this attribute getter that represent the same [=/service worker=] are the same objects.
+      Note: Within a [=environment settings object/Realm=], there is only one {{ServiceWorker}} object per associated [=/service worker=].
     </section>
 
     <section algorithm="service-worker-registration-navigationpreload">
@@ -616,9 +631,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       <dfn attribute for="ServiceWorkerContainer"><code>controller</code></dfn> attribute *must* run these steps:
 
         1. Let |client| be the <a>context object</a>'s [=ServiceWorkerContainer/service worker client=].
-        1. Return the {{ServiceWorker}} object that represents |client|'s <a>active service worker</a>.
+        1. If |client|'s [=active service worker=] is null, then return null.
+        1. Return the result of [=getting the service worker object=] that represents |client|'s [=active service worker=] in the [=context object=]'s [=relevant settings object=].
 
-      Note: {{ServiceWorkerContainer/controller|navigator.serviceWorker.controller}} returns <code>null</code> if the request is a force refresh (shift+refresh). The {{ServiceWorker}} objects returned from this attribute getter that represent the same [=/service worker=] are the same objects.
+      Note: {{ServiceWorkerContainer/controller|navigator.serviceWorker.controller}} returns <code>null</code> if the request is a force refresh (shift+refresh).
     </section>
 
     <section algorithm="navigator-service-worker-ready">
@@ -910,8 +926,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         attribute EventHandler onactivate;
         attribute EventHandler onfetch;
 
-        // event
-        attribute EventHandler onmessage; // event.source of the message events is Client object
+        attribute EventHandler onmessage;
         attribute EventHandler onmessageerror;
       };
     </pre>
@@ -923,7 +938,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <section>
       <h4 id="service-worker-global-scope-clients">{{ServiceWorkerGlobalScope/clients}}</h4>
 
-      <dfn attribute for="ServiceWorkerGlobalScope"><code>clients</code></dfn> attribute *must* return the {{Clients}} object that is associated with the <a>context object</a>.
+      The <dfn attribute for="ServiceWorkerGlobalScope"><code>clients</code></dfn> attribute *must* return the {{Clients}} object that is associated with the <a>context object</a>.
     </section>
 
     <section>
@@ -1074,17 +1089,18 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       The <dfn method for="Client"><code>postMessage(|message|, |options|)</code></dfn> method *must* run these steps:
 
-        1. Let |sourceSettings| be the [=context object=]'s [=relevant settings object=].
+        1. Let |contextObject| be the [=context object=].
+        1. Let |sourceSettings| be the |contextObject|'s [=relevant settings object=].
         1. Let |serializeWithTransferResult| be <a abstract-op>StructuredSerializeWithTransfer</a>(|message|, |options|.transfer). Rethrow any exceptions.
         1. Run the following steps [=in parallel=]:
             1. Let |targetClient| be null.
             1. For each [=/service worker client=] |client|:
-                1. If |client| is the [=context object=]'s [=Client/service worker client=], set |targetClient| to |client|, and [=break=].
+                1. If |client| is the |contextObject|'s [=Client/service worker client=], set |targetClient| to |client|, and [=break=].
             1. If |targetClient| is null, return.
             1. Let |destination| be the {{ServiceWorkerContainer}} object whose associated [=ServiceWorkerContainer/service worker client=] is |targetClient|.
             1. Add a [=task=] that runs the following steps to |destination|'s [=ServiceWorkerContainer/client message queue=]:
                 1. Let |origin| be the [=Unicode serialization of an origin|Unicode serialization=] of |sourceSettings|'s [=environment settings object/origin=].
-                1. Let |source| be a {{ServiceWorker}} object, which represents the [=ServiceWorkerGlobalScope/service worker=] associated with |sourceSettings|'s [=environment settings object/global object=].
+                1. Let |source| be the result of [=getting the service worker object=] that represents |contextObject|'s [=relevant global object=]'s [=ServiceWorkerGlobalScope/service worker=] in |targetClient|.
                 1. Let |deserializeRecord| be <a abstract-op>StructuredDeserializeWithTransfer</a>(|serializeWithTransferResult|, |destination|'s [=relevant Realm=]).
 
                     If this throws an exception, catch it, [=fire an event=] named {{messageerror!!event}} at |destination|, using {{MessageEvent}}, with the {{MessageEvent/origin}} attribute initialized to |origin| and the {{MessageEvent/source}} attribute initialized to |source|, and then abort these steps.
@@ -2614,7 +2630,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Invoke [=Resolve Job Promise=] with |job| and |registration|.
       1. Let |settingsObjects| be all [=environment settings objects=] whose [=environment settings object/origin=] is |registration|'s [=service worker registration/scope url=]'s origin.
       1. For each |settingsObject| of |settingsObjects|, [=queue a task=] on |settingsObject|'s [=responsible event loop=] in the [=DOM manipulation task source=] to run the following steps:
-          1. Let |registrationObjects| be every {{ServiceWorkerRegistration}} object in |settingsObject|'s [=environment settings object/realm execution context=], whose [=ServiceWorkerRegistration/service worker registration=] is |registration|.
+          1. Let |registrationObjects| be every {{ServiceWorkerRegistration}} object in |settingsObject|'s [=environment settings object/realm=], whose [=ServiceWorkerRegistration/service worker registration=] is |registration|.
           1. For each |registrationObject| of |registrationObjects|, [=fire an event=] on |registrationObject| named `updatefound`.
       1. Let |installingWorker| be |registration|'s <a>installing worker</a>.
       1. If the result of running the [=Should Skip Event=] algorithm with |installingWorker| and "install" is false, then:
@@ -3088,26 +3104,26 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       : Input
       :: |registration|, a [=/service worker registration=]
-      :: |target|, a string (one of "<code>installing</code>", "<code>waiting</code>", and "<code>active</code>")
+      :: |target|, a string (one of "`installing`", "`waiting`", and "`active`")
       :: |source|, a [=/service worker=] or null
       : Output
       :: None
 
       1. Let |registrationObjects| be an array containing all the {{ServiceWorkerRegistration}} objects associated with |registration|.
-      1. If |target| is "<code>installing</code>", then:
-          1. Set |registration|'s <a>installing worker</a> to |source|.
+      1. If |target| is "`installing`", then:
+          1. Set |registration|'s [=installing worker=] to |source|.
           1. For each |registrationObject| in |registrationObjects|:
-              1. <a>Queue a task</a> to set the {{ServiceWorkerRegistration/installing}} attribute of |registrationObject| to the {{ServiceWorker}} object that represents |registration|’s <a>installing worker</a>, or null if |registration|’s <a>installing worker</a> is null.
-      1. Else if |target| is "<code>waiting</code>", then:
-          1. Set |registration|'s <a>waiting worker</a> to |source|.
+              1. [=Queue a task=] to set the {{ServiceWorkerRegistration/installing}} attribute of |registrationObject| to null if |registration|’s [=installing worker=] is null, or the result of [=getting the service worker object=] that represents |registration|’s [=installing worker=] in |registrationObject|'s [=relevant settings object=].
+      1. Else if |target| is "`waiting`", then:
+          1. Set |registration|'s [=waiting worker=] to |source|.
           1. For each |registrationObject| in |registrationObjects|:
-              1. <a>Queue a task</a> to set the {{ServiceWorkerRegistration/waiting}} attribute of |registrationObject| to the {{ServiceWorker}} object that represents |registration|’s <a>waiting worker</a>, or null if |registration|’s <a>waiting worker</a> is null.
-      1. Else if |target| is "<code>active</code>", then:
+              1. [=Queue a task=] to set the {{ServiceWorkerRegistration/waiting}} attribute of |registrationObject| to null if |registration|’s [=waiting worker=] is null, or the result of [=getting the service worker object=] that represents |registration|’s [=waiting worker=] in |registrationObject|'s [=relevant settings object=].
+      1. Else if |target| is "`active`", then:
           1. Set |registration|'s [=service worker registration/active worker=] to |source|.
           1. For each |registrationObject| in |registrationObjects|:
-              1. <a>Queue a task</a> to set the {{ServiceWorkerRegistration/active}} attribute of |registrationObject| to the {{ServiceWorker}} object that represents |registration|’s [=service worker registration/active worker=], or null if |registration|’s [=service worker registration/active worker=] is null.
+              1. [=Queue a task=] to set the {{ServiceWorkerRegistration/active}} attribute of |registrationObject| to null if |registration|’s [=active worker=] is null, or the result of [=getting the service worker object=] that represents |registration|’s [=active worker=] in |registrationObject|'s [=relevant settings object=].
 
-        The <a>task</a> *must* use |registrationObject|'s <a>relevant settings object</a>'s <a>responsible event loop</a> and the <a>DOM manipulation task source</a>.
+        The [=task=] *must* use |registrationObject|'s [=relevant settings object=]'s [=responsible event loop=] and the [=DOM manipulation task source=].
   </section>
 
   <section algorithm>

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -320,6 +320,20 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     A {{ServiceWorker}} object has an associated {{ServiceWorkerState}} object which is itself associated with [=/service worker=]'s <a>state</a>.
 
     <section>
+      <h4 id="service-worker-creation">Getting {{ServiceWorker}} instances</h4>
+
+      An [=environment settings object=] has a <dfn for="environment settings object">service worker object map</dfn>, a [=/map=] where the [=map/keys=] are [=/service workers=] and the [=map/values=] are {{ServiceWorker}} objects.
+
+      <section algorithm="service-worker-creation-algorithm">
+        To <dfn lt="get the service worker object|getting the service worker object">get the service worker object</dfn> representing |serviceWorker| (a [=/service worker=]) in |environment| (an [=environment settings object=]), run these steps:
+
+          1. Let |objectMap| be |environment|'s [=environment settings object/service worker object map=].
+          1. If |objectMap|[|serviceWorker|] does not [=map/exist=], then set |objectMap|[|serviceWorker|] to a new {{ServiceWorker}} in |environment|'s [=environment settings object/Realm=], and associate it with |serviceWorker|.
+          1. Return |objectMap|[|serviceWorker|].
+      </section>
+    </section>
+
+    <section>
       <h4 id="service-worker-url">{{ServiceWorker/scriptURL}}</h4>
 
       The <dfn attribute for="ServiceWorker"><code>scriptURL</code></dfn> attribute *must* return the [=/service worker=]'s <a lt="URL serializer">serialized</a> [=service worker/script url=].
@@ -351,13 +365,14 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         1. Let |serviceWorker| be the [=/service worker=] represented by the <a>context object</a>.
         1. If the result of running the [=Should Skip Event=] algorithm with "message" and |serviceWorker|, is true, then return.
         1. Invoke <a>Run Service Worker</a> algorithm with |serviceWorker| as the argument.
-        1. Let |incumbentSettings| be the <a>incumbent settings object</a>, and |incumbentGlobal| its [=environment settings object/global object=].
+        1. Let |incumbentSettings| be the [=incumbent settings object=].
+        1. Let |incumbentGlobal| be |incumbentSettings|'s [=environment settings object/global object=].
         1. Let |serializeWithTransferResult| be <a abstract-op>StructuredSerializeWithTransfer</a>(|message|, |transfer|). Rethrow any exceptions.
         1. [=Queue a task=] on the [=DOM manipulation task source=] to run the following steps:
             1. Let |source| be determined by switching on the type of |incumbentGlobal|:
                 <dl class="switch">
                     <dt>{{ServiceWorkerGlobalScope}}</dt>
-                    <dd>a new {{ServiceWorker}} object that represents |incumbentGlobal|'s [=ServiceWorkerGlobalScope/service worker=].</dd>
+                    <dd>The result of [=getting the service worker object=] that represents |incumbentGlobal|'s [=ServiceWorkerGlobalScope/service worker=] in the [=relevant settings object=] of |serviceWorker|'s [=service worker/global object=].</dd>
 
                     <dt>{{Window}}</dt>
                     <dd>a new {{WindowClient}} object that represents |incumbentGlobal|'s [=relevant settings object=].</dd>
@@ -433,7 +448,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       <dfn attribute for="ServiceWorkerRegistration"><code>installing</code></dfn> attribute *must* return the value to which it was last set.
 
-      Note: The {{ServiceWorker}} objects returned from this attribute getter that represent the same [=/service worker=] are the same objects.
+      Note: Within a [=environment settings object/Realm=], there is only one {{ServiceWorker}} object per associated [=/service worker=].
     </section>
 
     <section algorithm="navigator-service-worker-waiting">
@@ -441,7 +456,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       <dfn attribute for="ServiceWorkerRegistration"><code>waiting</code></dfn> attribute *must* return the value to which it was last set.
 
-      Note: The {{ServiceWorker}} objects returned from this attribute getter that represent the same [=/service worker=] are the same objects.
+      Note: Within a [=environment settings object/Realm=], there is only one {{ServiceWorker}} object per associated [=/service worker=].
     </section>
 
     <section algorithm="navigator-service-worker-active">
@@ -449,7 +464,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       <dfn attribute for="ServiceWorkerRegistration"><code>active</code></dfn> attribute *must* return the value to which it was last set.
 
-      Note: The {{ServiceWorker}} objects returned from this attribute getter that represent the same [=/service worker=] are the same objects.
+      Note: Within a [=environment settings object/Realm=], there is only one {{ServiceWorker}} object per associated [=/service worker=].
     </section>
 
     <section algorithm="service-worker-registration-scope">
@@ -582,9 +597,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       <dfn attribute for="ServiceWorkerContainer"><code>controller</code></dfn> attribute *must* run these steps:
 
         1. Let |client| be the <a>context object</a>'s [=ServiceWorkerContainer/service worker client=].
-        1. Return the {{ServiceWorker}} object that represents |client|'s <a>active service worker</a>.
+        1. If |client|'s [=active service worker=] is null, then return null.
+        1. Return the result of [=getting the service worker object=] that represents |client|'s [=active service worker=] in the [=context object=]'s [=relevant settings object=].
 
-      Note: {{ServiceWorkerContainer/controller|navigator.serviceWorker.controller}} returns <code>null</code> if the request is a force refresh (shift+refresh). The {{ServiceWorker}} objects returned from this attribute getter that represent the same [=/service worker=] are the same objects.
+      Note: {{ServiceWorkerContainer/controller|navigator.serviceWorker.controller}} returns <code>null</code> if the request is a force refresh (shift+refresh).
     </section>
 
     <section algorithm="navigator-service-worker-ready">
@@ -832,8 +848,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         attribute EventHandler onactivate;
         attribute EventHandler onfetch;
 
-        // event
-        attribute EventHandler onmessage; // event.source of the message events is Client object
+        attribute EventHandler onmessage;
         attribute EventHandler onmessageerror;
       };
     </pre>
@@ -845,7 +860,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <section>
       <h4 id="service-worker-global-scope-clients">{{ServiceWorkerGlobalScope/clients}}</h4>
 
-      <dfn attribute for="ServiceWorkerGlobalScope"><code>clients</code></dfn> attribute *must* return the {{Clients}} object that is associated with the <a>context object</a>.
+      The <dfn attribute for="ServiceWorkerGlobalScope"><code>clients</code></dfn> attribute *must* return the {{Clients}} object that is associated with the <a>context object</a>.
     </section>
 
     <section>
@@ -986,17 +1001,18 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       The <dfn method for="Client"><code>postMessage(|message|, |transfer|)</code></dfn> method *must* run these steps:
 
-        1. Let |sourceSettings| be the [=context object=]'s [=relevant settings object=].
+        1. Let |contextObject| be the [=context object=].
+        1. Let |sourceSettings| be the |contextObject|'s [=relevant settings object=].
         1. Let |serializeWithTransferResult| be <a abstract-op>StructuredSerializeWithTransfer</a>(|message|, |transfer|). Rethrow any exceptions.
         1. Run the following steps [=in parallel=]:
             1. Let |targetClient| be null.
             1. For each [=/service worker client=] |client|:
-                1. If |client| is the [=context object=]'s [=Client/service worker client=], set |targetClient| to |client|, and [=break=].
+                1. If |client| is the |contextObject|'s [=Client/service worker client=], set |targetClient| to |client|, and [=break=].
             1. If |targetClient| is null, return.
             1. Let |destination| be the {{ServiceWorkerContainer}} object whose associated [=ServiceWorkerContainer/service worker client=] is |targetClient|.
             1. Add a [=task=] that runs the following steps to |destination|'s [=ServiceWorkerContainer/client message queue=]:
                 1. Let |origin| be the [=Unicode serialization of an origin|Unicode serialization=] of |sourceSettings|'s [=environment settings object/origin=].
-                1. Let |source| be a {{ServiceWorker}} object, which represents the [=ServiceWorkerGlobalScope/service worker=] associated with |sourceSettings|'s [=environment settings object/global object=].
+                1. Let |source| be the result of [=getting the service worker object=] that represents |contextObject|'s [=relevant global object=]'s [=ServiceWorkerGlobalScope/service worker=] in |targetClient|.
                 1. Let |deserializeRecord| be <a abstract-op>StructuredDeserializeWithTransfer</a>(|serializeWithTransferResult|, |destination|'s [=relevant Realm=]).
 
                     If this throws an exception, catch it, [=fire an event=] named {{messageerror!!event}} at |destination|, using {{MessageEvent}}, with the {{MessageEvent/origin}} attribute initialized to |origin| and the {{MessageEvent/source}} attribute initialized to |source|, and then abort these steps.
@@ -2435,7 +2451,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Invoke [=Resolve Job Promise=] with |job| and |registration|.
       1. Let |settingsObjects| be all [=environment settings objects=] whose [=environment settings object/origin=] is |registration|'s [=service worker registration/scope url=]'s origin.
       1. For each |settingsObject| of |settingsObjects|, [=queue a task=] on |settingsObject|'s [=responsible event loop=] in the [=DOM manipulation task source=] to run the following steps:
-          1. Let |registrationObjects| be every {{ServiceWorkerRegistration}} object in |settingsObject|'s [=environment settings object/realm execution context=], whose [=ServiceWorkerRegistration/service worker registration=] is |registration|.
+          1. Let |registrationObjects| be every {{ServiceWorkerRegistration}} object in |settingsObject|'s [=environment settings object/realm=], whose [=ServiceWorkerRegistration/service worker registration=] is |registration|.
           1. For each |registrationObject| of |registrationObjects|, [=fire an event=] on |registrationObject| named `updatefound`.
       1. Let |installingWorker| be |registration|'s <a>installing worker</a>.
       1. If the result of running the [=Should Skip Event=] algorithm with |installingWorker| and "install" is false, then:
@@ -2880,26 +2896,26 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       : Input
       :: |registration|, a [=/service worker registration=]
-      :: |target|, a string (one of "<code>installing</code>", "<code>waiting</code>", and "<code>active</code>")
+      :: |target|, a string (one of "`installing`", "`waiting`", and "`active`")
       :: |source|, a [=/service worker=] or null
       : Output
       :: None
 
       1. Let |registrationObjects| be an array containing all the {{ServiceWorkerRegistration}} objects associated with |registration|.
-      1. If |target| is "<code>installing</code>", then:
-          1. Set |registration|'s <a>installing worker</a> to |source|.
+      1. If |target| is "`installing`", then:
+          1. Set |registration|'s [=installing worker=] to |source|.
           1. For each |registrationObject| in |registrationObjects|:
-              1. <a>Queue a task</a> to set the {{ServiceWorkerRegistration/installing}} attribute of |registrationObject| to the {{ServiceWorker}} object that represents |registration|’s <a>installing worker</a>, or null if |registration|’s <a>installing worker</a> is null.
-      1. Else if |target| is "<code>waiting</code>", then:
-          1. Set |registration|'s <a>waiting worker</a> to |source|.
+              1. [=Queue a task=] to set the {{ServiceWorkerRegistration/installing}} attribute of |registrationObject| to null if |registration|’s [=installing worker=] is null, or the result of [=getting the service worker object=] that represents |registration|’s [=installing worker=] in |registrationObject|'s [=relevant settings object=].
+      1. Else if |target| is "`waiting`", then:
+          1. Set |registration|'s [=waiting worker=] to |source|.
           1. For each |registrationObject| in |registrationObjects|:
-              1. <a>Queue a task</a> to set the {{ServiceWorkerRegistration/waiting}} attribute of |registrationObject| to the {{ServiceWorker}} object that represents |registration|’s <a>waiting worker</a>, or null if |registration|’s <a>waiting worker</a> is null.
-      1. Else if |target| is "<code>active</code>", then:
+              1. [=Queue a task=] to set the {{ServiceWorkerRegistration/waiting}} attribute of |registrationObject| to null if |registration|’s [=waiting worker=] is null, or the result of [=getting the service worker object=] that represents |registration|’s [=waiting worker=] in |registrationObject|'s [=relevant settings object=].
+      1. Else if |target| is "`active`", then:
           1. Set |registration|'s [=service worker registration/active worker=] to |source|.
           1. For each |registrationObject| in |registrationObjects|:
-              1. <a>Queue a task</a> to set the {{ServiceWorkerRegistration/active}} attribute of |registrationObject| to the {{ServiceWorker}} object that represents |registration|’s [=service worker registration/active worker=], or null if |registration|’s [=service worker registration/active worker=] is null.
+              1. [=Queue a task=] to set the {{ServiceWorkerRegistration/active}} attribute of |registrationObject| to null if |registration|’s [=active worker=] is null, or the result of [=getting the service worker object=] that represents |registration|’s [=active worker=] in |registrationObject|'s [=relevant settings object=].
 
-        The <a>task</a> *must* use |registrationObject|'s <a>relevant settings object</a>'s <a>responsible event loop</a> and the <a>DOM manipulation task source</a>.
+        The [=task=] *must* use |registrationObject|'s [=relevant settings object=]'s [=responsible event loop=] and the [=DOM manipulation task source=].
   </section>
 
   <section algorithm>


### PR DESCRIPTION
@mattto nothing new here apart from that "context object" thing you mentioned.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/pull/1428.html" title="Last updated on Jun 7, 2019, 2:49 PM UTC (e972737)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1428/94e6a67...e972737.html" title="Last updated on Jun 7, 2019, 2:49 PM UTC (e972737)">Diff</a>