### PR TITLE
Clarify determination of active service worker and spec plan

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -257,15 +257,49 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   </section>
 
   <section>
-    <h3 id="selection">Selection and Use</h3>
+    <h3 id="control-and-use">Control and Use</h3>
 
-    A [=/service worker client=] independently <a lt="selection">selects</a> and <a>uses</a> a [=/service worker registration=] for its own loading and its subresources. The <dfn id="dfn-service-worker-registration-selection">selection</dfn> of a [=/service worker registration=], upon a <a>non-subresource request</a>, is a process of either <a lt="Match Service Worker Registration">matching</a> a [=/service worker registration=] from <a>scope to registration map</a> or inheriting an existing [=/service worker registration=] from its parent or owner context depending on the request's [=request/url=].
+    A [=/service worker client=] has an [=active service worker=] that serves its own loading and its subresources. When a [=/service worker client=] has a non-null [=active service worker=], it is said to be <dfn id="dfn-control" lt="controlling|controls|controlled">controlled</dfn> by the [=/service worker=]. When a [=/service worker client=] is [=controlled=] by a [=/service worker=], it is said that the [=/service worker client=] is <dfn id="dfn-use" lt="using|uses|used">using</dfn> the [=/service worker=]’s [=containing service worker registration=].
+    A [=/service worker client=]'s [=active service worker=] is determined as explained in the following subsections.
 
-    When the request's [=request/url=] is not <a lt="is local">local</a>, a [=/service worker client=] <a lt="Match Service Worker Registration">matches</a> a [=/service worker registration=] from <a>scope to registration map</a>. That is, the [=/service worker client=] attempts to consult a [=/service worker registration=] whose [=service worker registration/scope url=] <a lt="Match Service Worker Registration">matches</a> its <a>creation URL</a>.
+    *The rest of the section is non-normative.*
 
