### PR TITLE
Use `undefined` union type for getRegistration()

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -667,7 +667,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
         [NewObject] Promise&lt;ServiceWorkerRegistration&gt; register(USVString scriptURL, optional RegistrationOptions options = {});
 
-        [NewObject] Promise&lt;any&gt; getRegistration(optional USVString clientURL = "");
+        [NewObject] Promise&lt;(ServiceWorkerRegistration or undefined)&gt; getRegistration(optional USVString clientURL = "");
         [NewObject] Promise&lt;FrozenArray&lt;ServiceWorkerRegistration&gt;&gt; getRegistrations();
 
         undefined startMessages();


### PR DESCRIPTION
This is now possible thanks to https://github.com/heycam/webidl/pull/906.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/ServiceWorker/pull/1548.html" title="Last updated on Oct 24, 2020, 10:49 PM UTC (b9d32eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1548/044cc99...saschanaz:b9d32eb.html" title="Last updated on Oct 24, 2020, 10:49 PM UTC (b9d32eb)">Diff</a>