### PR TITLE
Export the Clear Registration Algorithm

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3086,7 +3086,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   </section>
 
   <section algorithm>
-    <h3 id="clear-registration-algorithm"><dfn>Clear Registration</dfn></h3>
+    <h3 id="clear-registration-algorithm"><dfn export>Clear Registration</dfn></h3>
 
       : Input
       :: |registration|, a [=/service worker registration=]


### PR DESCRIPTION
So that the Clear Site Data spec can reference the algorithm and use
it to clear out the service worker, instead of unregister().

Context:
https://github.com/w3c/ServiceWorker/issues/614#issuecomment-497539062

Eventually will resolve:
https://github.com/w3c/webappsec-clear-site-data/issues/54


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/asakusuma/ServiceWorker/pull/1438.html" title="Last updated on Jun 21, 2019, 3:27 AM UTC (985f42b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1438/a47c6d8...asakusuma:985f42b.html" title="Last updated on Jun 21, 2019, 3:27 AM UTC (985f42b)">Diff</a>