### PR TITLE
Introduce Cross-Origin Embedder Policy

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -164,6 +164,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A <a>script resource</a> has an associated <dfn export for="script resource" id="dfn-referrer-policy">referrer policy</dfn> (a [=/referrer policy=]). It is initially the empty string.
 
+    A [=/service worker=] has an associated <dfn>embedder policy</dfn> (an [=/embedder policy=]). It is initially set to a new [=/embedder policy=].
+
     A [=/service worker=] has an associated <dfn export id="dfn-script-resource-map">script resource map</dfn> which is an <a>ordered map</a> where the keys are [=/URLs=] and the values are [=/responses=].
 
     A [=/service worker=] has an associated  <dfn export id="dfn-set-of-used-scripts">set of used scripts</dfn> (a [=ordered set|set=]) whose [=list/item=] is a [=/URL=]. It is initially a new [=ordered set|set=].
@@ -1861,7 +1863,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
                     1. Add a copy of |requestResponse|'s response to |responses|.
             1. Else:
                 1. Let |requestResponses| be the result of running [=Query Cache=] with |r| and |options|.
+                1. Let |request for CORP check| be a copy of |r|.
+                1. Set |request for CORP check|'s [=request/mode=] to "<code>no-cors</code>".
+                1. Set |request for CORP check|'s [=request/origin=] to |promise|'s [=relevant settings object=]'s [=environment settings object/origin=].
+                1. Set |request for CORP check|'s [=request/client=] to |promise|'s [=relevant settings object=].
                 1. [=list/For each=] |requestResponse| of |requestResponses|:
+                    1. If |requestResponse|'s [=response/type=] is "<code>opaque</code>" and [=cross-origin resource policy check=] with |request for CORP check| and |requestResponse| returns <b>blocked</b>, then reject |promise| with a `TypeError` and abort these steps.
                     1. Add a copy of |requestResponse|'s response to |responses|.
             1. [=Queue a task=], on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to perform the following steps:
                 1. Let |responseList| be a [=list=].
@@ -2570,6 +2577,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |httpsState| be "<code>none</code>".
       1. Let |referrerPolicy| be the empty string.
+      1. Let |embedder policy| be a new [=/embedder policy=].
       1. Let |hasUpdatedResources| be false.
       1. Let |updatedResourceMap| be an [=ordered map=] where the [=map/keys=] are [=/URLs=] and the [=map/values=] are [=/responses=].
       1. Switching on |job|'s [=worker type=], run these substeps with the following options:
@@ -2609,6 +2617,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
           1. Set |httpsState| to |response|'s [=response/HTTPS state=].
           1. Set |referrerPolicy| to the result of <a>parse a referrer policy from a <code>Referrer-Policy</code> header</a> of |response|.
+          1. Set |embedder policy| be the result of [=obtain an embedder policy|obtaining an embedder policy=] from |response|.
           1. If |serviceWorkerAllowed| is failure, then:
               1. Asynchronously complete these steps with a <a>network error</a>.
           1. Let |scopeURL| be |registration|'s [=service worker registration/scope url=].
@@ -2677,6 +2686,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Append |url| to |worker|'s [=set of used scripts=].
       1. Set |worker|'s <a>script resource</a>'s <a>HTTPS state</a> to |httpsState|.
       1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
+      1. Set |worker|'s [=service worker/embedder policy=] to |embedder policy|.
       1. Let |forceBypassCache| be true if |job|'s [=job/force bypass cache flag=] is set, and false otherwise.
       1. Let |runResult| be the result of running the [=Run Service Worker=] algorithm with |worker| and |forceBypassCache|.
       1. If |runResult| is *failure* or an [=abrupt completion=], then:
@@ -2873,11 +2883,14 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               :: Return |workerGlobalScope|'s [=WorkerGlobalScope/HTTPS state=].
               : The [=environment settings object/referrer policy=]
               :: Return |workerGlobalScope|'s [=WorkerGlobalScope/referrer policy=].
