### PR TITLE
Remove embedder policy

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -168,8 +168,6 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
 
     A <a>script resource</a> has an associated <dfn export for="script resource" id="dfn-policy-container">policy container</dfn> (a [=/policy container=]). It is initially a new policy container.
 
-    A [=/service worker=] has an associated <dfn>embedder policy</dfn> (an [=/embedder policy=]).
-
     A [=/service worker=] has an associated <dfn export id="dfn-script-resource-map">script resource map</dfn> which is an <a>ordered map</a> where the keys are [=/URLs=] and the values are [=/responses=].
 
     A [=/service worker=] has an associated  <dfn export id="dfn-set-of-used-scripts">set of used scripts</dfn> (a [=ordered set|set=]) whose [=list/item=] is a [=/URL=]. It is initially a new [=ordered set|set=].
@@ -2622,7 +2620,6 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
           1. Invoke [=Reject Job Promise=] with |job| and `TypeError`.
           1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |referrerPolicy| be the empty string.
-      1. Let |embedder policy| be null.
       1. Let |hasUpdatedResources| be false.
       1. Let |updatedResourceMap| be an [=ordered map=] where the [=map/keys=] are [=/URLs=] and the [=map/values=] are [=/responses=].
       1. Switching on |job|'s [=worker type=], run these substeps with the following options:
@@ -2661,7 +2658,6 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
               Note: See the definition of the [=Service-Worker-Allowed=] header in Appendix B: Extended HTTP headers.
 
           1. Set |policyContainer| to the result of <a>creating a policy container from a fetch response</a> given |response|.
-          1. Set |embedder policy| to the result of [=obtain an embedder policy|obtaining an embedder policy=] from |response|.
           1. If |serviceWorkerAllowed| is failure, then:
               1. Asynchronously complete these steps with a <a>network error</a>.
           1. Let |scopeURL| be |registration|'s [=service worker registration/scope url=].
@@ -2728,8 +2724,6 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
       1. Set |worker|'s [=service worker/script url=] to |job|'s [=job/script url=], |worker|'s [=script resource=] to |script|, |worker|'s [=service worker/type=] to |job|'s [=worker type=], and |worker|'s [=script resource map=] to |updatedResourceMap|.
       1. Append |url| to |worker|'s [=set of used scripts=].
       1. Set |worker|'s <a>script resource</a>'s [=script resource/policy container=] to |policyContainer|.
-      1. Assert: |embedder policy| is not null.
-      1. Set |worker|'s [=service worker/embedder policy=] to |embedder policy|.
       1. Let |forceBypassCache| be true if |job|'s [=job/force bypass cache flag=] is set, and false otherwise.
       1. Let |runResult| be the result of running the [=Run Service Worker=] algorithm with |worker| and |forceBypassCache|.
       1. If |runResult| is *failure* or an [=abrupt completion=], then:
@@ -2924,13 +2918,10 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
               :: Return its registering [=/service worker client=]'s [=environment settings object/origin=].
               : The [=environment settings object/policy container=]
               :: Return |workerGlobalScope|'s [=WorkerGlobalScope/policy container=].
-              : The [=environment settings object/embedder policy=]
-              :: Return |workerGlobalScope|'s [=WorkerGlobalScope/embedder policy=].
 
           1. Set |settingsObject|'s [=environment/id=] to a new unique opaque string, [=creation URL=] to |serviceWorker|'s [=service worker/script url=], [=environment/top-level creation URL=] to null, [=environment/top-level origin=] to an [=implementation-defined=] value, [=environment/target browsing context=] to null, and [=active service worker=] to null.
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/url=] to |serviceWorker|'s [=service worker/script url=].
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/policy container=] to |serviceWorker|'s <a>script resource</a>'s [=script resource/policy container=].
-          1. Set |workerGlobalScope|'s [=WorkerGlobalScope/embedder policy=] to |serviceWorker|'s [=service worker/embedder policy=].
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/type=] to |serviceWorker|'s [=service worker/type=].
           1. Set |workerGlobalScope|'s [=ServiceWorkerGlobalScope/force bypass cache for import scripts flag=] if |forceBypassCache| is true.
           1. Create a new {{WorkerLocation}} object and associate it with |workerGlobalScope|.


### PR DESCRIPTION
This is an editorial PR, adapting to embedder policy moving to the policy container (https://github.com/whatwg/html/pull/6793). As a result of that, ServiceWorker does not need to mention embedder policy anymore.