### PR TITLE
Abort with fetch controller's error in Handle Fetch

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3058,8 +3058,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. Associate |preloadResponseObject| with |navigationPreloadResponse|.
                       1. Resolve |preloadResponse| with |preloadResponseObject|.
               1. [=If aborted=], then:
-                  1. If |controller|'s [=fetch controller/serialized abort reason=] is non-null, let |deserializedError| be the result of calling [$StructuredDeserialize$] with |controller|'s [=fetch controller/serialized abort reason=] and |workerRealm|. If that threw an exception or returns undefined, then let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
-                  1. Otherwise, let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
+                  1. Let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
+                  1. If |controller|'s [=fetch controller/serialized abort reason=] is non-null, set |deserializedError| to the result of calling [$StructuredDeserialize$] with |controller|'s [=fetch controller/serialized abort reason=] and |workerRealm|. If that threw an exception or returns undefined, then set |deserializedError| to a "{{AbortError}}" {{DOMException}}.
                   1. [=Fetch controller/abort=] |preloadFetchController| with |deserializedError|.
           1. Else, resolve |preloadResponse| with undefined.
 
@@ -3084,7 +3084,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Set |eventHandled| to [=a new promise=] in |workerRealm|.
           1. [=Queue a task=] |task| to run the following substeps:
               1. Let |e| be the result of <a>creating an event</a> with {{FetchEvent}}.
-              1. Let |requestObject| be the result of <a href="https://fetch.spec.whatwg.org/#request-create">creating</a> a {{Request}} object, given |request|, a new {{Headers}} object's [=guard=] which is "`immutable`", and |workerRealm|.
+              1. Let |requestObject| be the result of [=Request/creating=] a {{Request}} object, given |request|, a new {{Headers}} object's [=guard=] which is "`immutable`", and |workerRealm|.
               1. Initialize |e|’s {{Event/type}} attribute to {{fetch!!event}}.
               1. Initialize |e|’s {{Event/cancelable}} attribute to true.
               1. Initialize |e|’s {{FetchEvent/request}} attribute to |requestObject|.
