### PR TITLE
Set default value of optional dictionary to {}

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -321,7 +321,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         readonly attribute USVString scriptURL;
         readonly attribute ServiceWorkerState state;
         void postMessage(any message, sequence&lt;object&gt; transfer);
-        void postMessage(any message, optional PostMessageOptions options);
+        void postMessage(any message, optional PostMessageOptions options = {});
 
         // event
         attribute EventHandler onstatechange;
@@ -624,7 +624,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         readonly attribute ServiceWorker? controller;
         readonly attribute Promise&lt;ServiceWorkerRegistration&gt; ready;
 
-        [NewObject] Promise&lt;ServiceWorkerRegistration&gt; register(USVString scriptURL, optional RegistrationOptions options);
+        [NewObject] Promise&lt;ServiceWorkerRegistration&gt; register(USVString scriptURL, optional RegistrationOptions options = {});
 
         [NewObject] Promise&lt;any&gt; getRegistration(optional USVString clientURL = "");
         [NewObject] Promise&lt;FrozenArray&lt;ServiceWorkerRegistration&gt;&gt; getRegistrations();
@@ -1049,7 +1049,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         readonly attribute DOMString id;
         readonly attribute ClientType type;
         void postMessage(any message, sequence&lt;object&gt; transfer);
-        void postMessage(any message, optional PostMessageOptions options);
+        void postMessage(any message, optional PostMessageOptions options = {});
       };
 
       [Exposed=ServiceWorker]
@@ -1222,7 +1222,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       interface Clients {
         // The objects returned will be new instances every time
         [NewObject] Promise&lt;any&gt; get(DOMString id);
-        [NewObject] Promise&lt;FrozenArray&lt;Client&gt;&gt; matchAll(optional ClientQueryOptions options);
+        [NewObject] Promise&lt;FrozenArray&lt;Client&gt;&gt; matchAll(optional ClientQueryOptions options = {});
         [NewObject] Promise&lt;WindowClient?&gt; openWindow(USVString url);
         [NewObject] Promise&lt;void&gt; claim();
       };
@@ -1370,7 +1370,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <h3 id="extendableevent-interface">{{ExtendableEvent}}</h3>
 
     <pre class="idl">
-      [Constructor(DOMString type, optional ExtendableEventInit eventInitDict), Exposed=ServiceWorker]
+      [Constructor(DOMString type, optional ExtendableEventInit eventInitDict = {}), Exposed=ServiceWorker]
       interface ExtendableEvent : Event {
         void waitUntil(Promise&lt;any&gt; f);
       };
@@ -1558,7 +1558,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <h3 id="extendablemessageevent-interface">{{ExtendableMessageEvent}}</h3>
 
     <pre class="idl">
