### PR TITLE
Maintain timing for worker start/ready, for navigation requests.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -197,7 +197,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         * Detects abnormal operation: such as infinite loops and tasks exceeding imposed time limits (if any) while handling the events.
     </section>
 
-   <section>
+    <section>
       <h4 id="service-worker-events">Events</h4>
 
       The Service Workers specification defines <dfn export id="dfn-service-worker-events">service worker events</dfn> (each of which is an [=event=]) that include (see the <a href="#execution-context-events">list</a>):
@@ -2985,7 +2985,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       : Input
       :: |request|, a [=/request=]
-      :: |crossOriginIsolatedCapability|, a boolean
+      :: |useHighResPerformanceTimers|, a boolean
       : Output
       :: |response|, a [=/response=]
 
@@ -3048,7 +3048,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If the result of running the [=Should Skip Event=] algorithm with "fetch" and |activeWorker| is true, then:
           1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
           1. Return null.
-      1. Let |timingInfo|'s [=service worker timing info/start time=] be the [=coarsened shared current time=] given |crossOriginIsolatedCapability|.
+      1. Let |timingInfo|'s [=service worker timing info/start time=] be the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
       1. If |activeWorker|'s <a>state</a> is "`activating`", wait for |activeWorker|'s <a>state</a> to become "`activated`".
       1. If the result of running the [=Run Service Worker=] algorithm with |activeWorker| is *failure*, then set |handleFetchFailed| to true.
       1. Else:
@@ -3065,7 +3065,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. If |request| is a <a>non-subresource request</a> and |request|'s [=request/destination=] is not {{RequestDestination/"report"}}, initialize |e|'s {{FetchEvent/resultingClientId}} attribute to |reservedClient|'s [=environment/id=], and to the empty string otherwise.
               1. If |request| is a <a>navigation request</a>, initialize |e|'s {{FetchEvent/replacesClientId}} attribute to |request|'s [=request/replaces client id=], and to the empty string otherwise.
               1. Initialize |e|’s {{FetchEvent/handled}} to |eventHandled|.
-              1. Let |timingInfo|'s [=service worker timing info/fetch event dispatch time=] to the [=coarsened shared current time=] given |crossOriginIsolatedCapability|.
+              1. Let |timingInfo|'s [=service worker timing info/fetch event dispatch time=] to the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
               1. <a>Dispatch</a> |e| at |activeWorker|'s [=service worker/global object=].
               1. Invoke [=Update Service Worker Extended Events Set=] with |activeWorker| and |e|.
               1. If |e|'s [=FetchEvent/respond-with entered flag=] is set, set |respondWithEntered| to true.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3052,7 +3052,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
           1. Return null.
       1. If |activeWorker|'s <a>state</a> is "`activating`", wait for |activeWorker|'s <a>state</a> to become "`activated`".
-      1. Let |workerStartTime| be the  [=coarsened shared current time=] given <var>crossOriginIsolatedCapability</var>.
+      1. Let |workerStartTime| be the [=coarsened shared current time=] given |crossOriginIsolatedCapability|.
       1. If the result of running the [=Run Service Worker=] algorithm with |activeWorker| is *failure*, then set |handleFetchFailed| to true.
       1. Else:
           1. Set |workerRealm| to the [=relevant realm=] of the |activeWorker|'s [=service worker/global object=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3048,6 +3048,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If the result of running the [=Should Skip Event=] algorithm with "fetch" and |activeWorker| is true, then:
           1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
           1. Return null.
+      1. If |useHighResPerformanceTimers| is true, then set |useHighResPerformanceTimers| to |activeWorker|'s  
+         [=service worker/global object=]'s [=WorkerGlobalScope/cross-origin isolated capability=].
       1. Let |timingInfo|'s [=service worker timing info/start time=] be the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
       1. If |activeWorker|'s <a>state</a> is "`activating`", wait for |activeWorker|'s <a>state</a> to become "`activated`".
       1. If the result of running the [=Run Service Worker=] algorithm with |activeWorker| is *failure*, then set |handleFetchFailed| to true.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3076,7 +3076,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. If |response| is null, |request|'s [=request/body=] is not null, and |request|'s [=request/body=]'s [=Body/source=] is null, then:
                   1. If |request|'s [=request/body=] is [=Body/unusable=], set |handleFetchFailed| to true.
                   1. Else, [=ReadableStream/cancel=] |request|'s [=request/body=] with undefined.
