### PR TITLE
Update agent and realm allocation

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2854,7 +2854,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Assert: |script| is not null.
       1. Let |startFailed| be false.
       1. Let |agent| be the result of [=obtain a service worker agent|obtaining a service worker agent=], and run the following steps in that context:
-          1. Let |realmExecutionContext| be the result of [=create a new JavaScript realm|creating a new JavaScript realm=] given <var>agent</var> and the following customizations:
+          1. Let |realmExecutionContext| be the result of [=create a new JavaScript realm|creating a new JavaScript realm=] given |agent| and the following customizations:
               * For the global object, create a new {{ServiceWorkerGlobalScope}} object. Let |workerGlobalScope| be the created object.
           1. Set |serviceWorker|'s [=service worker/global object=] to |workerGlobalScope|.
           1. Let |workerEventLoop| be <var>agent</var>'s <a>event loop</a>.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2857,28 +2857,24 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Let |realmExecutionContext| be the result of [=create a new JavaScript realm|creating a new JavaScript realm=] given |agent| and the following customizations:
               * For the global object, create a new {{ServiceWorkerGlobalScope}} object. Let |workerGlobalScope| be the created object.
           1. Set |serviceWorker|'s [=service worker/global object=] to |workerGlobalScope|.
-          1. Let |workerEventLoop| be |agent|'s [=agent/event loop=].
           1. Let |settingsObject| be a new <a>environment settings object</a> whose algorithms are defined as follows:
 
               : The [=environment settings object/realm execution context=]
               :: Return |realmExecutionContext|.
-              : The [=environment settings object/global object=]
-              :: Return |workerGlobalScope|.
-              : The <a>responsible event loop</a>
-              :: Return |workerEventLoop|.
-              : The [=environment settings object/referrer policy=]
-              :: Return |workerGlobalScope|'s [=WorkerGlobalScope/referrer policy=].
+              : The [=environment settings object/module map=]
+              :: Return |workerGlobalScope|'s [=WorkerGlobalScope/module map=].
               : The <a>API URL character encoding</a>
-              :: Return UTF-8.
+              :: Return [=UTF-8=].
               : The <a>API base URL</a>
               :: Return |serviceWorker|'s [=service worker/script url=].
               : The [=environment settings object/origin=]
               :: Return its registering [=/service worker client=]'s [=environment settings object/origin=].
-              : The <a>creation URL</a>
-              :: Return |workerGlobalScope|'s [=WorkerGlobalScope/url=].
               : The [=environment settings object/HTTPS state=]
               :: Return |workerGlobalScope|'s [=WorkerGlobalScope/HTTPS state=].
+              : The [=environment settings object/referrer policy=]
+              :: Return |workerGlobalScope|'s [=WorkerGlobalScope/referrer policy=].
 
+          1. Set |settingsObject|'s [=environment/id=] to a new unique opaque string, its [=creation URL=] to |serviceWorker|'s [=service worker/script url=], its [=environment/target browsing context=] to null, and its [=active service worker=] to null.
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/url=] to |serviceWorker|'s [=service worker/script url=].
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/HTTPS state=] to |serviceWorker|'s <a>script resource</a>'s <a>HTTPS state</a>.
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/referrer policy=] to |serviceWorker|'s <a>script resource</a>'s [=script resource/referrer policy=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2853,12 +2853,11 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Let |script| be |serviceWorker|'s [=service worker/script resource=].
       1. Assert: |script| is not null.
       1. Let |startFailed| be false.
-      1. Create a separate parallel execution environment (i.e. a separate thread or process or equivalent construct), and run the following steps in that context:
-          1. Call the JavaScript [=InitializeHostDefinedRealm|InitializeHostDefinedRealm()=] abstract operation with the following customizations:
+      1. Let |agent| be the result of [=obtain a service worker agent|obtaining a service worker agent=], and run the following steps in that context:
+          1. Let |realmExecutionContext| be the result of [=create a new JavaScript realm|creating a new JavaScript realm=] given <var>agent</var> and the following customizations:
               * For the global object, create a new {{ServiceWorkerGlobalScope}} object. Let |workerGlobalScope| be the created object.
-              * Let |realmExecutionContext| be the created [=execution context|JavaScript execution context=].
           1. Set |serviceWorker|'s [=service worker/global object=] to |workerGlobalScope|.
-          1. Let |workerEventLoop| be a newly created <a>event loop</a>.
+          1. Let |workerEventLoop| be <var>agent</var>'s <a>event loop</a>.
           1. Let |settingsObject| be a new <a>environment settings object</a> whose algorithms are defined as follows:
 
               : The [=environment settings object/realm execution context=]

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2857,7 +2857,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Let |realmExecutionContext| be the result of [=create a new JavaScript realm|creating a new JavaScript realm=] given |agent| and the following customizations:
               * For the global object, create a new {{ServiceWorkerGlobalScope}} object. Let |workerGlobalScope| be the created object.
           1. Set |serviceWorker|'s [=service worker/global object=] to |workerGlobalScope|.
-          1. Let |workerEventLoop| be <var>agent</var>'s <a>event loop</a>.
+          1. Let |workerEventLoop| be |agent|'s [=event loop=].
           1. Let |settingsObject| be a new <a>environment settings object</a> whose algorithms are defined as follows:
 
               : The [=environment settings object/realm execution context=]

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2857,7 +2857,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Let |realmExecutionContext| be the result of [=create a new JavaScript realm|creating a new JavaScript realm=] given |agent| and the following customizations:
               * For the global object, create a new {{ServiceWorkerGlobalScope}} object. Let |workerGlobalScope| be the created object.
           1. Set |serviceWorker|'s [=service worker/global object=] to |workerGlobalScope|.
-          1. Let |workerEventLoop| be |agent|'s [=event loop=].
+          1. Let |workerEventLoop| be |agent|'s [=agent/event loop=].
           1. Let |settingsObject| be a new <a>environment settings object</a> whose algorithms are defined as follows:
 
               : The [=environment settings object/realm execution context=]


### PR DESCRIPTION
Follows https://github.com/whatwg/html/pull/5411.

This moves to the imperative style of agent allocation, as HTML is no longer declaratively defining service worker agents and their relations to others.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/domenic/ServiceWorker/pull/1508.html" title="Last updated on Apr 6, 2020, 9:45 PM UTC (ebbc2b1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1508/5c6d27b...domenic:ebbc2b1.html" title="Last updated on Apr 6, 2020, 9:45 PM UTC (ebbc2b1)">Diff</a>