### PR TITLE
Increment encoded/decoded body size for constructed responses

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1640,6 +1640,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                             ::
                                 1. Assert: |chunk| is a {{Uint8Array}}.
                                 1. Append the bytes represented by |chunk| to |bytes|.
+                                1. Increment |potentialResponse|'s [=response/body info=]'s [=response body info/encoded size=] by |bytes|'s {{Uint8Array/size}}.
+                                1. Increment |potentialResponse|'s [=response/body info=]'s [=response body info/decoded size=] by |bytes|'s {{Uint8Array/size}}.
                                 1. Perform ! [=DetachArrayBuffer=](|chunk|.\[[ViewedArrayBuffer]]).
                             : [=read request/close steps=]
                             ::


### PR DESCRIPTION
Currently responses that come from service workers get encoded/decoded body size of 0.
This rectifies it.

WPT: https://github.com/web-platform-tests/wpt/pull/33283
Chromium bug: https://bugs.chromium.org/p/chromium/issues/detail?id=925239
Closes w3c/navigation-timing#124


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/noamr/ServiceWorker/pull/1664.html" title="Last updated on Nov 28, 2022, 11:33 AM UTC (e5b8b3e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1664/5bcc30d...noamr:e5b8b3e.html" title="Last updated on Nov 28, 2022, 11:33 AM UTC (e5b8b3e)">Diff</a>