### PR TITLE
Define the time origin for service workers

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2895,6 +2895,7 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
 
       Note: This algorithm blocks until the service worker is [=running=] or fails to start.
 
+      1. Let |unsafeCreationTime| be the [=unsafe shared current time=].
       1. If |serviceWorker| is [=running=], then return |serviceWorker|'s [=start status=].
       1. If |serviceWorker|'s [=state=] is "`redundant`", then return *failure*.
       1. Assert: |serviceWorker|'s [=start status=] is null.
@@ -2919,6 +2920,8 @@ spec: rfc7231; urlPrefix: https://tools.ietf.org/html/rfc7231
               :: Return its registering [=/service worker client=]'s [=environment settings object/origin=].
               : The [=environment settings object/policy container=]
               :: Return |workerGlobalScope|'s [=WorkerGlobalScope/policy container=].
+              : The [=environment settings object/time origin=]
+              :: Return the result of [=coarsen time|coarsening=] |unsafeCreationTime| given |workerGlobalScope|'s [=WorkerGlobalScope/cross-origin isolated capability=].
 
           1. Set |settingsObject|'s [=environment/id=] to a new unique opaque string, [=creation URL=] to |serviceWorker|'s [=service worker/script url=], [=environment/top-level creation URL=] to null, [=environment/top-level origin=] to an [=implementation-defined=] value, [=environment/target browsing context=] to null, and [=active service worker=] to null.
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/url=] to |serviceWorker|'s [=service worker/script url=].


### PR DESCRIPTION
In [this HTML PR](https://github.com/whatwg/html/pull/7339) we add
a `time origin` getter to the `environment settings object`.
We need to account for that value in service workers, which would be the
time the worker environment is created.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/noamr/ServiceWorker/pull/1621.html" title="Last updated on Nov 24, 2021, 3:59 PM UTC (b67daec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1621/1db9650...noamr:b67daec.html" title="Last updated on Nov 24, 2021, 3:59 PM UTC (b67daec)">Diff</a>