### PR TITLE
align default metadata used for both ED and CRD

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: Service Workers Nightly
+Title: Service Workers
 Status: ED
 ED: https://w3c.github.io/ServiceWorker/
 TR: https://www.w3.org/TR/service-workers/
@@ -12,7 +12,6 @@ Former Editor: Jungkee Song, Microsoft&sbquo; represented Samsung until April 20
 Repository: w3c/ServiceWorker
 Group: serviceworkers
 !Tests: <a href=https://github.com/web-platform-tests/wpt/tree/master/service-workers>web-platform-tests service-workers/</a> (<a href=https://github.com/web-platform-tests/wpt/labels/service-workers>ongoing work</a>)
-Status Text: This is a living document. Readers need to be aware that this specification may include unimplemented features, and details that may change. <a href="https://w3c.github.io/ServiceWorker/v1/">Service Workers 1</a> is a version that is advancing toward a W3C Recommendation.
 Abstract: The core of this specification is a worker that wakes to receive events. This provides an event destination that can be used when other destinations would be inappropriate, or no other destination exists.
 Abstract:
 Abstract: For example, to allow the developer to decide how a page should be fetched, an event needs to dispatch potentially before any other execution contexts exist for that origin. To react to a push message, or completion of a persistent download, the context that originally registered interest may no longer exist. In these cases, the service worker is the ideal event destination.


### PR DESCRIPTION
align default metadata used for both ED and CRD, PR sent on bikeshed (See https://github.com/tabatkins/bikeshed-boilerplate/pull/24) to differentiate statuses


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/pull/1647.html" title="Last updated on Jun 16, 2022, 12:10 PM UTC (994563a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1647/adb4ef0...994563a.html" title="Last updated on Jun 16, 2022, 12:10 PM UTC (994563a)">Diff</a>