+              : The [=environment settings object/embedder policy=]
+              :: Return |workerGlobalScope|'s [=WorkerGlobalScope/embedder policy=].
 
           1. Set |settingsObject|'s [=environment/id=] to a new unique opaque string, its [=creation URL=] to |serviceWorker|'s [=service worker/script url=], its [=environment/target browsing context=] to null, and its [=active service worker=] to null.
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/url=] to |serviceWorker|'s [=service worker/script url=].
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/HTTPS state=] to |serviceWorker|'s <a>script resource</a>'s <a>HTTPS state</a>.
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/referrer policy=] to |serviceWorker|'s <a>script resource</a>'s [=script resource/referrer policy=].
+          1. Set |workerGlobalScope|'s [=WorkerGlobalScope/embedder policy=] to |serviceWorker|'s [=service worker/embedder policy=].
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/type=] to |serviceWorker|'s [=service worker/type=].
           1. Set |workerGlobalScope|'s [=ServiceWorkerGlobalScope/force bypass cache for import scripts flag=] if |forceBypassCache| is true.
           1. Create a new {{WorkerLocation}} object and associate it with |workerGlobalScope|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3486,7 +3486,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       :: a boolean
 
       1. If |response|'s [=response/type=] is not "<code>opaque</code>", then return true.
-      1. Let |request| be a new [=request=] whose [=request/url=] is |response|'s [=response/url=].
+      1. Let |request| be a new [=/request=] whose [=request/url=] is |response|'s [=response/url=].
       1. Set |request|'s [=request/mode=] to "<code>no-cors</code>".
       1. Set |request|'s [=request/origin=] to |settings object|'s [=environment settings object/origin=].
       1. Set |request|'s [=request/client=] to |settings object|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1864,7 +1864,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             1. Else:
                 1. Let |requestResponses| be the result of running [=Query Cache=] with |r| and |options|.
                 1. [=list/For each=] |requestResponse| of |requestResponses|:
-                    1. If [=Cross-Origin Resource Policy Check for Cached Resource=] with |requestResponse|'s response and |promise|'s [=relevant settings object=] returns false, then reject |promise| with a `TypeError` and abort these steps.
+                    1. If [=Cross-Origin Resource Policy Check for Cached Resource=] with |requestResponse|'s request, |requestResponse|'s response and |promise|'s [=relevant settings object=] returns false, then reject |promise| with a `TypeError` and abort these steps.
                     1. Add a copy of |requestResponse|'s response to |responses|.
             1. [=Queue a task=], on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to perform the following steps:
                 1. Let |responseList| be a [=list=].
@@ -3480,13 +3480,14 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <h3 id="cross-origin-resource-policy-check-for-cached-resource-algorithm"><dfn>Cross-Origin Resource Policy Check for Cached Resource</dfn></h3>
 
       : Input
+      :: |passed request|, a [=/request=]
       :: |response|, a [=/response=]
       :: |settings object|, an [=/environment settings object=]
       : Output
       :: a boolean
 
       1. If |response|'s [=response/type=] is not "<code>opaque</code>", then return true.
-      1. Let |request| be a new [=/request=] whose [=request/url=] is |response|'s [=response/url=].
+      1. Let |request| be a copy of |passed request|.
       1. Set |request|'s [=request/mode=] to "<code>no-cors</code>".
       1. Set |request|'s [=request/origin=] to |settings object|'s [=environment settings object/origin=].
       1. Set |request|'s [=request/client=] to |settings object|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -164,7 +164,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A <a>script resource</a> has an associated <dfn export for="script resource" id="dfn-referrer-policy">referrer policy</dfn> (a [=/referrer policy=]). It is initially the empty string.
 
-    A [=/service worker=] has an associated <dfn>embedder policy</dfn> (an [=/embedder policy=]). It is initially set to a new [=/embedder policy=].
+    A [=/service worker=] has an associated <dfn>embedder policy</dfn> (an [=/embedder policy=]).
 
     A [=/service worker=] has an associated <dfn export id="dfn-script-resource-map">script resource map</dfn> which is an <a>ordered map</a> where the keys are [=/URLs=] and the values are [=/responses=].
 
@@ -1866,7 +1866,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
                 1. [=list/For each=] |requestResponse| of |requestResponses|:
                     1. Add a copy of |requestResponse|'s response to |responses|.
             1. [=list/For each=] |response| of |responses|:
