### PR TITLE
Drop 'potential-navigation-or-subresource request'.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2244,7 +2244,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     The implementers are encouraged to note:
 
-      * Plug-ins should not load via [=/service workers=]. As plug-ins may get their security origins from their own urls, the embedding [=/service worker=] cannot handle it. For this reason, the <a>Handle Fetch</a> algorithm makes the <a>potential-navigation-or-subresource request</a> (whose context is either <code>&lt;embed&gt;</code> or <code>&lt;object&gt;</code>) immediately fallback to the network without dispatching {{fetch!!event}} event.
+      * Plug-ins should not load via [=/service workers=]. As plug-ins may get their security origins from their own urls, the embedding [=/service worker=] cannot handle it. For this reason, the <a>Handle Fetch</a> algorithm makes <code>&lt;embed&gt;</code> and <code>&lt;object&gt;</code> requests immediately fallback to the network without dispatching {{fetch!!event}} event.
       * Some of the legacy networking stack code may need to be carefully audited to understand the ramifications of interactions with [=/service workers=].
   </section>
 
@@ -2931,7 +2931,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Let |preloadResponse| be a new [=promise=].
       1. Let |fetchInstance| be the instance of the [=/fetch=] algorithm representing the ongoing fetch.
       1. Assert: |request|'s [=request/destination=] is not "<code>serviceworker</code>".
-      1. If |request| is a <a>potential-navigation-or-subresource request</a>, then:
+      1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
       1. Else if |request| is a <a>non-subresource request</a>, then:
 


### PR DESCRIPTION
https://github.com/whatwg/fetch/pull/948/files is changing `<embed>` and `<object>` requests to
look more like navigations than subresource requests. As a result, it seems reasonable for service
worker to explicitly carve out those request destinations which have behavior service worker cares
about, rather than relying on a fetch-level concept that doesn't make sense in the new model.

I believe this is an editorial change without any behavior modification.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mikewest/ServiceWorker/pull/1486.html" title="Last updated on Nov 25, 2019, 8:52 AM UTC (33abec1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1486/ffdd6c0...mikewest:33abec1.html" title="Last updated on Nov 25, 2019, 8:52 AM UTC (33abec1)">Diff</a>