### PR TITLE
Expose a "service worker timing info" struct

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -201,6 +201,20 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           * <dfn export id="dfn-functional-events">Functional events</dfn>: {{fetch!!event}} and the [=events=] defined by other specifications that <a href="#extensibility">extend</a> the Service Workers specification. (See the <a href="#execution-context-events">list</a>.)
           * {{message!!event}} and {{messageerror!!event}}.
     </section>
+    <section>
+      <h4 id="service-worker-timing">Timing</h4>
+
+      Service workers mark certain points in time that are later exposed by the {{PerformanceNavigationTiming|navigation timing}} API.
+
+      A <dfn export>service worker timing info</dfn> is a [=/struct=]. It has the following [=struct/items=]:
+
+      <section dfn-for="service worker timing info">
+        : <dfn export>start time</dfn>
+        :: A {{DOMHighResTimeStamp}}, initially 0.
+        : <dfn export>fetch event dispatch time</dfn>
+        :: A {{DOMHighResTimeStamp}}, initially 0.
+      </section>
+    </section>
   </section>
 
   <section dfn-for="service worker registration">


### PR DESCRIPTION
to report worker-specific timing information to Navigation Timing.

In preparation for https://github.com/w3c/ServiceWorker/pull/1575


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/noamr/ServiceWorker/pull/1581.html" title="Last updated on Apr 15, 2021, 1:11 PM UTC (2f50de4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1581/62db59f...noamr:2f50de4.html" title="Last updated on Apr 15, 2021, 1:11 PM UTC (2f50de4)">Diff</a>