### PR TITLE
Adapt to referrer policy being in policy container

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -105,9 +105,6 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
     type: dfn
         text: Vary; url: section-7.1.4
 
-spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-referrer-policy/
-    type: dfn
-        text: Parse a referrer policy from a Referrer-Policy header; url: parse-referrer-policy-from-header
 </pre>
 
 <pre class="biblio">
@@ -163,8 +160,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
     A <a>script resource</a> has an associated <dfn export for="script resource" id="dfn-has-ever-been-evaluated-flag">has ever been evaluated flag</dfn>. It is initially unset.
 
     A <a>script resource</a> has an associated <dfn export for="script resource" id="dfn-policy-container">policy container</dfn> (a [=/policy container=]). It is initially a new policy container.
-
-    A <a>script resource</a> has an associated <dfn export for="script resource" id="dfn-referrer-policy">referrer policy</dfn> (a [=/referrer policy=]). It is initially the empty string.
 
     A [=/service worker=] has an associated <dfn>embedder policy</dfn> (an [=/embedder policy=]).
 
@@ -2659,7 +2654,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               Note: See the definition of the [=Service-Worker-Allowed=] header in Appendix B: Extended HTTP headers.
 
           1. Set |policyContainer| to the result of <a>creating a policy container from a fetch response</a> given |response|.
-          1. Set |referrerPolicy| to the result of <a>parse a referrer policy from a <code>Referrer-Policy</code> header</a> of |response|.
           1. Set |embedder policy| to the result of [=obtain an embedder policy|obtaining an embedder policy=] from |response|.
           1. If |serviceWorkerAllowed| is failure, then:
               1. Asynchronously complete these steps with a <a>network error</a>.
@@ -2728,7 +2722,6 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
       1. Set |worker|'s [=service worker/script url=] to |job|'s [=job/script url=], |worker|'s [=script resource=] to |script|, |worker|'s [=service worker/type=] to |job|'s [=worker type=], and |worker|'s [=script resource map=] to |updatedResourceMap|.
       1. Append |url| to |worker|'s [=set of used scripts=].
       1. Set |worker|'s <a>script resource</a>'s [=script resource/policy container=] to |policyContainer|.
-      1. Set |worker|'s <a>script resource</a>'s [=script resource/referrer policy=] to |referrerPolicy|.
       1. Assert: |embedder policy| is not null.
       1. Set |worker|'s [=service worker/embedder policy=] to |embedder policy|.
       1. Let |forceBypassCache| be true if |job|'s [=job/force bypass cache flag=] is set, and false otherwise.
@@ -2925,15 +2918,12 @@ spec: webappsec-referrer-policy; urlPrefix: https://w3c.github.io/webappsec-refe
               :: Return its registering [=/service worker client=]'s [=environment settings object/origin=].
               : The [=environment settings object/policy container=]
               :: Return |workerGlobalScope|'s [=WorkerGlobalScope/policy container=].
-              : The [=environment settings object/referrer policy=]
-              :: Return |workerGlobalScope|'s [=WorkerGlobalScope/referrer policy=].
               : The [=environment settings object/embedder policy=]
               :: Return |workerGlobalScope|'s [=WorkerGlobalScope/embedder policy=].
 
           1. Set |settingsObject|'s [=environment/id=] to a new unique opaque string, [=creation URL=] to |serviceWorker|'s [=service worker/script url=], [=environment/top-level creation URL=] to null, [=environment/top-level origin=] to an [=implementation-defined=] value, [=environment/target browsing context=] to null, and [=active service worker=] to null.
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/url=] to |serviceWorker|'s [=service worker/script url=].
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/policy container=] to |serviceWorker|'s <a>script resource</a>'s [=script resource/policy container=].
-          1. Set |workerGlobalScope|'s [=WorkerGlobalScope/referrer policy=] to |serviceWorker|'s <a>script resource</a>'s [=script resource/referrer policy=].
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/embedder policy=] to |serviceWorker|'s [=service worker/embedder policy=].
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/type=] to |serviceWorker|'s [=service worker/type=].
           1. Set |workerGlobalScope|'s [=ServiceWorkerGlobalScope/force bypass cache for import scripts flag=] if |forceBypassCache| is true.


### PR DESCRIPTION
This is a companion change to https://github.com/whatwg/html/pull/6677, which moves referrer policy into the policy container. As a consequence, referrer policy is taken care by the policy container mechanisms and does not need to be considered directly by ServiceWorker anymore.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/ServiceWorker/pull/1593.html" title="Last updated on May 12, 2021, 8:08 AM UTC (b0b97bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1593/e005153...antosart:b0b97bc.html" title="Last updated on May 12, 2021, 8:08 AM UTC (b0b97bc)">Diff</a>