### PR TITLE
Override the "mode" of Service Worker requests

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2609,6 +2609,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
               Note: Even if the cache mode is not set to "<code>no-cache</code>", the user agent obeys Cache-Control header's max-age value in the network layer to determine if it should bypass the browser cache.
 
+          1. Set |request|'s [=request/mode=] to "`same-origin`".
           1. Set |request|'s [=service-workers mode=] to "`none`".
           1. If the [=fetching scripts/is top-level=] flag is unset, then return the result of [=/fetching=] |request|.
           1. Set |request|'s [=request/redirect mode=] to "<code>error</code>".


### PR DESCRIPTION
Tests for this behavior have already been merged to WPT:

https://github.com/web-platform-tests/wpt/blob/1740f4c70674b363cce9fddd19eb4110a54d609e/fetch/metadata/serviceworker.https.sub.html

Firefox 82 and Chromium 86 both implement this behavior:

https://wpt.fyi/results/fetch/metadata/serviceworker.https.sub.html?run_id=645350001&run_id=647020002&run_id=641150001&run_id=657230003

We could also specify this by extending an existing step that concerns other workers. [In a patch to do that, it was suggested that Service Workers was the more appropriate location.](https://github.com/whatwg/html/pull/5875)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/ServiceWorker/pull/1534.html" title="Last updated on Aug 31, 2020, 6:05 PM UTC (838a6e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1534/e4c2953...bocoup:838a6e7.html" title="Last updated on Aug 31, 2020, 6:05 PM UTC (838a6e7)">Diff</a>