@@ -3107,8 +3107,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If |response| is not null, then set |response|'s [=response/service worker timing info=] to |timingInfo|.
               1. If |e|'s <a>canceled flag</a> is set, set |eventCanceled| to true.
               1. If |controller| [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then:
-                  1. If |controller|'s [=fetch controller/serialized abort reason=] is non-null, let |deserializedError| be the result of calling [$StructuredDeserialize$] with |controller|'s [=fetch controller/serialized abort reason=] and |workerRealm|. If that threw an exception or returns undefined, then let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
-                  1. Otherwise, let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
+                  1. Let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
+                  1. If |controller|'s [=fetch controller/serialized abort reason=] is non-null, set |deserializedError| to the result of calling [$StructuredDeserialize$] with |controller|'s [=fetch controller/serialized abort reason=] and |workerRealm|. If that threw an exception or returns undefined, then set |deserializedError| to a "{{AbortError}}" {{DOMException}}.
                   1. [=Queue a task=] to [=AbortSignal/signal abort=] on |requestObject|'s {{Request/signal}} with |deserializedError|.
 
              If |task| is discarded, set |handleFetchFailed| to true.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3057,7 +3057,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. If |navigationPreloadResponse|'s [=response/type=] is "`error`", reject |preloadResponse| with a `TypeError` and terminate these substeps.
                       1. Associate |preloadResponseObject| with |navigationPreloadResponse|.
                       1. Resolve |preloadResponse| with |preloadResponseObject|.
-              1. [=If aborted=], then [=fetch controller/abort=] |preloadFetchController|.
+              1. [=If aborted=], then [=fetch controller/abort=] |preloadFetchController| with |controller|'s [=fetch controller/cloned error=].
           1. Else, resolve |preloadResponse| with undefined.
 
           Note: From this point, the [=/service worker client=] starts to <a>use</a> its <a>active service worker</a>'s <a>containing service worker registration</a>.
@@ -3103,7 +3103,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Else, [=ReadableStream/cancel=] |request|'s [=request/body=] with undefined.
               1. If |response| is not null, then set |response|'s [=response/service worker timing info=] to |timingInfo|.
               1. If |e|'s <a>canceled flag</a> is set, set |eventCanceled| to true.
-              1. If |controller| [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then [=queue a task=] to [=AbortSignal/signal abort=] on |requestObject|'s {{Request/signal}}.
+              1. If |controller| [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then [=queue a task=] to [=AbortSignal/signal abort=] on |requestObject|'s {{Request/signal}} with |controller|'s [=fetch controller/cloned error=].
 
              If |task| is discarded, set |handleFetchFailed| to true.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3058,7 +3058,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. Associate |preloadResponseObject| with |navigationPreloadResponse|.
                       1. Resolve |preloadResponse| with |preloadResponseObject|.
               1. [=If aborted=], then:
-                  1. If [=fetch controller/serialized abort reason=] is non-null, let |deserializedError| be the result of calling [$StructuredDeserialize$] with [=fetch controller/serialized abort reason=] and |workerRealm|. If that threw an exception or returns undefined, then let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
+                  1. If |controller|'s [=fetch controller/serialized abort reason=] is non-null, let |deserializedError| be the result of calling [$StructuredDeserialize$] with |controller|'s [=fetch controller/serialized abort reason=] and |workerRealm|. If that threw an exception or returns undefined, then let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
                   1. Otherwise, let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
                   1. [=Fetch controller/abort=] |preloadFetchController| with |deserializedError|.
           1. Else, resolve |preloadResponse| with undefined.
@@ -3084,7 +3084,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Set |eventHandled| to [=a new promise=] in |workerRealm|.
           1. [=Queue a task=] |task| to run the following substeps:
               1. Let |e| be the result of <a>creating an event</a> with {{FetchEvent}}.
-              1. Let |requestObject| be the result of <a href="https://fetch.spec.whatwg.org/#request-create">creating</a> a {{Request}} object, given |request|, a [=headers guard=] which is "`immutable`", and |workerRealm|.
+              1. Let |requestObject| be the result of <a href="https://fetch.spec.whatwg.org/#request-create">creating</a> a {{Request}} object, given |request|, a new {{Headers}} object's [=guard=] which is "`immutable`", and |workerRealm|.
               1. Initialize |e|’s {{Event/type}} attribute to {{fetch!!event}}.
               1. Initialize |e|’s {{Event/cancelable}} attribute to true.
               1. Initialize |e|’s {{FetchEvent/request}} attribute to |requestObject|.
@@ -3107,7 +3107,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If |response| is not null, then set |response|'s [=response/service worker timing info=] to |timingInfo|.
               1. If |e|'s <a>canceled flag</a> is set, set |eventCanceled| to true.
               1. If |controller| [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then:
-                  1. If [=fetch controller/serialized abort reason=] is non-null, let |deserializedError| be the result of calling [$StructuredDeserialize$] with [=fetch controller/serialized abort reason=] and |workerRealm|. If that threw an exception or returns undefined, then let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
+                  1. If |controller|'s [=fetch controller/serialized abort reason=] is non-null, let |deserializedError| be the result of calling [$StructuredDeserialize$] with |controller|'s [=fetch controller/serialized abort reason=] and |workerRealm|. If that threw an exception or returns undefined, then let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
                   1. Otherwise, let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
                   1. [=Queue a task=] to [=AbortSignal/signal abort=] on |requestObject|'s {{Request/signal}} with |deserializedError|.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3058,9 +3058,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. Associate |preloadResponseObject| with |navigationPreloadResponse|.
                       1. Resolve |preloadResponse| with |preloadResponseObject|.
               1. [=If aborted=], then:
-	          1. If [=fetch controller/serialized abort reason=] is non-null, let |deserializedError| be the result of calling [$StructuredDeserialize$] with [=fetch controller/serialized abort reason=] and |workerRealm|. If that threw an exception or returns undefined, then let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
-		  1. Otherwise, let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
-	          1. [=Fetch controller/abort=] |preloadFetchController| with |deserializedError|.
+                  1. If [=fetch controller/serialized abort reason=] is non-null, let |deserializedError| be the result of calling [$StructuredDeserialize$] with [=fetch controller/serialized abort reason=] and |workerRealm|. If that threw an exception or returns undefined, then let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
+                  1. Otherwise, let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
+                  1. [=Fetch controller/abort=] |preloadFetchController| with |deserializedError|.
           1. Else, resolve |preloadResponse| with undefined.
 
           Note: From this point, the [=/service worker client=] starts to <a>use</a> its <a>active service worker</a>'s <a>containing service worker registration</a>.
@@ -3107,9 +3107,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If |response| is not null, then set |response|'s [=response/service worker timing info=] to |timingInfo|.
               1. If |e|'s <a>canceled flag</a> is set, set |eventCanceled| to true.
               1. If |controller| [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then:
-	          1. If [=fetch controller/serialized abort reason=] is non-null, let |deserializedError| be the result of calling [$StructuredDeserialize$] with [=fetch controller/serialized abort reason=] and |workerRealm|. If that threw an exception or returns undefined, then let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
-		  1. Otherwise, let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
-	          1. [=Queue a task=] to [=AbortSignal/signal abort=] on |requestObject|'s {{Request/signal}} with |deserializedError|.
+                  1. If [=fetch controller/serialized abort reason=] is non-null, let |deserializedError| be the result of calling [$StructuredDeserialize$] with [=fetch controller/serialized abort reason=] and |workerRealm|. If that threw an exception or returns undefined, then let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
+                  1. Otherwise, let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
+                  1. [=Queue a task=] to [=AbortSignal/signal abort=] on |requestObject|'s {{Request/signal}} with |deserializedError|.
 
              If |task| is discarded, set |handleFetchFailed| to true.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3057,7 +3057,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. If |navigationPreloadResponse|'s [=response/type=] is "`error`", reject |preloadResponse| with a `TypeError` and terminate these substeps.
                       1. Associate |preloadResponseObject| with |navigationPreloadResponse|.
                       1. Resolve |preloadResponse| with |preloadResponseObject|.
-              1. [=If aborted=], then [=fetch controller/abort=] |preloadFetchController| with |controller|'s [=fetch controller/cloned error=].
+              1. [=If aborted=], then:
+	          1. If [=fetch controller/serialized abort reason=] is non-null, let |deserializedError| be the result of calling [$StructuredDeserialize$] with [=fetch controller/serialized abort reason=] and |workerRealm|. If that threw an exception or returns undefined, then let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
+		  1. Otherwise, let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
+	          1. [=Fetch controller/abort=] |preloadFetchController| with |deserializedError|.
           1. Else, resolve |preloadResponse| with undefined.
 
           Note: From this point, the [=/service worker client=] starts to <a>use</a> its <a>active service worker</a>'s <a>containing service worker registration</a>.
@@ -3081,7 +3084,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Set |eventHandled| to [=a new promise=] in |workerRealm|.
           1. [=Queue a task=] |task| to run the following substeps:
               1. Let |e| be the result of <a>creating an event</a> with {{FetchEvent}}.
-              1. Let |requestObject| be a new {{Request}} object associated with |request| and a new associated {{Headers}} object whose [=guard=] is "`immutable`".
+              1. Let |requestObject| be the result of <a href="https://fetch.spec.whatwg.org/#request-create">creating</a> a {{Request}} object, given |request|, a [=headers guard=] which is "`immutable`", and |workerRealm|.
               1. Initialize |e|’s {{Event/type}} attribute to {{fetch!!event}}.
               1. Initialize |e|’s {{Event/cancelable}} attribute to true.
               1. Initialize |e|’s {{FetchEvent/request}} attribute to |requestObject|.
@@ -3103,7 +3106,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Else, [=ReadableStream/cancel=] |request|'s [=request/body=] with undefined.
               1. If |response| is not null, then set |response|'s [=response/service worker timing info=] to |timingInfo|.
               1. If |e|'s <a>canceled flag</a> is set, set |eventCanceled| to true.
-              1. If |controller| [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then [=queue a task=] to [=AbortSignal/signal abort=] on |requestObject|'s {{Request/signal}} with |controller|'s [=fetch controller/cloned error=].
+              1. If |controller| [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then:
+	          1. If [=fetch controller/serialized abort reason=] is non-null, let |deserializedError| be the result of calling [$StructuredDeserialize$] with [=fetch controller/serialized abort reason=] and |workerRealm|. If that threw an exception or returns undefined, then let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
+		  1. Otherwise, let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
+	          1. [=Queue a task=] to [=AbortSignal/signal abort=] on |requestObject|'s {{Request/signal}} with |deserializedError|.
 
              If |task| is discarded, set |handleFetchFailed| to true.
 


### PR DESCRIPTION
In conjunction with https://github.com/whatwg/fetch/pull/1343.

When the service worker intercepts a fetch request, the signal's abort reason must be passed to the service worker to abort the fetch controller and signal abort in https://w3c.github.io/ServiceWorker/#handle-fetch.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/ServiceWorker/pull/1655.html" title="Last updated on Aug 15, 2022, 10:37 AM UTC (5689b03)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1655/adb4ef0...nidhijaju:5689b03.html" title="Last updated on Aug 15, 2022, 10:37 AM UTC (5689b03)">Diff</a>