### PR TITLE
Define service worker events

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -193,7 +193,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <section>
       <h4 id="service-worker-events">Events</h4>
 
-      Service Workers specification defines <dfn export id="dfn-lifecycle-events">lifecycle events</dfn> (each of which is an [=event=]), {{install!!event}} and {{activate!!event}}. Service Workers and other specifications that <a href="#extensibility">extend</a> Service Workers define set of events called <dfn export id="dfn-functional-events">functional events</dfn> (each of which is an [=event=]) including {{fetch!!event}}. (See the <a href="#execution-context-events">list</a> of [=lifecycle events=] and [=functional events=].)
+      The Service Workers specification defines <dfn export id="dfn-service-worker-events">service worker events</dfn> (each of which is an [=event=]) that include (see the <a href="#execution-context-events">list</a>):
+          * <dfn export id="dfn-lifecycle-events">Lifecycle events</dfn>: {{install!!event}} and {{activate!!event}}.
+          * <dfn export id="dfn-functional-events">Functional events</dfn>: {{fetch!!event}} and the [=events=] defined by other specifications that <a href="#extensibility">extend</a> the Service Workers specification. (See the <a href="#execution-context-events">list</a>.)
+          * {{message!!event}} and {{messageerror!!event}}.
     </section>
   </section>
 
@@ -1613,7 +1616,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   <section>
     <h3 id="execution-context-events">Events</h3>
 
-    The following events are dispatched on {{ServiceWorkerGlobalScope}} object:
+    The following events, called [=service worker events=], are dispatched on {{ServiceWorkerGlobalScope}} object:
 
     <table class="data" dfn-for="ServiceWorkerGlobalScope">
       <thead>

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -182,7 +182,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <section>
       <h4 id="service-worker-events">Events</h4>
 
-      Service Workers specification defines <dfn export id="dfn-lifecycle-events">lifecycle events</dfn> (each of which is an [=event=]), {{install!!event}} and {{activate!!event}}. Service Workers and other specifications that <a href="#extensibility">extend</a> Service Workers define set of events called <dfn export id="dfn-functional-events">functional events</dfn> (each of which is an [=event=]) including {{fetch!!event}}. (See the <a href="#execution-context-events">list</a> of [=lifecycle events=] and [=functional events=].)
+      The Service Workers specification defines <dfn export id="dfn-service-worker-events">service worker events</dfn> (each of which is an [=event=]) that include (see the <a href="#execution-context-events">list</a>):
+          * <dfn export id="dfn-lifecycle-events">Lifecycle events</dfn>: {{install!!event}} and {{activate!!event}}.
+          * <dfn export id="dfn-functional-events">Functional events</dfn>: {{fetch!!event}} and the [=events=] defined by other specifications that <a href="#extensibility">extend</a> the Service Workers specification. (See the <a href="#execution-context-events">list</a>.)
+          * {{message!!event}} and {{messageerror!!event}}.
     </section>
   </section>
 
@@ -1493,7 +1496,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   <section>
     <h3 id="execution-context-events">Events</h3>
 
-    The following events are dispatched on {{ServiceWorkerGlobalScope}} object:
+    The following events, called [=service worker events=], are dispatched on {{ServiceWorkerGlobalScope}} object:
 
     <table class="data" dfn-for="ServiceWorkerGlobalScope">
       <thead>
@@ -2354,7 +2357,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               <p>Note: This step has two known issues.</p>
               <p>First, using the to-be-created [=environment settings object=] rather than a concrete [=environment settings object=]. This is used due to the unique processing model of service workers compared to the processing model of other [=web workers=]. The script fetching algorithms of HTML standard originally designed for other [=web workers=] require an [=environment settings object=] of the execution environment, but service workers fetch a script separately in the [=Update=] algorithm before the script later runs multiple times through the [=Run Service Worker=] algorithm.</p>
               <p>Second, the [=fetch a classic worker script=] algorithm and the [=fetch a module worker script graph=] algorithm in HTML take |job|’s [=job/client=] as an argument. |job|’s [=job/client=] is null when passed from the [=Soft Update=] algorithm.</p>
-              <p>These issues are tracked in the [issue #1013](https://github.com/w3c/ServiceWorker/issues/1013) of the ServiceWorkers GitHub repository. We will address these issues in [Service Workers Nightly](https://w3c.github.io/ServiceWorker/).</p>
+              <p>These issues are tracked in the [issue #1013](https://github.com/w3c/ServiceWorker/issues/1013) of the Service Workers GitHub repository. We will address these issues in [Service Workers Nightly](https://w3c.github.io/ServiceWorker/).</p>
           </div>
 
           To [=fetching scripts/perform the fetch=] given |request|, run the following steps:


### PR DESCRIPTION
This introduces the concept, service worker events, to refer to the events that
are one of lifecycle events, functional events, and the legacy message events
dispatched to ServiceWorkerGlobalScope.

Related PR: https://github.com/whatwg/dom/pull/653.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/pull/1452.html" title="Last updated on Jul 20, 2019, 12:25 AM UTC (85600fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1452/2e2d872...85600fc.html" title="Last updated on Jul 20, 2019, 12:25 AM UTC (85600fc)">Diff</a>