-                1. If |response|'s [=response/type=] is "`opaque`" and [=cross-origin resource policy check=] with |response|'s [=internal/internal response=], |promise|'s [=relevant settings object=]'s [=environment settings object/origin=], and |promise|'s [=relevant settings object=] returns <b>blocked</b>, then reject |promise| with a `TypeError` and abort these steps.
+                1. If |response|'s [=response/type=] is "`opaque`" and [=cross-origin resource policy check=] with |promise|'s [=relevant settings object=]'s [=environment settings object/origin=], |promise|'s [=relevant settings object=], and |response|'s [=internal/internal response=] returns <b>blocked</b>, then reject |promise| with a `TypeError` and abort these steps.
             1. [=Queue a task=], on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to perform the following steps:
                 1. Let |responseList| be a [=list=].
                 1. [=list/For each=] |response| of |responses|:
@@ -2574,7 +2574,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |httpsState| be "<code>none</code>".
       1. Let |referrerPolicy| be the empty string.
-      1. Let |embedder policy| be a new [=/embedder policy=].
+      1. Let |embedder policy| be null.
       1. Let |hasUpdatedResources| be false.
       1. Let |updatedResourceMap| be an [=ordered map=] where the [=map/keys=] are [=/URLs=] and the [=map/values=] are [=/responses=].
       1. Switching on |job|'s [=worker type=], run these substeps with the following options:
@@ -2614,7 +2614,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
           1. Set |httpsState| to |response|'s [=response/HTTPS state=].
           1. Set |referrerPolicy| to the result of <a>parse a referrer policy from a <code>Referrer-Policy</code> header</a> of |response|.
-          1. Set |embedder policy| be the result of [=obtain an embedder policy|obtaining an embedder policy=] from |response|.
+          1. Set |embedder policy| to be the result of [=obtain an embedder policy|obtaining an embedder policy=] from |response|.
           1. If |serviceWorkerAllowed| is failure, then:
               1. Asynchronously complete these steps with a <a>network error</a>.
           1. Let |scopeURL| be |registration|'s [=service worker registration/scope url=].
@@ -2683,6 +2683,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Append |url| to |worker|'s [=set of used scripts=].
       1. Set |worker|'s <a>script resource</a>'s <a>HTTPS state</a> to |httpsState|.
       1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
+      1. Assert: |embedder policy| is not null.
       1. Set |worker|'s [=service worker/embedder policy=] to |embedder policy|.
       1. Let |forceBypassCache| be true if |job|'s [=job/force bypass cache flag=] is set, and false otherwise.
       1. Let |runResult| be the result of running the [=Run Service Worker=] algorithm with |worker| and |forceBypassCache|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2614,7 +2614,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
           1. Set |httpsState| to |response|'s [=response/HTTPS state=].
           1. Set |referrerPolicy| to the result of <a>parse a referrer policy from a <code>Referrer-Policy</code> header</a> of |response|.
-          1. Set |embedder policy| to be the result of [=obtain an embedder policy|obtaining an embedder policy=] from |response|.
+          1. Set |embedder policy| to the result of [=obtain an embedder policy|obtaining an embedder policy=] from |response|.
           1. If |serviceWorkerAllowed| is failure, then:
               1. Asynchronously complete these steps with a <a>network error</a>.
           1. Let |scopeURL| be |registration|'s [=service worker registration/scope url=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1864,8 +1864,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             1. Else:
                 1. Let |requestResponses| be the result of running [=Query Cache=] with |r| and |options|.
                 1. [=list/For each=] |requestResponse| of |requestResponses|:
-                    1. If [=Cross-Origin Resource Policy Check for Cached Resource=] with |requestResponse|'s request, |requestResponse|'s response and |promise|'s [=relevant settings object=] returns false, then reject |promise| with a `TypeError` and abort these steps.
                     1. Add a copy of |requestResponse|'s response to |responses|.
+            1. [=list/For each=] |response| of |responses|:
+                1. If |response|'s [=response/type=] is "`opaque`" and [=cross-origin resource policy check=] with |response|'s [=internal/internal response=], |promise|'s [=relevant settings object=]'s [=environment settings object/origin=], and |promise|'s [=relevant settings object=] returns <b>blocked</b>, then reject |promise| with a `TypeError` and abort these steps.
             1. [=Queue a task=], on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to perform the following steps:
                 1. Let |responseList| be a [=list=].
                 1. [=list/For each=] |response| of |responses|:
