### PR TITLE
Adapt to policy container

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -81,6 +81,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
             text: ancestor origins list; for: Location; url: concept-location-ancestor-origins-list
         urlPrefix: syntax.html
             text: delay the load event; for: document; url: delay-the-load-event
+        urlPrefix: origin.html
+            text: creating a policy container from a fetch response
 
 spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
     type: dfn
@@ -159,6 +161,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     A [=/service worker=] has an associated <dfn export id="dfn-script-resource">script resource</dfn> (a <a>script</a>), which represents its own script resource. It is initially set to null.
 
     A <a>script resource</a> has an associated <dfn export for="script resource" id="dfn-has-ever-been-evaluated-flag">has ever been evaluated flag</dfn>. It is initially unset.
+
+    A <a>script resource</a> has an associated <dfn export for="script resource" id="dfn-policy-container">policy container</dfn> (a [=/policy container=]). It is initially a new policy container.
 
     A <a>script resource</a> has an associated <dfn export for="script resource" id="dfn-referrer-policy">referrer policy</dfn> (a [=/referrer policy=]). It is initially the empty string.
 
@@ -2639,6 +2643,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
               Note: See the definition of the [=Service-Worker-Allowed=] header in Appendix B: Extended HTTP headers.
 
+          1. Set |policyContainer| to the result of <a>creating a policy container from a fetch response</a> given |response|.
           1. Set |referrerPolicy| to the result of <a>parse a referrer policy from a <code>Referrer-Policy</code> header</a> of |response|.
           1. Set |embedder policy| to the result of [=obtain an embedder policy|obtaining an embedder policy=] from |response|.
           1. If |serviceWorkerAllowed| is failure, then:
@@ -2707,6 +2712,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Let |worker| be a new [=/service worker=].
       1. Set |worker|'s [=service worker/script url=] to |job|'s [=job/script url=], |worker|'s [=script resource=] to |script|, |worker|'s [=service worker/type=] to |job|'s [=worker type=], and |worker|'s [=script resource map=] to |updatedResourceMap|.
       1. Append |url| to |worker|'s [=set of used scripts=].
+      1. Set |worker|'s <a>script resource</a>'s [=script resource/policy container=] to |policyContainer|.
       1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
       1. Assert: |embedder policy| is not null.
       1. Set |worker|'s [=service worker/embedder policy=] to |embedder policy|.
@@ -2902,6 +2908,8 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               :: Return |serviceWorker|'s [=service worker/script url=].
               : The [=environment settings object/origin=]
               :: Return its registering [=/service worker client=]'s [=environment settings object/origin=].
+              : The [=environment settings object/policy container=]
+              :: Return |workerGlobalScope|'s [=WorkerGlobalScope/policy container=].
               : The [=environment settings object/referrer policy=]
               :: Return |workerGlobalScope|'s [=WorkerGlobalScope/referrer policy=].
               : The [=environment settings object/embedder policy=]
@@ -2909,6 +2917,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
           1. Set |settingsObject|'s [=environment/id=] to a new unique opaque string, [=creation URL=] to |serviceWorker|'s [=service worker/script url=], [=environment/top-level creation URL=] to null, [=environment/top-level origin=] to an [=implementation-defined=] value, [=environment/target browsing context=] to null, and [=active service worker=] to null.
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/url=] to |serviceWorker|'s [=service worker/script url=].
+          1. Set |workerGlobalScope|'s [=WorkerGlobalScope/policy container=] to |serviceWorker|'s <a>script resource</a>'s [=script resource/policy container=].
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/referrer policy=] to |serviceWorker|'s <a>script resource</a>'s [=script resource/referrer policy=].
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/embedder policy=] to |serviceWorker|'s [=service worker/embedder policy=].
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/type=] to |serviceWorker|'s [=service worker/type=].


### PR DESCRIPTION
This is a companion PR to https://github.com/whatwg/html/pull/6504, which adds the concept of a policy container and attaches it to the environment settings object and the WorkerGlobalScope. This PR correctly initializes the policy container of the underlying WorkerGlobalScope of a ServiceWorkerGlobalScope.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/ServiceWorker/pull/1588.html" title="Last updated on Apr 27, 2021, 11:25 AM UTC (28aafd2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1588/d26edf9...antosart:28aafd2.html" title="Last updated on Apr 27, 2021, 11:25 AM UTC (28aafd2)">Diff</a>