-    When the request's [=request/url=] <a>is local</a>, if the [=/service worker client=]'s <a>responsible browsing context</a> is a <a>nested browsing context</a> or the [=/service worker client=] is a <a>worker client</a>, the [=/service worker client=] inherits the [=/service worker registration=] from its <a>parent browsing context</a>'s environment or from the environment of a {{Document}} in the [=/service worker client=]'s [=environment settings object/global object=]'s [=owner set=], respectively, if it exists.
+    Issue: The behavior in this section is not fully specified yet and will be specified in [HTML Standard](https://html.spec.whatwg.org). The work is tracked by the [issue](https://github.com/w3c/ServiceWorker/issues/765) and the [pull request](https://github.com/whatwg/html/pull/2809).
 
-    If the <a>selection</a> was successful, the <a lt="selection">selected</a> [=/service worker registration=]'s <a>active worker</a> starts to <dfn id="dfn-control">control</dfn> the [=/service worker client=]. Otherwise, the flow returns to [=/fetch=] where it falls back to the default behavior. When a [=/service worker client=] is <a>controlled</a> by an <a>active worker</a>, it is considered that the [=/service worker client=] is <dfn id="dfn-use" lt="using|uses|used">using</dfn> the <a>active worker</a>'s <a>containing service worker registration</a>.
+    <section>
+      <h4 id="control-and-use-window-client">The window client case</h4>
+
+      A [=window client=] is [created](https://html.spec.whatwg.org/#set-up-a-window-environment-settings-object) when a [=/browsing context=] is [created](https://html.spec.whatwg.org/#creating-a-new-browsing-context) and when it [=navigates=].
+
+      When a [=window client=] is [created](https://html.spec.whatwg.org/#set-up-a-window-environment-settings-object) in the process of a [=/browsing context=] [creation](https://html.spec.whatwg.org/#creating-a-new-browsing-context):
+
+      If the [=/browsing context=]'s initial [=active document=]'s [=/origin=] is an [=opaque origin=], the [=window client=]'s [=active service worker=] is set to null.
+      Otherwise, it is set to the creator [=document=]'s [=/service worker client=]'s [=active service worker=].
+
+      When a [=window client=] is [created](https://html.spec.whatwg.org/#set-up-a-window-environment-settings-object) in the process of the [=/browsing context=]'s [=navigate|navigation=]:
+
+      If the [=fetch=] is routed through [=/HTTP fetch=], the [=window client=]'s [=active service worker=] is set to the result of the <a lt="Match Service Worker Registration">service worker registration matching</a>.
+      Otherwise, if the created [=document=]'s [=/origin=] is an [=opaque origin=] or not the [=same origin|same=] as its creator [=document=]'s [=/origin=], the [=window client=]'s [=active service worker=] is set to null.
+      Otherwise, it is set to the creator [=document=]'s [=/service worker client=]'s [=active service worker=].
+
+      Note: For an initial [=navigate|navigation=] with [=replacement enabled=], the initial [=window client=] that was [created](https://html.spec.whatwg.org/#set-up-a-window-environment-settings-object) when the [=/browsing context=] was [created](https://html.spec.whatwg.org/#creating-a-new-browsing-context) is reused, but the [=active service worker=] is determined by the same behavior as above.
+
+      Note: [Sandboxed](https://html.spec.whatwg.org/#attr-iframe-sandbox) [=iframes=] without the sandboxing directives, `allow-same-origin` and `allow-scripts`, result in having the [=active service worker=] value of null as their [=/origin=] is an [=opaque origin=]..
+    </section>
+
+    <section>
+      <h4 id="control-and-use-worker-client">The worker client case</h4>
+
+      A [=worker client=] is <a href="https://html.spec.whatwg.org/#set-up-a-worker-environment-settings-object">created</a> when the user agent [=run a worker|runs a worker=].
+
+      When the [=worker client=] is created:
+
+      When the [=fetch=] is routed through [=/HTTP fetch=], the [=worker client=]'s [=active service worker=] is set to the result of the <a lt="Match Service Worker Registration">service worker registration matching</a>.
+      Otherwise, if the [=worker client=]'s [=service worker client/origin=] is an [=opaque origin=], or the [=/request=]'s [=request/URL=] is a [=blob URL=] and the [=worker client=]'s [=service worker client/origin=] is not the [=same origin|same=] as the [=/origin=] of the last item in the [=worker client=]'s [=/global object=]'s [=owner set=], the [=worker client=]'s [=active service worker=] is set to null.
+      Otherwise, it is set to the [=active service worker=] of the [=environment settings object=] of the last [=item=] in the [=worker client=]'s [=/global object=]'s [=owner set=].
+    </section>
+
+    Note: [=Window clients=] and [=worker clients=] with a [data: URL](https://tools.ietf.org/html/rfc2397#section-2) result in having the [=active service worker=] value of null as their [=/origin=] is an [=opaque origin=]. [=Window clients=] and [=worker clients=] with a [=blob URL=] can inherit the [=active service worker=] of their creator [=document=] or owner, but if the [=/request=]'s [=request/origin=] is not the [=same origin|same=] as the [=/origin=] of their creator [=document=] or owner, the [=active service worker=] is set to null.
   </section>
 
   <section>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -259,7 +259,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   <section>
     <h3 id="control-and-use">Control and Use</h3>
 
-    A [=/service worker client=] has an [=active service worker=] that serves its own loading and its subresources. When a [=/service worker client=] has a non-null [=active service worker=], it is said to be <dfn id="dfn-control" lt="controlling|controls|controlled">controlled</dfn> by the [=/service worker=]. When a [=/service worker client=] is [=controlled=] by a [=/service worker=], it is said that the [=/service worker client=] is <dfn id="dfn-use" lt="using|uses|used">using</dfn> the [=/service worker=]’s [=containing service worker registration=].
+    A [=/service worker client=] has an [=active service worker=] that serves its own loading and its subresources. When a [=/service worker client=] has a non-null [=active service worker=], it is said to be <dfn id="dfn-control" lt="controlling|controls|controlled">controlled</dfn> by that [=active service worker=]. When a [=/service worker client=] is [=controlled=] by a [=/service worker=], it is said that the [=/service worker client=] is <dfn id="dfn-use" lt="using|uses|used">using</dfn> the [=/service worker=]’s [=containing service worker registration=].
     A [=/service worker client=]'s [=active service worker=] is determined as explained in the following subsections.
 
     *The rest of the section is non-normative.*

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -242,7 +242,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   <section>
     <h3 id="control-and-use">Control and Use</h3>
 
-    A [=/service worker client=] has an [=active service worker=] that serves its own loading and its subresources. When a [=/service worker client=] has a non-null [=active service worker=], it is said to be <dfn id="dfn-control" lt="controlling|controls|controlled">controlled</dfn> by the [=/service worker=]. When a [=/service worker client=] is [=controlled=] by a [=/service worker=], it is said that the [=/service worker client=] is <dfn id="dfn-use" lt="using|uses|used">using</dfn> the [=/service worker=]’s [=containing service worker registration=].
+    A [=/service worker client=] has an [=active service worker=] that serves its own loading and its subresources. When a [=/service worker client=] has a non-null [=active service worker=], it is said to be <dfn id="dfn-control" lt="controlling|controls|controlled">controlled</dfn> by that [=active service worker=]. When a [=/service worker client=] is [=controlled=] by a [=/service worker=], it is said that the [=/service worker client=] is <dfn id="dfn-use" lt="using|uses|used">using</dfn> the [=/service worker=]’s [=containing service worker registration=].
     A [=/service worker client=]'s [=active service worker=] is determined as explained in the following subsections.
 
     *The rest of the section is non-normative.*

--- a/docs/v1/index.bs
+++ b/docs/v1/index.bs
@@ -240,15 +240,49 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   </section>
 
   <section>
-    <h3 id="selection">Selection and Use</h3>
+    <h3 id="control-and-use">Control and Use</h3>
 
-    A [=/service worker client=] independently <a lt="selection">selects</a> and <a>uses</a> a [=/service worker registration=] for its own loading and its subresources. The <dfn id="dfn-service-worker-registration-selection">selection</dfn> of a [=/service worker registration=], upon a <a>non-subresource request</a>, is a process of either <a lt="Match Service Worker Registration">matching</a> a [=/service worker registration=] from <a>scope to registration map</a> or inheriting an existing [=/service worker registration=] from its parent or owner context depending on the request's [=request/url=].
+    A [=/service worker client=] has an [=active service worker=] that serves its own loading and its subresources. When a [=/service worker client=] has a non-null [=active service worker=], it is said to be <dfn id="dfn-control" lt="controlling|controls|controlled">controlled</dfn> by the [=/service worker=]. When a [=/service worker client=] is [=controlled=] by a [=/service worker=], it is said that the [=/service worker client=] is <dfn id="dfn-use" lt="using|uses|used">using</dfn> the [=/service worker=]’s [=containing service worker registration=].
+    A [=/service worker client=]'s [=active service worker=] is determined as explained in the following subsections.
 
-    When the request's [=request/url=] is not <a lt="is local">local</a>, a [=/service worker client=] <a lt="Match Service Worker Registration">matches</a> a [=/service worker registration=] from <a>scope to registration map</a>. That is, the [=/service worker client=] attempts to consult a [=/service worker registration=] whose [=service worker registration/scope url=] <a lt="Match Service Worker Registration">matches</a> its <a>creation URL</a>.
+    *The rest of the section is non-normative.*
 
-    When the request's [=request/url=] <a>is local</a>, if the [=/service worker client=]'s <a>responsible browsing context</a> is a <a>nested browsing context</a> or the [=/service worker client=] is a <a>worker client</a>, the [=/service worker client=] inherits the [=/service worker registration=] from its <a>parent browsing context</a>'s environment or from the environment of a {{Document}} in the [=/service worker client=]'s [=environment settings object/global object=]'s [=owner set=], respectively, if it exists.
+    Note: The behavior in this section is not fully specified yet and will be specified in [HTML Standard](https://html.spec.whatwg.org). The work is tracked by the [issue](https://github.com/w3c/ServiceWorker/issues/765) and the [pull request](https://github.com/whatwg/html/pull/2809). For any Service Workers changes, we will incorporate them into [Service Workers Nightly](https://w3c.github.io/ServiceWorker/).
 
-    If the <a>selection</a> was successful, the <a lt="selection">selected</a> [=/service worker registration=]'s <a>active worker</a> starts to <dfn id="dfn-control">control</dfn> the [=/service worker client=]. Otherwise, the flow returns to [=/fetch=] where it falls back to the default behavior. When a [=/service worker client=] is <a>controlled</a> by an <a>active worker</a>, it is considered that the [=/service worker client=] is <dfn id="dfn-use" lt="using|uses|used">using</dfn> the <a>active worker</a>'s <a>containing service worker registration</a>.
+    <section>
+      <h4 id="control-and-use-window-client">The window client case</h4>
+
+      A [=window client=] is [created](https://html.spec.whatwg.org/#set-up-a-window-environment-settings-object) when a [=/browsing context=] is [created](https://html.spec.whatwg.org/#creating-a-new-browsing-context) and when it [=navigates=].
+
+      When a [=window client=] is [created](https://html.spec.whatwg.org/#set-up-a-window-environment-settings-object) in the process of a [=/browsing context=] [creation](https://html.spec.whatwg.org/#creating-a-new-browsing-context):
+
+      If the [=/browsing context=]'s initial [=active document=]'s [=/origin=] is an [=opaque origin=], the [=window client=]'s [=active service worker=] is set to null.
+      Otherwise, it is set to the creator [=document=]'s [=/service worker client=]'s [=active service worker=].
+
+      When a [=window client=] is [created](https://html.spec.whatwg.org/#set-up-a-window-environment-settings-object) in the process of the [=/browsing context=]'s [=navigate|navigation=]:
+
+      If the [=fetch=] is routed through [=/HTTP fetch=], the [=window client=]'s [=active service worker=] is set to the result of the <a lt="Match Service Worker Registration">service worker registration matching</a>.
+      Otherwise, if the created [=document=]'s [=/origin=] is an [=opaque origin=] or not the [=same origin|same=] as its creator [=document=]'s [=/origin=], the [=window client=]'s [=active service worker=] is set to null.
+      Otherwise, it is set to the creator [=document=]'s [=/service worker client=]'s [=active service worker=].
+
+      Note: For an initial [=navigate|navigation=] with [=replacement enabled=], the initial [=window client=] that was [created](https://html.spec.whatwg.org/#set-up-a-window-environment-settings-object) when the [=/browsing context=] was [created](https://html.spec.whatwg.org/#creating-a-new-browsing-context) is reused, but the [=active service worker=] is determined by the same behavior as above.
+
+      Note: [Sandboxed](https://html.spec.whatwg.org/#attr-iframe-sandbox) [=iframes=] without the sandboxing directives, `allow-same-origin` and `allow-scripts`, result in having the [=active service worker=] value of null as their [=/origin=] is an [=opaque origin=]..
+    </section>
+
+    <section>
+      <h4 id="control-and-use-worker-client">The worker client case</h4>
+
+      A [=worker client=] is <a href="https://html.spec.whatwg.org/#set-up-a-worker-environment-settings-object">created</a> when the user agent [=run a worker|runs a worker=].
+
+      When the [=worker client=] is created:
+
+      When the [=fetch=] is routed through [=/HTTP fetch=], the [=worker client=]'s [=active service worker=] is set to the result of the <a lt="Match Service Worker Registration">service worker registration matching</a>.
+      Otherwise, if the [=worker client=]'s [=service worker client/origin=] is an [=opaque origin=], or the [=/request=]'s [=request/URL=] is a [=blob URL=] and the [=worker client=]'s [=service worker client/origin=] is not the [=same origin|same=] as the [=/origin=] of the last item in the [=worker client=]'s [=/global object=]'s [=owner set=], the [=worker client=]'s [=active service worker=] is set to null.
+      Otherwise, it is set to the [=active service worker=] of the [=environment settings object=] of the last [=item=] in the [=worker client=]'s [=/global object=]'s [=owner set=].
+    </section>
+
+    Note: [=Window clients=] and [=worker clients=] with a [data: URL](https://tools.ietf.org/html/rfc2397#section-2) result in having the [=active service worker=] value of null as their [=/origin=] is an [=opaque origin=]. [=Window clients=] and [=worker clients=] with a [=blob URL=] can inherit the [=active service worker=] of their creator [=document=] or owner, but if the [=/request=]'s [=request/origin=] is not the [=same origin|same=] as the [=/origin=] of their creator [=document=] or owner, the [=active service worker=] is set to null.
   </section>
 
   <section>


### PR DESCRIPTION
This change makes it clear that this behavior needs to be (and will be)
specified normatively in HTML Standard, and any future changes for Service
Workers will be incorporated into Service Workers Nightly. It also clarifies,
non-normatively, the behavior of how a service worker client's active service
worker is determined.

Issue: https://github.com/w3c/ServiceWorker/issues/765.
This moves the issue to the next milestone.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/pull/1455.html" title="Last updated on Aug 9, 2019, 4:33 PM UTC (983d3ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1455/2e2d872...983d3ea.html" title="Last updated on Aug 9, 2019, 4:33 PM UTC (983d3ea)">Diff</a>