### PR TITLE
Use undefined union for getRegistration()/match()/get()

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -667,7 +667,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
         [NewObject] Promise&lt;ServiceWorkerRegistration&gt; register(USVString scriptURL, optional RegistrationOptions options = {});
 
-        [NewObject] Promise&lt;any&gt; getRegistration(optional USVString clientURL = "");
+        [NewObject] Promise&lt;(ServiceWorkerRegistration or undefined)&gt; getRegistration(optional USVString clientURL = "");
         [NewObject] Promise&lt;FrozenArray&lt;ServiceWorkerRegistration&gt;&gt; getRegistrations();
 
         undefined startMessages();
@@ -1275,7 +1275,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       [Exposed=ServiceWorker]
       interface Clients {
         // The objects returned will be new instances every time
-        [NewObject] Promise&lt;any&gt; get(DOMString id);
+        [NewObject] Promise&lt;(Client or undefined)&gt; get(DOMString id);
         [NewObject] Promise&lt;FrozenArray&lt;Client&gt;&gt; matchAll(optional ClientQueryOptions options = {});
         [NewObject] Promise&lt;WindowClient?&gt; openWindow(USVString url);
         [NewObject] Promise&lt;undefined&gt; claim();
@@ -1814,7 +1814,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <pre class="idl">
       [SecureContext, Exposed=(Window,Worker)]
       interface Cache {
-        [NewObject] Promise&lt;any&gt; match(RequestInfo request, optional CacheQueryOptions options = {});
+        [NewObject] Promise&lt;(Response or undefined)&gt; match(RequestInfo request, optional CacheQueryOptions options = {});
         [NewObject] Promise&lt;FrozenArray&lt;Response&gt;&gt; matchAll(optional RequestInfo request, optional CacheQueryOptions options = {});
         [NewObject] Promise&lt;undefined&gt; add(RequestInfo request);
         [NewObject] Promise&lt;undefined&gt; addAll(sequence&lt;RequestInfo&gt; requests);
@@ -2073,7 +2073,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     <pre class="idl">
       [SecureContext, Exposed=(Window,Worker)]
       interface CacheStorage {
-        [NewObject] Promise&lt;any&gt; match(RequestInfo request, optional MultiCacheQueryOptions options = {});
+        [NewObject] Promise&lt;(Response or undefined)&gt; match(RequestInfo request, optional MultiCacheQueryOptions options = {});
         [NewObject] Promise&lt;boolean&gt; has(DOMString cacheName);
         [NewObject] Promise&lt;Cache&gt; open(DOMString cacheName);
         [NewObject] Promise&lt;boolean&gt; delete(DOMString cacheName);


### PR DESCRIPTION
Thanks to https://github.com/heycam/webidl/pull/906.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/ServiceWorker/pull/1559.html" title="Last updated on Feb 4, 2021, 7:57 PM UTC (0125a86)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1559/044cc99...saschanaz:0125a86.html" title="Last updated on Feb 4, 2021, 7:57 PM UTC (0125a86)">Diff</a>