### PR TITLE
Fix typo "Serview" to "Service"

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -203,7 +203,7 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
   </section>
 
   <section>
-    <h3 id="service-worker-timing">Serview Worker Timing</h3>
+    <h3 id="service-worker-timing">Service Worker Timing</h3>
 
     Service workers mark certain points in time that are later exposed by the <a interface lt="PerformanceNavigationTiming">navigation timing</a> API.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mfalken/ServiceWorker/pull/1598.html" title="Last updated on Jun 10, 2021, 10:12 PM UTC (c1e1ff2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1598/ff226f6...mfalken:c1e1ff2.html" title="Last updated on Jun 10, 2021, 10:12 PM UTC (c1e1ff2)">Diff</a>