-              1. If |response| is not null, then set |response|'s [=response/service worker timing=] to |timingInfo|.
               1. If |e|'s <a>canceled flag</a> is set, set |eventCanceled| to true.
               1. If |fetchInstance| is [=fetch/terminated=], then [=queue a task=] to [=AbortSignal/signal abort=] on |requestObject|'s {{Request/signal}}.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3076,6 +3076,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. If |response| is null, |request|'s [=request/body=] is not null, and |request|'s [=request/body=]'s [=Body/source=] is null, then:
                   1. If |request|'s [=request/body=] is [=Body/unusable=], set |handleFetchFailed| to true.
                   1. Else, [=ReadableStream/cancel=] |request|'s [=request/body=] with undefined.
+              <!-- TODO: assign timingInfo to the response, once FETCH exposes that association. -->
               1. If |e|'s <a>canceled flag</a> is set, set |eventCanceled| to true.
               1. If |fetchInstance| is [=fetch/terminated=], then [=queue a task=] to [=AbortSignal/signal abort=] on |requestObject|'s {{Request/signal}}.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3068,7 +3068,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. If |request| is a <a>non-subresource request</a> and |request|'s [=request/destination=] is not {{RequestDestination/"report"}}, initialize |e|'s {{FetchEvent/resultingClientId}} attribute to |reservedClient|'s [=environment/id=], and to the empty string otherwise.
               1. If |request| is a <a>navigation request</a>, initialize |e|'s {{FetchEvent/replacesClientId}} attribute to |request|'s [=request/replaces client id=], and to the empty string otherwise.
               1. Initialize |e|’s {{FetchEvent/handled}} to |eventHandled|.
-              1. If |request| is a <a>navigation request</a>, then:
+              1. If |request| is a [=navigation request=], then:
                   1. Set |activeWorker|'s [=service worker/start time=] to |workerStartTime|.
                   1. Set |activeWorker|'s [=service worker/ready time=] to the [=coarsened shared current time=] given |crossOriginIsolatedCapability|.
               1. <a>Dispatch</a> |e| at |activeWorker|'s [=service worker/global object=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3076,7 +3076,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. If |response| is null, |request|'s [=request/body=] is not null, and |request|'s [=request/body=]'s [=Body/source=] is null, then:
                   1. If |request|'s [=request/body=] is [=Body/unusable=], set |handleFetchFailed| to true.
                   1. Else, [=ReadableStream/cancel=] |request|'s [=request/body=] with undefined.
-              <!-- TODO: assign timingInfo to the response, once FETCH exposes that association. -->
+              1. If |response| is not null, then set |response|'s [=response/service worker timing info=] to |timingInfo|.
               1. If |e|'s <a>canceled flag</a> is set, set |eventCanceled| to true.
               1. If |fetchInstance| is [=fetch/terminated=], then [=queue a task=] to [=AbortSignal/signal abort=] on |requestObject|'s {{Request/signal}}.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -184,6 +184,10 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A [=/service worker=] has an associated <dfn>start status</dfn> which can be null or a [=Completion=]. It is initially null.
 
+    A [=/service worker=] has an associated <dfn export id="dfn-timing-info">start time</dfn> (a {{DOMHighResTimeStamp}}). It is initially set to 0.
+
+    A [=/service worker=] has an associated <dfn export id="dfn-timing-info">ready time</dfn> (a {{DOMHighResTimeStamp}}). It is initially set to 0.
+
     A [=/service worker=] is said to be <dfn>running</dfn> if its [=event loop=] is running.
 
     <section>
@@ -2998,6 +3002,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Let |preloadResponse| be a new [=promise=].
       1. Let |workerRealm| be null.
       1. Let |eventHandled| be null.