@@ -3474,24 +3475,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             1. Let |responseCopy| be a copy of |cachedResponse|.
             1. Add |requestCopy|/|responseCopy| to |resultList|.
       1. Return |resultList|.
-  </section>
-
-  <section algorithm>
-    <h3 id="cross-origin-resource-policy-check-for-cached-resource-algorithm"><dfn>Cross-Origin Resource Policy Check for Cached Resource</dfn></h3>
-
-      : Input
-      :: |passed request|, a [=/request=]
-      :: |response|, a [=/response=]
-      :: |settings object|, an [=/environment settings object=]
-      : Output
-      :: a boolean
-
-      1. If |response|'s [=response/type=] is not "<code>opaque</code>", then return true.
-      1. Let |request| be a copy of |passed request|.
-      1. Set |request|'s [=request/mode=] to "<code>no-cors</code>".
-      1. Set |request|'s [=request/origin=] to |settings object|'s [=environment settings object/origin=].
-      1. Set |request|'s [=request/client=] to |settings object|.
-      1. Return true if [=cross-origin resource policy check=] with |request| and |response| returns <b>allowed</b>, and false otherwise.
   </section>
 
   <section algorithm>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1863,12 +1863,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
                     1. Add a copy of |requestResponse|'s response to |responses|.
             1. Else:
                 1. Let |requestResponses| be the result of running [=Query Cache=] with |r| and |options|.
-                1. Let |request for CORP check| be a copy of |r|.
-                1. Set |request for CORP check|'s [=request/mode=] to "<code>no-cors</code>".
-                1. Set |request for CORP check|'s [=request/origin=] to |promise|'s [=relevant settings object=]'s [=environment settings object/origin=].
-                1. Set |request for CORP check|'s [=request/client=] to |promise|'s [=relevant settings object=].
                 1. [=list/For each=] |requestResponse| of |requestResponses|:
-                    1. If |requestResponse|'s [=response/type=] is "<code>opaque</code>" and [=cross-origin resource policy check=] with |request for CORP check| and |requestResponse| returns <b>blocked</b>, then reject |promise| with a `TypeError` and abort these steps.
+                    1. If [=Cross-Origin Resource Policy Check for Cached Resource=] with |requestResponse|'s response and |promise|'s [=relevant settings object=] returns false, then reject |promise| with a `TypeError` and abort these steps.
                     1. Add a copy of |requestResponse|'s response to |responses|.
             1. [=Queue a task=], on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to perform the following steps:
                 1. Let |responseList| be a [=list=].
@@ -3478,6 +3474,23 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
             1. Let |responseCopy| be a copy of |cachedResponse|.
             1. Add |requestCopy|/|responseCopy| to |resultList|.
       1. Return |resultList|.
+  </section>
+
+  <section algorithm>
+    <h3 id="cross-origin-resource-policy-check-for-cached-resource-algorithm"><dfn>Cross-Origin Resource Policy Check for Cached Resource</dfn></h3>
+
+      : Input
+      :: |response|, a [=/response=]
+      :: |settings object|, an [=/environment settings object=]
+      : Output
+      :: a boolean
+
+      1. If |response|'s [=response/type=] is not "<code>opaque</code>", then return true.
+      1. Let |request| be a new [=request=] whose [=request/url=] is |response|'s [=response/url=].
+      1. Set |request|'s [=request/mode=] to "<code>no-cors</code>".
+      1. Set |request|'s [=request/origin=] to |settings object|'s [=environment settings object/origin=].
+      1. Set |request|'s [=request/client=] to |settings object|.
+      1. Return true if [=cross-origin resource policy check=] with |request| and |response| returns <b>allowed</b>, and false otherwise.
   </section>
 
   <section algorithm>


### PR DESCRIPTION
This is part of https://github.com/whatwg/html/pull/5454.

 - Define embedder policy in environment settings object for service
   workers.
 - Add the CORP check in #dom-cache-matchall.

Closes #1490 and whatwg/fetch#985.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yutakahirano/ServiceWorker/pull/1516.html" title="Last updated on Jun 10, 2020, 1:16 PM UTC (65484fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1516/0aceaac...yutakahirano:65484fc.html" title="Last updated on Jun 10, 2020, 1:16 PM UTC (65484fc)">Diff</a>