### PR TITLE
Refactor filtered/internal responses in Cache API. (Fixes #1609, #1614)

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2004,14 +2004,14 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
             1. Let |requestObj| be the result of invoking {{Request}}'s constructor with |request| as its argument. If this [=throws=] an |exception|, return [=a promise rejected with=] |exception|.
             1. Set |innerRequest| to |requestObj|'s [=Request/request=].
         1. If |innerRequest|'s [=request/url=]'s [=url/scheme=] is not one of "`http`" and "`https`", or |innerRequest|'s [=request/method=] is not \`<code>GET</code>\`, return [=a promise rejected with=] a `TypeError`.
+        1. If |response|'s [=response/status=] is `206`, return [=a promise rejected with=] a `TypeError`.
         1. Let |innerResponse| be |response|'s [=Response/response=].
-        1. If |innerResponse|'s [=response/status=] is `206`, return [=a promise rejected with=] a `TypeError`.
         1. If |innerResponse|'s [=response/header list=] contains a [=header=] [=header/named=] \``Vary`\`, then:
             1. Let |fieldValues| be the [=list=] containing the [=list/items=] corresponding to the  [=Vary=] header's [=http/field-values=].
             1. [=list/For each=] |fieldValue| in |fieldValues|:
                 1. If |fieldValue| matches "`*`", return [=a promise rejected with=] a `TypeError`.
         1. If |innerResponse|'s [=response/body=] is [=Body/disturbed=] or [=Body/locked=], return [=a promise rejected with=] a `TypeError`.
-        1. Let |clonedResponse| be a [=response/clone=] of |innerResponse|.
+        1. Let |clonedResponse| be a [=response/clone=] of |response|.
         1. Let |bodyReadPromise| be [=a promise resolved with=] undefined.
         1. If |innerResponse|'s [=response/body=] is non-null, run these substeps:
             1. Let |stream| be |innerResponse|'s [=response/body=]'s [=body/stream=].
@@ -3549,8 +3549,9 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
           1. Set |cachedURL|'s [=url/query=] to the empty string.
           1. Set |queryURL|'s [=url/query=] to the empty string.
       1. If |queryURL| does not [=url/equal=] |cachedURL| with the *exclude fragment flag* set, then return false.
-      1. If |response| is null, |options|["{{CacheQueryOptions/ignoreVary}}"] is true, or |response|'s [=response/header list=] does not [=header list/contain=] \``Vary`\`, then return true.
-      1. Let |fieldValues| be the [=list=] containing the elements corresponding to the [=http/field-values=] of the [=Vary=] header for the [=header/value=] of the [=header=] with [=header/name=] \``Vary`\`.
+      1. Let |internal header list| be |response|'s [=Response/response=]'s [=response/header list=].
+      1. If |response| is null, |options|["{{CacheQueryOptions/ignoreVary}}"] is true, or |internal header list| does not [=header list/contain=] \``Vary`\`, then return true.
+      1. Let |fieldValues| be the result of [=header list/getting, decoding, and splitting=] \``Vary`\` from |internal header list|.
       1. For each |fieldValue| in |fieldValues|:
           1. If |fieldValue| matches "`*`", or the [=header list/combine|combined value=] given |fieldValue| and |request|'s [=request/header list=] does not match the [=header list/combine|combined value=] given |fieldValue| and |requestQuery|'s [=request/header list=], then return false.
       1. Return true.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wanderview/ServiceWorker/pull/1615.html" title="Last updated on Nov 9, 2021, 8:21 PM UTC (2ef642a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1615/1db9650...wanderview:2ef642a.html" title="Last updated on Nov 9, 2021, 8:21 PM UTC (2ef642a)">Diff</a>