+      1. Let |crossOriginIsolatedCapability| be |request|'s [=request/client=]'s [=environment settings object/cross-origin isolated capability=].
       1. Let |fetchInstance| be the instance of the [=/fetch=] algorithm representing the ongoing fetch.
       1. Assert: |request|'s [=request/destination=] is not "<code>serviceworker</code>".
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
@@ -3047,6 +3052,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
           1. Return null.
       1. If |activeWorker|'s <a>state</a> is "`activating`", wait for |activeWorker|'s <a>state</a> to become "`activated`".
+      1. Let |workerStartTime| be the  [=coarsened shared current time=] given <var>crossOriginIsolatedCapability</var>.
       1. If the result of running the [=Run Service Worker=] algorithm with |activeWorker| is *failure*, then set |handleFetchFailed| to true.
       1. Else:
           1. Set |workerRealm| to the [=relevant realm=] of the |activeWorker|'s [=service worker/global object=].
@@ -3062,6 +3068,9 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. If |request| is a <a>non-subresource request</a> and |request|'s [=request/destination=] is not {{RequestDestination/"report"}}, initialize |e|'s {{FetchEvent/resultingClientId}} attribute to |reservedClient|'s [=environment/id=], and to the empty string otherwise.
               1. If |request| is a <a>navigation request</a>, initialize |e|'s {{FetchEvent/replacesClientId}} attribute to |request|'s [=request/replaces client id=], and to the empty string otherwise.
               1. Initialize |e|’s {{FetchEvent/handled}} to |eventHandled|.
+              1. If |request| is a <a>navigation request</a>, then:
+                  1. Set |activeWorker|'s [=service worker/start time=] to |workerStartTime|.
+                  1. Set |activeWorker|'s [=service worker/ready time=] to the [=coarsened shared current time=] given |crossOriginIsolatedCapability|.
               1. <a>Dispatch</a> |e| at |activeWorker|'s [=service worker/global object=].
               1. Invoke [=Update Service Worker Extended Events Set=] with |activeWorker| and |e|.
               1. If |e|'s [=FetchEvent/respond-with entered flag=] is set, set |respondWithEntered| to true.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -184,10 +184,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A [=/service worker=] has an associated <dfn>start status</dfn> which can be null or a [=Completion=]. It is initially null.
 
-    A [=/service worker=] has an associated <dfn export id="dfn-timing-info">start time</dfn> (a {{DOMHighResTimeStamp}}). It is initially set to 0.
-
-    A [=/service worker=] has an associated <dfn export id="dfn-timing-info">ready time</dfn> (a {{DOMHighResTimeStamp}}). It is initially set to 0.
-
     A [=/service worker=] is said to be <dfn>running</dfn> if its [=event loop=] is running.
 
     <section>
@@ -201,7 +197,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         * Detects abnormal operation: such as infinite loops and tasks exceeding imposed time limits (if any) while handling the events.
     </section>
 
-    <section>
+   <section>
       <h4 id="service-worker-events">Events</h4>
 
       The Service Workers specification defines <dfn export id="dfn-service-worker-events">service worker events</dfn> (each of which is an [=event=]) that include (see the <a href="#execution-context-events">list</a>):
@@ -2989,6 +2985,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       : Input
       :: |request|, a [=/request=]
+      :: |crossOriginIsolatedCapability|, a boolean
       : Output
       :: |response|, a [=/response=]
 
@@ -3002,7 +2999,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Let |preloadResponse| be a new [=promise=].
       1. Let |workerRealm| be null.
       1. Let |eventHandled| be null.
-      1. Let |crossOriginIsolatedCapability| be |request|'s [=request/client=]'s [=environment settings object/cross-origin isolated capability=].
+      1. Let |timingInfo| be a new [=service worker timing info=].
       1. Let |fetchInstance| be the instance of the [=/fetch=] algorithm representing the ongoing fetch.
       1. Assert: |request|'s [=request/destination=] is not "<code>serviceworker</code>".
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
@@ -3051,8 +3048,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If the result of running the [=Should Skip Event=] algorithm with "fetch" and |activeWorker| is true, then:
           1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
           1. Return null.
+      1. Let |timingInfo|'s [=service worker timing info/start time=] be the [=coarsened shared current time=] given |crossOriginIsolatedCapability|.
       1. If |activeWorker|'s <a>state</a> is "`activating`", wait for |activeWorker|'s <a>state</a> to become "`activated`".