-      [Constructor(DOMString type, optional ExtendableMessageEventInit eventInitDict), Exposed=ServiceWorker]
+      [Constructor(DOMString type, optional ExtendableMessageEventInit eventInitDict = {}), Exposed=ServiceWorker]
       interface ExtendableMessageEvent : ExtendableEvent {
         readonly attribute any data;
         readonly attribute USVString origin;
@@ -1743,13 +1743,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <pre class="idl">
       [SecureContext, Exposed=(Window,Worker)]
       interface Cache {
-        [NewObject] Promise&lt;any&gt; match(RequestInfo request, optional CacheQueryOptions options);
-        [NewObject] Promise&lt;FrozenArray&lt;Response&gt;&gt; matchAll(optional RequestInfo request, optional CacheQueryOptions options);
+        [NewObject] Promise&lt;any&gt; match(RequestInfo request, optional CacheQueryOptions options = {});
+        [NewObject] Promise&lt;FrozenArray&lt;Response&gt;&gt; matchAll(optional RequestInfo request, optional CacheQueryOptions options = {});
         [NewObject] Promise&lt;void&gt; add(RequestInfo request);
         [NewObject] Promise&lt;void&gt; addAll(sequence&lt;RequestInfo&gt; requests);
         [NewObject] Promise&lt;void&gt; put(RequestInfo request, Response response);
-        [NewObject] Promise&lt;boolean&gt; delete(RequestInfo request, optional CacheQueryOptions options);
-        [NewObject] Promise&lt;FrozenArray&lt;Request&gt;&gt; keys(optional RequestInfo request, optional CacheQueryOptions options);
+        [NewObject] Promise&lt;boolean&gt; delete(RequestInfo request, optional CacheQueryOptions options = {});
+        [NewObject] Promise&lt;FrozenArray&lt;Request&gt;&gt; keys(optional RequestInfo request, optional CacheQueryOptions options = {});
       };
     </pre>
     <pre class="idl" id="cache-query-options-dictionary">
@@ -2000,7 +2000,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <pre class="idl">
       [SecureContext, Exposed=(Window,Worker)]
       interface CacheStorage {
-        [NewObject] Promise&lt;any&gt; match(RequestInfo request, optional MultiCacheQueryOptions options);
+        [NewObject] Promise&lt;any&gt; match(RequestInfo request, optional MultiCacheQueryOptions options = {});
         [NewObject] Promise&lt;boolean&gt; has(DOMString cacheName);
         [NewObject] Promise&lt;Cache&gt; open(DOMString cacheName);
         [NewObject] Promise&lt;boolean&gt; delete(DOMString cacheName);

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -589,7 +589,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         readonly attribute ServiceWorker? controller;
         readonly attribute Promise&lt;ServiceWorkerRegistration&gt; ready;
 
-        [NewObject] Promise&lt;ServiceWorkerRegistration&gt; register(USVString scriptURL, optional RegistrationOptions options);
+        [NewObject] Promise&lt;ServiceWorkerRegistration&gt; register(USVString scriptURL, optional RegistrationOptions options = {});
 
         [NewObject] Promise&lt;any&gt; getRegistration(optional USVString clientURL = "");
         [NewObject] Promise&lt;FrozenArray&lt;ServiceWorkerRegistration&gt;&gt; getRegistrations();
@@ -1126,7 +1126,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       interface Clients {
         // The objects returned will be new instances every time
         [NewObject] Promise&lt;any&gt; get(DOMString id);
-        [NewObject] Promise&lt;FrozenArray&lt;Client&gt;&gt; matchAll(optional ClientQueryOptions options);
+        [NewObject] Promise&lt;FrozenArray&lt;Client&gt;&gt; matchAll(optional ClientQueryOptions options = {});
         [NewObject] Promise&lt;WindowClient?&gt; openWindow(USVString url);
         [NewObject] Promise&lt;void&gt; claim();
       };
@@ -1274,7 +1274,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <h3 id="extendableevent-interface">{{ExtendableEvent}}</h3>
 
     <pre class="idl">
-      [Constructor(DOMString type, optional ExtendableEventInit eventInitDict), Exposed=ServiceWorker]
+      [Constructor(DOMString type, optional ExtendableEventInit eventInitDict = {}), Exposed=ServiceWorker]
       interface ExtendableEvent : Event {
         void waitUntil(Promise&lt;any&gt; f);
       };
@@ -1438,7 +1438,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <h3 id="extendablemessageevent-interface">{{ExtendableMessageEvent}}</h3>
 
     <pre class="idl">
-      [Constructor(DOMString type, optional ExtendableMessageEventInit eventInitDict), Exposed=ServiceWorker]
+      [Constructor(DOMString type, optional ExtendableMessageEventInit eventInitDict = {}), Exposed=ServiceWorker]
       interface ExtendableMessageEvent : ExtendableEvent {
         readonly attribute any data;
         readonly attribute USVString origin;
@@ -1624,13 +1624,13 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <pre class="idl">
       [SecureContext, Exposed=(Window,Worker)]
       interface Cache {
-        [NewObject] Promise&lt;any&gt; match(RequestInfo request, optional CacheQueryOptions options);
-        [NewObject] Promise&lt;FrozenArray&lt;Response&gt;&gt; matchAll(optional RequestInfo request, optional CacheQueryOptions options);
+        [NewObject] Promise&lt;any&gt; match(RequestInfo request, optional CacheQueryOptions options = {});
+        [NewObject] Promise&lt;FrozenArray&lt;Response&gt;&gt; matchAll(optional RequestInfo request, optional CacheQueryOptions options = {});
         [NewObject] Promise&lt;void&gt; add(RequestInfo request);
         [NewObject] Promise&lt;void&gt; addAll(sequence&lt;RequestInfo&gt; requests);
         [NewObject] Promise&lt;void&gt; put(RequestInfo request, Response response);
-        [NewObject] Promise&lt;boolean&gt; delete(RequestInfo request, optional CacheQueryOptions options);
-        [NewObject] Promise&lt;FrozenArray&lt;Request&gt;&gt; keys(optional RequestInfo request, optional CacheQueryOptions options);
+        [NewObject] Promise&lt;boolean&gt; delete(RequestInfo request, optional CacheQueryOptions options = {});
+        [NewObject] Promise&lt;FrozenArray&lt;Request&gt;&gt; keys(optional RequestInfo request, optional CacheQueryOptions options = {});
       };
     </pre>
     <pre class="idl" id="cache-query-options-dictionary">
@@ -1878,7 +1878,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <pre class="idl">
       [SecureContext, Exposed=(Window,Worker)]
       interface CacheStorage {
-        [NewObject] Promise&lt;any&gt; match(RequestInfo request, optional MultiCacheQueryOptions options);
+        [NewObject] Promise&lt;any&gt; match(RequestInfo request, optional MultiCacheQueryOptions options = {});
         [NewObject] Promise&lt;boolean&gt; has(DOMString cacheName);
         [NewObject] Promise&lt;Cache&gt; open(DOMString cacheName);
         [NewObject] Promise&lt;boolean&gt; delete(DOMString cacheName);


### PR DESCRIPTION
This is part of heycam/webidl#758

heycam/webidl#750 introduces the change that use `{}` as default value for optional dictionaries.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/CYBAI/ServiceWorker/pull/1448.html" title="Last updated on Aug 9, 2019, 10:48 AM UTC (e4bf188)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1448/7c07a47...CYBAI:e4bf188.html" title="Last updated on Aug 9, 2019, 10:48 AM UTC (e4bf188)">Diff</a>