### PR TITLE
Use ExtendableMessageEvent for messageerror in service workers.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -456,10 +456,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
                 1. Let |destination| be the {{ServiceWorkerGlobalScope}} object associated with |serviceWorker|.
                 1.  Let |deserializeRecord| be <a abstract-op>StructuredDeserializeWithTransfer</a>(|serializeWithTransferResult|, |destination|'s [=global object/Realm=]).
 
-                    If this throws an exception, catch it, [=fire an event=] named {{messageerror!!event}} at |destination|, using {{MessageEvent}}, with the {{MessageEvent/origin}} attribute initialized to |origin| and the {{MessageEvent/source}} attribute initialized to |source|, and then abort these steps.
-                1. Let |messageClone| be |deserializeRecord|.\[[Deserialized]].
-                1. Let |newPorts| be a new [=frozen array type|frozen array=] consisting of all {{MessagePort}} objects in |deserializeRecord|.\[[TransferredValues]], if any, maintaining their relative order.
-                1. Let |e| be the result of [=creating an event=] named {{message!!event}}, using {{ExtendableMessageEvent}}, with the {{ExtendableMessageEvent/origin}} attribute initialized to |origin|, the {{ExtendableMessageEvent/source}} attribute initialized to |source|, the {{ExtendableMessageEvent/data}} attribute initialized to |messageClone|, and the {{ExtendableMessageEvent/ports}} attribute initialized to |newPorts|.
+                    If this throws an exception, let |e| be the result of [=creating an event=] named {{messageerror!!event}}, using {{ExtendableMessageEvent}}, with the {{ExtendableMessageEvent/origin}} attribute initialized to |origin| and the {{ExtendableMessageEvent/source}} attribute initialized to |source|.
+                1. Else:
+                    1. Let |messageClone| be |deserializeRecord|.\[[Deserialized]].
+                    1. Let |newPorts| be a new [=frozen array type|frozen array=] consisting of all {{MessagePort}} objects in |deserializeRecord|.\[[TransferredValues]], if any, maintaining their relative order.
+                    1. Let |e| be the result of [=creating an event=] named {{message!!event}}, using {{ExtendableMessageEvent}}, with the {{ExtendableMessageEvent/origin}} attribute initialized to |origin|, the {{ExtendableMessageEvent/source}} attribute initialized to |source|, the {{ExtendableMessageEvent/data}} attribute initialized to |messageClone|, and the {{ExtendableMessageEvent/ports}} attribute initialized to |newPorts|.
                 1. [=Dispatch=] |e| at |destination|.
                 1. Invoke [=Update Service Worker Extended Events Set=] with |serviceWorker| and |e|.
     </section>


### PR DESCRIPTION
It seems inconsistent to use ExtendableMessageEvent for message events but not for messageerror events. This fixes that inconsistency.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/pull/1485.html" title="Last updated on Nov 21, 2019, 11:16 PM UTC (5b2b076)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1485/ffdd6c0...5b2b076.html" title="Last updated on Nov 21, 2019, 11:16 PM UTC (5b2b076)">Diff</a>