-      1. Let |workerStartTime| be the [=coarsened shared current time=] given |crossOriginIsolatedCapability|.
       1. If the result of running the [=Run Service Worker=] algorithm with |activeWorker| is *failure*, then set |handleFetchFailed| to true.
       1. Else:
           1. Set |workerRealm| to the [=relevant realm=] of the |activeWorker|'s [=service worker/global object=].
@@ -3068,9 +3065,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. If |request| is a <a>non-subresource request</a> and |request|'s [=request/destination=] is not {{RequestDestination/"report"}}, initialize |e|'s {{FetchEvent/resultingClientId}} attribute to |reservedClient|'s [=environment/id=], and to the empty string otherwise.
               1. If |request| is a <a>navigation request</a>, initialize |e|'s {{FetchEvent/replacesClientId}} attribute to |request|'s [=request/replaces client id=], and to the empty string otherwise.
               1. Initialize |e|’s {{FetchEvent/handled}} to |eventHandled|.
-              1. If |request| is a [=navigation request=], then:
-                  1. Set |activeWorker|'s [=service worker/start time=] to |workerStartTime|.
-                  1. Set |activeWorker|'s [=service worker/ready time=] to the [=coarsened shared current time=] given |crossOriginIsolatedCapability|.
+              1. Let |timingInfo|'s [=service worker timing info/fetch event dispatch time=] to the [=coarsened shared current time=] given |crossOriginIsolatedCapability|.
               1. <a>Dispatch</a> |e| at |activeWorker|'s [=service worker/global object=].
               1. Invoke [=Update Service Worker Extended Events Set=] with |activeWorker| and |e|.
               1. If |e|'s [=FetchEvent/respond-with entered flag=] is set, set |respondWithEntered| to true.
@@ -3081,6 +3076,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               1. If |response| is null, |request|'s [=request/body=] is not null, and |request|'s [=request/body=]'s [=Body/source=] is null, then:
                   1. If |request|'s [=request/body=] is [=Body/unusable=], set |handleFetchFailed| to true.
                   1. Else, [=ReadableStream/cancel=] |request|'s [=request/body=] with undefined.
+              1. If |response| is not null, then set |response|'s [=response/service worker timing=] to |timingInfo|.
               1. If |e|'s <a>canceled flag</a> is set, set |eventCanceled| to true.
               1. If |fetchInstance| is [=fetch/terminated=], then [=queue a task=] to [=AbortSignal/signal abort=] on |requestObject|'s {{Request/signal}}.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3048,8 +3048,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. If the result of running the [=Should Skip Event=] algorithm with "fetch" and |activeWorker| is true, then:
           1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
           1. Return null.
-      1. If |useHighResPerformanceTimers| is true, then set |useHighResPerformanceTimers| to |activeWorker|'s  
-         [=service worker/global object=]'s [=WorkerGlobalScope/cross-origin isolated capability=].
+      1. If |useHighResPerformanceTimers| is true, then set |useHighResPerformanceTimers| to |activeWorker|'s [=service worker/global object=]'s [=WorkerGlobalScope/cross-origin isolated capability=].
       1. Let |timingInfo|'s [=service worker timing info/start time=] be the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
       1. If |activeWorker|'s <a>state</a> is "`activating`", wait for |activeWorker|'s <a>state</a> to become "`activated`".
       1. If the result of running the [=Run Service Worker=] algorithm with |activeWorker| is *failure*, then set |handleFetchFailed| to true.


### PR DESCRIPTION
The timing when worker is started or ready are web-accessible via
the navigation timing API (https://w3c.github.io/navigation-timing/).

`workerStart` is specified to be the time when the service worker is run.

In Chromium and Gecko, `worker ready time` (exposed as `fetchStart`)
is set to the right before the time when the Fetch event can be
dispatched for the newly created worker.

In preparation for https://github.com/w3c/navigation-timing/issues/136


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/noamr/ServiceWorker/pull/1575.html" title="Last updated on May 13, 2021, 11:19 AM UTC (21510d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1575/e005153...noamr:21510d9.html" title="Last updated on May 13, 2021, 11:19 AM UTC (21510d9)">Diff</a>