### PR TITLE
Service worker struct should be exported without a 'for' attribute

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -210,12 +210,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
     A <dfn export>service worker timing info</dfn> is a [=/struct=]. It has the following [=struct/items=]:
 
-      <section dfn-for="service worker timing info">
-        : <dfn export>start time</dfn>
-        :: A {{DOMHighResTimeStamp}}, initially 0.
-        : <dfn export>fetch event dispatch time</dfn>
-        :: A {{DOMHighResTimeStamp}}, initially 0.
-      </section>
+    <section dfn-for="service worker timing info">
+      : <dfn export>start time</dfn>
+      :: A {{DOMHighResTimeStamp}}, initially 0.
+      : <dfn export>fetch event dispatch time</dfn>
+      :: A {{DOMHighResTimeStamp}}, initially 0.
+    </section>
   </section>
 
   <section dfn-for="service worker registration">

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -201,12 +201,14 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
           * <dfn export id="dfn-functional-events">Functional events</dfn>: {{fetch!!event}} and the [=events=] defined by other specifications that <a href="#extensibility">extend</a> the Service Workers specification. (See the <a href="#execution-context-events">list</a>.)
           * {{message!!event}} and {{messageerror!!event}}.
     </section>
-    <section>
-      <h4 id="service-worker-timing">Timing</h4>
+  </section>
 
-      Service workers mark certain points in time that are later exposed by the {{PerformanceNavigationTiming|navigation timing}} API.
+  <section>
+    <h3 id="service-worker-timing">Serview Worker Timing</h3>
 
-      A <dfn export for="">service worker timing info</dfn> is a [=/struct=]. It has the following [=struct/items=]:
+    Service workers mark certain points in time that are later exposed by the {{PerformanceNavigationTiming|navigation timing}} API.
+
+    A <dfn export>service worker timing info</dfn> is a [=/struct=]. It has the following [=struct/items=]:
 
       <section dfn-for="service worker timing info">
         : <dfn export>start time</dfn>
@@ -214,7 +216,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
         : <dfn export>fetch event dispatch time</dfn>
         :: A {{DOMHighResTimeStamp}}, initially 0.
       </section>
-    </section>
   </section>
 
   <section dfn-for="service worker registration">

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -206,7 +206,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
 
       Service workers mark certain points in time that are later exposed by the {{PerformanceNavigationTiming|navigation timing}} API.
 
-      A <dfn export>service worker timing info</dfn> is a [=/struct=]. It has the following [=struct/items=]:
+      A <dfn export for="">service worker timing info</dfn> is a [=/struct=]. It has the following [=struct/items=]:
 
       <section dfn-for="service worker timing info">
         : <dfn export>start time</dfn>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -206,15 +206,15 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   <section>
     <h3 id="service-worker-timing">Serview Worker Timing</h3>
 
-    Service workers mark certain points in time that are later exposed by the [=PerformanceNavigationTiming!!idl|navigation timing=] API.
+    Service workers mark certain points in time that are later exposed by the <a interface lt="PerformanceNavigationTiming">navigation timing</a> API.
 
     A <dfn export>service worker timing info</dfn> is a [=/struct=]. It has the following [=struct/items=]:
 
     <section dfn-for="service worker timing info">
-      : <dfn export>start time</dfn>
-      :: A {{DOMHighResTimeStamp}}, initially 0.
-      : <dfn export>fetch event dispatch time</dfn>
-      :: A {{DOMHighResTimeStamp}}, initially 0.
+        : <dfn export>start time</dfn>
+        :: A {{DOMHighResTimeStamp}}, initially 0.
+        : <dfn export>fetch event dispatch time</dfn>
+        :: A {{DOMHighResTimeStamp}}, initially 0.
     </section>
   </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -206,7 +206,7 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
   <section>
     <h3 id="service-worker-timing">Serview Worker Timing</h3>
 
-    Service workers mark certain points in time that are later exposed by the {{PerformanceNavigationTiming|navigation timing}} API.
+    Service workers mark certain points in time that are later exposed by the [=PerformanceNavigationTiming!!idl|navigation timing=] API.
 
     A <dfn export>service worker timing info</dfn> is a [=/struct=]. It has the following [=struct/items=]:
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/noamr/ServiceWorker/pull/1590.html" title="Last updated on Apr 29, 2021, 9:48 AM UTC (5f55eaf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1590/b807be1...noamr:5f55eaf.html" title="Last updated on Apr 29, 2021, 9:48 AM UTC (5f55eaf)">Diff</a>