### PR TITLE
Skip executing fetch handlers if it is no-op.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -51,7 +51,7 @@ spec: infra;
 spec: webidl;
     type: dfn;
         text: resolve;
-	text: es-callback-interface
+        text: es-callback-interface;
 
 spec:csp-next; type:dfn; text:enforced
 </pre>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -82,6 +82,8 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
         text: Cyclic Module Record; url: sec-cyclic-module-records
         text: function; url: sec-function-definitions
         text: function body; url: prod-FunctionBody
+        text: IsCallable; url: sec-iscallable
+        text: Get; url: sec-get-o-p
         url: sec-ecmascript-language-statements-and-declarations
             text: statement
             text: declaration
@@ -3010,6 +3012,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. [=list/For each=] |eventListener| of |eventListenerList|:
           1. If |eventListener|'s [=callback=] is not null:
               1. Set |callback| to an ECMAScript object coverted from |eventListener|'s [=callback=]. It is [=es-callback-interface=].
+              1. If [=IsCallable=](|callback|) is false:
+                  1. Let |getResult| be [=Completion=]([=Get=](|callback|, <code>handleEvent</code>).
+                  1. If |getResult| is [=abrupt completion=], then return false.
+                  1. Set |callback| to |getResult|.
+                  1. If [=IsCallable=](|callback|) is false, then return false.
               1. If |callback| is a [=function=], and [=function body=] is not empty (i.e. either [=statement=] or [=declaration=] exist), then return false.
 
               Note: it detects something like `onfetch = () => {}`. Some sites have a fetch event listener with empty body to make them recognized as progressive web application (PWA).

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -31,11 +31,7 @@ spec: html;
 
 spec: dom;
     type: interface; text: Document
-    type: dfn;
-        text: event
-        text: event listener list
-        for: event listener; text: callback
-        for: event listener; text: type
+    type: dfn; text: event
 
 spec: fetch;
     type: dfn

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3008,7 +3008,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       1. If |workerGlobalScope|'s <a>set of event types to handle</a> does not [=set/contain=] <code>fetch</code>, then returns false.
       1. Let |eventListenerList| be an empty [=list=].
-      1. [=list/For each=] |eventListner| of |workerGlobalScope|'s <a>set of event types to handle</a>:
+      1. [=list/For each=] |eventListener| of |workerGlobalScope|'s <a>set of event types to handle</a>:
           1. If |eventListener|'s <a spec="dom">type</a> is <code>fetch</code>, then [=list/append=] |eventListener| to |eventListenerList|.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
           1. If |eventListener|'s [=callback=] is not null:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -191,7 +191,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A [=/service worker=] has an associated <dfn>start status</dfn> which can be null or a [=Completion=]. It is initially null.
 
-    A [=/service worker=] has an associated <dfn>has had non-no-op fetch listeners flag</dfn>. It is initially true.
+    A [=/service worker=] has an associated <dfn>all fetch listeners are no-op flag</dfn>. It is initially null.
 
     A [=/service worker=] is said to be <dfn>running</dfn> if its [=event loop=] is running.
 
@@ -2975,7 +2975,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   Note: If the global object's associated list of event listeners does not have any event listener added at this moment, the service worker's set of event types to handle remains an empty set.
 
               1. Set |script|'s <a>has ever been evaluated flag</a>.
-              1. If the [=No-Op Handler identification=] algorithm with |serviceWorker| returns true, the [=has had non-no-op fetch listeners flag=] is set to false.
+              1. If the [=No-Op Handler identification=] algorithm with |serviceWorker| returns true, the [=all fetch listeners are no-op flag=] is set.
           1. Run the <a>responsible event loop</a> specified by |settingsObject| until it is destroyed.
           1. Empty |workerGlobalScope|'s <a>list of active timers</a>.
       1. Wait for |serviceWorker| to be [=running=], or for |startFailed| to be true.
@@ -3165,7 +3165,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: a boolean
 
-      1. If |serviceworker| has |has non-no-op fetch listeners flag|, and the value is false, then the user agent *may* return true.
+      1. If |serviceworker| has |all fetch listeners are no-op flag| and set, then the user agent *may* return true.
       1. Return false.
   </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3009,7 +3009,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. set |eventListenerList| to [=map/value=] whose [=map/key=] is <code>fetch</code> in |workerGlobalScope|'s <a>set of event types to handle</a>.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
           1. If |eventListener|'s [=callback=] is not null:
-              1. Set |callback| to an ECMAScript object coverted from |eventListener|'s [=callback=].
+              1. Set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventListener|'s [=callback=] to an ECMAScript value.
               1. If [$IsCallable$](|callback|) is false:
                   1. Let |getResult| be [=Completion=]([$Get$](|callback|), <code>handleEvent</code>).
                   1. If |getResult| is [=abrupt completion=], then return false.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -33,6 +33,7 @@ spec: dom;
     type: interface; text: Document
     type: dfn;
         text: event
+        text: event listener list
         for: event listener; text: callback
         for: event listener; text: type
 
@@ -3006,14 +3007,13 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: a boolean
 
       1. If |workerGlobalScope|'s [=set of event types to handle=] does not [=set/contain=] <code>fetch</code>, then returns true.
-      1. Let |onFetchHandler| be |workerGlobalScope|'s <code>onfetch</code> attribute.
-      1. If |onFetchHandler|'s <a spec="html">listener</a> is null, then return false.
+      1. Let |eventHandler| be |workerGlobalScope|'s <a spec="html">event handler map</a>["fetch"]'s value.
       1. Let |eventListenerList| be an empty [=list=].
-      1. [=list/For each=] |eventListener| of [onFetchHandler|'s <a spec="html">listener</a>:
+      1. [=list/For each=] |eventListener| of |workerGlobalScope|'s [=event listener list=]:
           1. If |eventListener|'s <a spec="dom">type</a> is <code>fetch</code>, then [=list/append=] |eventListener| to |eventListenerList|.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
           1. If |eventListener|'s [=callback=] is not null:
-              1. If |eventListener| is an EventListener of the type created by <a spec="html">activate an event handler</a>, then set |callback| to the result of [=converting|convert to an ECMAScript value=] |workerGlobalScope|'s <a spec="html">event handler map</a>["fetch"]'s value to an ECMAScript value.
+              1. If |eventListener| equals |eventHandler|'s <a spec="html">listener</a>, then set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventHandler|'s value to an ECMAScript value.
               1. Otherwise, set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventListener|'s [=callback=] to an ECMAScript value.
               1. If [$IsCallable$](|callback|) is false:
                   1. Let |getResult| be [=Completion=]([$Get$](|callback|), <code>handleEvent</code>).

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -81,7 +81,6 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
         text: Cyclic Module Record; url: sec-cyclic-module-records
         text: function; url: sec-function-definitions
         text: function body; url: prod-FunctionBody
-        text: object object; url: sec-object-objects
         url: sec-ecmascript-language-statements-and-declarations
             text: statement
             text: declaration

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -66,7 +66,7 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
         text: Get; url: sec-get-o-p
     type: dfn
         text: Assert; url: sec-algorithm-conventions
-        text: [[Call]]; url: sec-ecmascript-function-objects-call-thisargument-argumentslist
+        text: \[[Call]]; url: sec-ecmascript-function-objects-call-thisargument-argumentslist
         text: promise; url: sec-promise-objects
         text: DetachArrayBuffer; url: sec-detacharraybuffer
         url: sec-list-and-record-specification-type
@@ -2167,7 +2167,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
             1. Return [=a new promise=] |promise| and run the following substeps [=in parallel=]:
                 1. [=map/For each=] |cacheName| → |cache| of the [=relevant name to cache map=]:
                     1. If |options|["{{MultiCacheQueryOptions/cacheName}}"] matches |cacheName|, then:
-                        1. Resolve |promise| with the result of running the algorithm specified in {{Cache/match(request, options)}} method of {{Cache}} interface with |request| and |options| (providing |cache| as thisArgument to the `[[Call]]` internal method of {{Cache/match(request, options)}}.)
+                        1. Resolve |promise| with the result of running the algorithm specified in {{Cache/match(request, options)}} method of {{Cache}} interface with |request| and |options| (providing |cache| as thisArgument to the `\[[Call]]` internal method of {{Cache/match(request, options)}}.)
                         1. Abort these steps.
                 1. Resolve |promise| with undefined.
         1. Else:
@@ -2175,7 +2175,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
             1. [=map/For each=] <var ignore>cacheName</var> → |cache| of the [=relevant name to cache map=]:
                 1. Set |promise| to the result of [=promise/reacting=] to itself with a fulfillment handler that, when called with argument |response|, performs the following substeps:
                     1. If |response| is not undefined, return |response|.
-                    1. Return the result of running the algorithm specified in {{Cache/match(request, options)}} method of {{Cache}} interface with |request| and |options| as the arguments (providing |cache| as thisArgument to the `[[Call]]` internal method of {{Cache/match(request, options)}}.)
+                    1. Return the result of running the algorithm specified in {{Cache/match(request, options)}} method of {{Cache}} interface with |request| and |options| as the arguments (providing |cache| as thisArgument to the `\[[Call]]` internal method of {{Cache/match(request, options)}}.)
             1. Return |promise|.
     </section>
 
@@ -3004,19 +3004,16 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       1. If |workerGlobalScope|'s [=set of event types to handle=] does not [=set/contain=] <code>fetch</code>, then return true.
       1. Let |eventHandler| be |workerGlobalScope|'s [=EventTarget/event handler map=]["onfetch"]'s value.
-      1. Let |eventListenerList| be an empty [=list=].
-      1. [=list/For each=] |eventListener| of |workerGlobalScope|'s [=event listener list=]:
-          1. If |eventListener|'s [=event listener/type=] is "<code>fetch</code>", then [=list/append=] |eventListener| to |eventListenerList|.
-      1. [=list/For each=] |eventListener| of |eventListenerList|:
-          1. If |eventListener|'s [=event listener/callback=] is null, then [=continue=].
-          1. If |eventHandler| is not null, and |eventListener| equals |eventHandler|'s [=event handler/listener=], then set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventHandler|'s [=event handler/listener=] value to an ECMAScript value.
-          1. Otherwise, set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventListener|'s [=event listener/callback=] to an ECMAScript value.
+      1. Let |eventListenerCallbacks| be the result of calling [=legacy-obtain service worker fetch event listener callbacks=] given |workerGlobalScope|.
+      1. [=list/For each=] |eventListenerCallback| of |eventListenerCallbacks|:
+          1. Let |callback| be null.
+          1. If |eventHandler| is not null and |eventListenerCallback| equals |eventHandler|'s [=event handler/listener=]'s [=event listener/callback=], then set |callback| to the result of [=convert to an ECMAScript value|converting to an ECMAScript value=] |eventHandler|'s [=event handler/value=].
+          1. Otherwise, set |callback| to the result of [=convert to an ECMAScript value|converting to an ECMAScript value=] |eventListenerCallback|.
           1. If [$IsCallable$](|callback|) is false:
               1. Let |getResult| be [=Completion=]([$Get$](|callback|), <code>handleEvent</code>).
               1. If |getResult| is [=abrupt completion=], then return false.
               1. Set |callback| to |getResult|.
-          1. If [$IsCallable$](|callback|) is false, then return false.
-          1. If |callback|'s [=function body=] is not empty (i.e. either a [=statement=] or [=declaration=] exist), then return false.
+          1. If [$IsCallable$](|callback|) is false, or |callback|'s [=function body=] is not empty (i.e. either a [=statement=] or [=declaration=] exist), then return false.
 
           Note: This detects "<code>fetch</code>" listeners like `() => {}`. Some sites have a fetch event listener with empty body to make them recognized by Chromium as a progressive web application (PWA).
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -33,8 +33,7 @@ spec: dom;
     type: interface; text: Document
     type: dfn;
         text: event
-        text: callback; url: event-listener-callback
-        text: EventListener; url: callbackdef-eventlistener
+        for: event listener; text: callback
 
 spec: fetch;
     type: dfn
@@ -3009,7 +3008,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If |workerGlobalScope|'s <a>set of event types to handle</a> does not [=set/contain=] <code>fetch</code>, then returns false.
       1. set |eventListenerList| to [=map/value=] whose [=map/key=] is <code>fetch</code> in |workerGlobalScope|'s <a>set of event types to handle</a>.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
-          1. If |eventListener|'s [=callback=] is [=EventListener=]:
+          1. If |eventListener|'s [=callback=] is not null:
               1. Set |callback| to |eventListener|'s [=callback=].
               1. If |callback|'s <code>handleEvent</code> property is not a [=function=], then return false.
               1. If a [=function body=] of |callback|'s <code>handleEvent</code> property is not empty (i.e. either [=statement=] or [=declaration=] exist), return false.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3072,7 +3072,7 @@ spec: dom; urlPrefix: https://dom.spec.whatwg.org/
           1. Set |registration| to the result of running <a>Match Service Worker Registration</a> given |storage key| and |request|'s [=request/url=].
           1. If |registration| is null or |registration|'s <a>active worker</a> is null, return null.
           1. If |request|'s [=request/destination=] is not {{RequestDestination/"report"}}, set |reservedClient|'s <a>active service worker</a> to |registration|'s <a>active worker</a>.
-	  1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s <a>set of event types to handle</a> [=set/contains=] <code>fetch</code>, and the result of running the [=Skippable Fetch Handler=] algorithm with |registration|'s [=active worker=] is false then:
+          1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s <a>set of event types to handle</a> [=set/contains=] <code>fetch</code>, and the result of running the [=Skippable Fetch Handler=] algorithm with |registration|'s [=active worker=] is false then:
 
               Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3061,7 +3061,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Set |registration| to the result of running <a>Match Service Worker Registration</a> given |storage key| and |request|'s [=request/url=].
           1. If |registration| is null or |registration|'s <a>active worker</a> is null, return null.
           1. If |request|'s [=request/destination=] is not {{RequestDestination/"report"}}, set |reservedClient|'s <a>active service worker</a> to |registration|'s <a>active worker</a>.
-          1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s <a>set of event types to handle</a> [=set/contains=] <code>fetch</code>, and the result of running [=Skippable Fetch Handler=] algorithm with [=active worker=] is false then:
+	  1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s <a>set of event types to handle</a> [=set/contains=] <code>fetch</code>, and the result of running the [=Skippable Fetch Handler=] algorithm with |registration|'s [=active worker=] is false then:
 
               Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2987,7 +2987,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   Note: If the global object's associated list of event listeners does not have any event listener added at this moment, the service worker's [=set of event types to handle=] remains an empty set.
 
               1. Set |script|'s <a>has ever been evaluated flag</a>.
-              1. If the [=Empty Fetch Handler identification=] algorithm with |workerGlobalScope| returns true, the [=all fetch listeners are empty flag=] may be set.
+              1. If the [=Empty Fetch Handler Identification=] algorithm with |workerGlobalScope| returns true, the [=all fetch listeners are empty flag=] may be set.
 
               Note: the user agents are encouraged to show warnings that the event listeners are no-op, and their executions can be skipped.
 
@@ -2999,7 +2999,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section algorithm>
-    <h3 id="empty-fetch-handler-identification-algorithm"><dfn>Empty Fetch Handler identification</dfn></h3>
+    <h3 id="empty-fetch-handler-identification-algorithm"><dfn>Empty Fetch Handler Identification</dfn></h3>
 
       : Input
       :: |workerGlobalScope|, a [=service worker/global object=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2986,6 +2986,9 @@ spec: dom; urlPrefix: https://dom.spec.whatwg.org/
 
               1. Set |script|'s <a>has ever been evaluated flag</a>.
               1. If the [=No-Op Handler identification=] algorithm with |serviceWorker| returns true, the [=all fetch listeners are empty flag=] is set.
+
+              Note: the user agents are encouraged to show warnings that the event listeners are no-op, and their executions can be skipped.
+
           1. Run the <a>responsible event loop</a> specified by |settingsObject| until it is destroyed.
           1. Empty |workerGlobalScope|'s <a>list of active timers</a>.
       1. Wait for |serviceWorker| to be [=running=], or for |startFailed| to be true.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3003,7 +3003,7 @@ spec: dom; urlPrefix: https://dom.spec.whatwg.org/
 
       1. If |serviceWorker|'s set of event types to handle does not contain "fetch", then returns false.
       1. If one of fetch [=event listeners=] in |serviceWorker| is not a [=function=], then return false.
-      1. If the [=callback=]'s [=function bodies=] of all fetch event listener in |serviceWorker| are empty (no [=statement=] or [=declaration=] exist), then the user agent *may* return true.
+      1. If the [=callback=]'s [=function bodies=] of all fetch event listener in |serviceWorker| are empty (no [=statement=] or [=declaration=] exist), then the user agent return true.
 
       Note: it detects something like `onfetch = () => {}`. Some sites have a fetch event listener with empty body to make them recognized as progressive web application (PWA).
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3015,7 +3015,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. If |eventListener|'s <a spec="dom">type</a> is <code>fetch</code>, then [=list/append=] |eventListener| to |eventListenerList|.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
           1. If |eventListener|'s [=callback=] is not null:
-              1. Set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventListener|'s [=callback=] to an ECMAScript value.
+              1. If |eventListener| is an EventListener of the type created by <a spec="html">activate an event handler</a>, then set |callback| to the result of [=converting|convert to an ECMAScript value=] |workerGlobalScope|'s <a spec="html">event handler map</a>["fetch"]'s value to an ECMAScript value.
+              1. Otherwise, set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventListener|'s [=callback=] to an ECMAScript value.
               1. If [$IsCallable$](|callback|) is false:
                   1. Let |getResult| be [=Completion=]([$Get$](|callback|), <code>handleEvent</code>).
                   1. If |getResult| is [=abrupt completion=], then return false.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3126,7 +3126,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. [=In parallel=]:
               1. If |activeWorker|'s [=service worker/state=] is "activating", then wait for |activeWorker|'s [=service worker/state=] to become "activated".
               1. Run the [=Run Service Worker=] algorithm with |activeWorker|.
-              1. If |shouldSoftUpdate| is true, then run the [=Soft Update algorithm=] with |registration|.
+              1. If |shouldSoftUpdate| is true, then run the [=Soft Update=] algorithm with |registration|.
           1. Return null.
       1. If |useHighResPerformanceTimers| is true, then set |useHighResPerformanceTimers| to |activeWorker|'s [=service worker/global object=]'s [=WorkerGlobalScope/cross-origin isolated capability=].
       1. Let |timingInfo|'s [=service worker timing info/start time=] be the [=coarsened shared current time=] given |useHighResPerformanceTimers|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3006,27 +3006,27 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: a boolean
 
-      1. If |workerGlobalScope|'s [=set of event types to handle=] does not [=set/contain=] <code>fetch</code>, then returns true.
-      1. Let |eventHandler| be |workerGlobalScope|'s <a spec="html">event handler map</a>["fetch"]'s value.
+      1. If |workerGlobalScope|'s [=set of event types to handle=] does not [=set/contain=] <code>fetch</code>, then return true.
+      1. Let |eventHandler| be |workerGlobalScope|'s <a spec="html">event handler map</a>["onfetch"]'s value.
       1. Let |eventListenerList| be an empty [=list=].
       1. [=list/For each=] |eventListener| of |workerGlobalScope|'s [=event listener list=]:
-          1. If |eventListener|'s <a spec="dom">type</a> is <code>fetch</code>, then [=list/append=] |eventListener| to |eventListenerList|.
+          1. If |eventListener|'s <a spec="dom">type</a> is "<code>fetch</code>", then [=list/append=] |eventListener| to |eventListenerList|.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
-          1. If |eventListener|'s [=callback=] is not null:
-              1. If |eventListener| equals |eventHandler|'s <a spec="html">listener</a>, then set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventHandler|'s value to an ECMAScript value.
-              1. Otherwise, set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventListener|'s [=callback=] to an ECMAScript value.
-              1. If [$IsCallable$](|callback|) is false:
-                  1. Let |getResult| be [=Completion=]([$Get$](|callback|), <code>handleEvent</code>).
-                  1. If |getResult| is [=abrupt completion=], then return false.
-                  1. Set |callback| to |getResult|.
-              1. If [$IsCallable$](|callback|) is false, then return false.
-              1. If |callback|'s [=function body=] is not empty (i.e. either a [=statement=] or [=declaration=] exist), then return false.
+          1. If |eventListener|'s [=event listener/callback=] is null, then [=continue=].
+          1. If |eventListener| equals |eventHandler|'s <a spec="html">listener</a>, then set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventHandler|'s value to an ECMAScript value.
+          1. Otherwise, set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventListener|'s [=callback=] to an ECMAScript value.
+          1. If [$IsCallable$](|callback|) is false:
+              1. Let |getResult| be [=Completion=]([$Get$](|callback|), <code>handleEvent</code>).
+              1. If |getResult| is [=abrupt completion=], then return false.
+              1. Set |callback| to |getResult|.
+          1. If [$IsCallable$](|callback|) is false, then return false.
+          1. If |callback|'s [=function body=] is not empty (i.e. either a [=statement=] or [=declaration=] exist), then return false.
 
-              Note: it detects something like `onfetch = () => {}`. Some sites have a fetch event listener with empty body to make them recognized as progressive web application (PWA).
+          Note: This detects "<code>fetch</code>" listeners like `() => {}`. Some sites have a fetch event listener with empty body to make them recognized by Chromium as a progressive web application (PWA).
 
       1. Return true.
 
-      Note: the user agents are encouraged to show warnings that the event listeners are no-op, and their executions can be skipped.
+      Note: User agents are encouraged to show a warning indicating that empty "<code>fetch</code>" listeners are unnecessary, and may have a negative performance impact.
 
   </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -69,6 +69,11 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
         text: Completion; url: sec-completion-record-specification-type
         text: Module Record; url: sec-abstract-module-records
         text: Cyclic Module Record; url: sec-cyclic-module-records
+        text: function; url: sec-function-definitions
+        text: function bodies; url: prod-FunctionBody
+        url: sec-ecmascript-language-statements-and-declarations
+            text: statement
+            text: declaration
 
 spec: page-visibility; urlPrefix: https://www.w3.org/TR/page-visibility/
     type: enum; text: VisibilityState; url: VisibilityState
@@ -118,6 +123,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         text: storage key; url: storage-key
         text: obtain a storage key; url: obtain-a-storage-key
         text: storage key/equals; url: storage-key-equals
+
+spec: dom; urlPrefix: https://dom.spec.whatwg.org/
+    type: dfn
+        text: event listeners; url: concept-event-listener
+        text: callback; url: event-listener-callback
 
 </pre>
 
@@ -2992,7 +3002,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: a boolean
 
       1. If |serviceWorker|'s set of event types to handle does not contain "fetch", then returns false.
-      1. If the callback's function bodies (https://tc39.es/ecma262/#prod-FunctionBody) of all fetch event listener in |service worker| are empty, then the user agent *may* return true.
+      1. If one of fetch [=event listeners=] in |serviceWorker| is not a [=function=], then return false.
+      1. If the [=callback=]'s [=function bodies=] of all fetch event listener in |serviceWorker| are empty (no [=statement=] or [=declaration=] exist), then the user agent *may* return true.
 
       Note: it detects something like `onfetch = () => {}`. Some sites have a fetch event listener with empty body to make them recognized as progressive web application (PWA).
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -51,6 +51,7 @@ spec: infra;
 spec: webidl;
     type: dfn;
         text: resolve;
+	text: idl-callback-interface
 
 spec:csp-next; type:dfn; text:enforced
 </pre>
@@ -3008,7 +3009,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. set |eventListenerList| to [=map/value=] whose [=map/key=] is <code>fetch</code> in |workerGlobalScope|'s <a>set of event types to handle</a>.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
           1. If |eventListener|'s [=callback=] is not null:
-              1. Set |callback| to |eventListener|'s [=callback=].
+              1. Set |callback| to an ECMAScript object coverted from |eventListener|'s [=callback=], which is [=idl-callback-interface=].
+              1. If |callback| is a [=function=], and [=function body=] is not empty (i.e. either [=statement=] or [=declaration=] exist), then return false.
+              1. If |callback| does not have <code>handleEvent</code> property, then return false.
               1. If |callback|'s <code>handleEvent</code> property is not a [=function=], then return false.
               1. If a [=function body=] of |callback|'s <code>handleEvent</code> property is not empty (i.e. either [=statement=] or [=declaration=] exist), return false.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -29,6 +29,9 @@ spec: html;
 
 spec: dom;
     type: interface; text: Document
+    type: dfn
+        text: callback; url: event-listener-callback
+        text: EventListener; url: callbackdef-eventlistener
 
 spec: fetch;
     type: dfn
@@ -43,7 +46,6 @@ spec: infra;
 spec: webidl;
     type: dfn;
         text: resolve;
-        text: es-callback-interface;
 </pre>
 
 <pre class="anchors">
@@ -71,7 +73,7 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
         text: Module Record; url: sec-abstract-module-records
         text: Cyclic Module Record; url: sec-cyclic-module-records
         text: function; url: sec-function-definitions
-        text: function bodies; url: prod-FunctionBody
+        text: function body; url: prod-FunctionBody
         text: object object; url: sec-object-objects
         url: sec-ecmascript-language-statements-and-declarations
             text: statement
@@ -125,10 +127,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         text: storage key; url: storage-key
         text: obtain a storage key; url: obtain-a-storage-key
         text: storage key/equals; url: storage-key-equals
-
-spec: dom; urlPrefix: https://dom.spec.whatwg.org/
-    type: dfn
-        text: callback; url: event-listener-callback
 
 </pre>
 
@@ -2986,7 +2984,7 @@ spec: dom; urlPrefix: https://dom.spec.whatwg.org/
                   Note: If the global object's associated list of event listeners does not have any event listener added at this moment, the service worker's <a>set of event types to handle</a> remains an empty set.
 
               1. Set |script|'s <a>has ever been evaluated flag</a>.
-              1. If the [=Empty Handler identification=] algorithm with |serviceWorker| returns true, the [=all fetch listeners are empty flag=] is set.
+              1. If the [=Empty Handler identification=] algorithm with |workerGlobalScope| returns true, the [=all fetch listeners are empty flag=] is set.
 
               Note: the user agents are encouraged to show warnings that the event listeners are no-op, and their executions can be skipped.
 
@@ -3001,23 +2999,19 @@ spec: dom; urlPrefix: https://dom.spec.whatwg.org/
     <h3 id="empty-handler-identification-algorithm"><dfn>Empty Handler identification</dfn></h3>
 
       : Input
-      :: |serviceWorker|, a [=/service worker=]
+      :: |workerGlobalScope|, a [=service worker/global object=].
       : Output
       :: a boolean
 
-      1. If |serviceWorker|'s <a>set of event types to handle</a> does not [=set/contain=] <code>fetch</code>, then returns false.
-      1. set |eventListenerList| to <a>event listeners</a> for |serviceWorker|'s <a>set of event types to handle</a> <code>fetch</code>.
+      1. If |workerGlobalScope|'s <a>set of event types to handle</a> does not [=set/contain=] <code>fetch</code>, then returns false.
+      1. set |eventListenerList| to [=map/value=] whose [=map/key=] is <code>fetch</a> in [=workerGlobalScope=]'s <a>set of event types to handle</a>.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
-          1. If |eventListener| is null, then return false.
-          1. If |eventListener| is not [=callback=], then return false.
-          1. If |eventListener|'s [=callback=] is not [=es-callback-interface=], then return false.
-          1. If |eventListener|'s [=callback=] is not a [=function=]:
-              1. If |eventListener| is not an [=object object=], return false.
-              1. If |eventListener|'s properties does not contains <code>handleEvent</code> , return false.
-              1. If |evnetListner| <code>handleEvent</code> property's [=function bodies=] is not empty (i.e. either [=statement=] or [=declaration=] exist), return false.
-          1. If |evnetListner| [=callback=]'s [=function bodies=] is not empty (i.e. either [=statement=] or [=declaration=] exist), return false.
+          1. If |eventListener|'s [=callback=] is [=EventListener=]:
+              1. Set |callback| to |eventListener|'s [=callback=].
+              1. If |callback|'s <code>handleEvent</code> property is not a [=function=], then return false.
+              1. If a [=function body=] of |callback|'s <code>handleEvent</code> property is not empty (i.e. either [=statement=] or [=declaration=] exist), return false.
 
-          Note: it detects something like `onfetch = () => {}`. Some sites have a fetch event listener with empty body to make them recognized as progressive web application (PWA).
+              Note: it detects something like `onfetch = () => {}`. Some sites have a fetch event listener with empty body to make them recognized as progressive web application (PWA).
 
       1. Return true.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -191,6 +191,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A [=/service worker=] has an associated <dfn>start status</dfn> which can be null or a [=Completion=]. It is initially null.
 
+    A [=/service worker=] has an associated <dfn>has had non-no-op fetch listeners flag</dfn>. It is initially true.
+
     A [=/service worker=] is said to be <dfn>running</dfn> if its [=event loop=] is running.
 
     <section>
@@ -2970,14 +2972,32 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. For each |eventType| of |settingsObject|'s [=environment settings object/global object=]'s associated list of <a>event listeners</a>' event types:
                   1. [=set/Append=] |eventType| to |workerGlobalScope|'s associated [=ServiceWorkerGlobalScope/service worker=]'s <a>set of event types to handle</a>.
 
-                  Note: If the global object's associated list of event listeners does not have any event listener added at this moment, the service worker's set of event types to handle remains an empty set. The user agents are encouraged to show a warning that the event listeners must be added on the very first evaluation of the worker script.
+                  Note: If the global object's associated list of event listeners does not have any event listener added at this moment, the service worker's set of event types to handle remains an empty set.
 
               1. Set |script|'s <a>has ever been evaluated flag</a>.
+              1. If the [=No-Op Handler identification=] algorithm with |serviceWorker| returns true, the [=has had non-no-op fetch listeners flag=] is set to false.
           1. Run the <a>responsible event loop</a> specified by |settingsObject| until it is destroyed.
           1. Empty |workerGlobalScope|'s <a>list of active timers</a>.
       1. Wait for |serviceWorker| to be [=running=], or for |startFailed| to be true.
       1. If |startFailed| is true, then return *failure*.
       1. Return |serviceWorker|'s [=start status=].
+  </section>
+
+  <section algorithm>
+    <h3 id="no-op-handler-identification-algorithm"><dfn>No-Op Handler identification</dfn></h3>
+
+      : Input
+      :: |serviceWorker|, a [=/service worker=]
+      : Output
+      :: a boolean
+
+      1. If |service worker|'s set of event types to handle does not contain "fetch", then returns false.
+      1. If the callback's function bodies (https://tc39.es/ecma262/#prod-FunctionBody) of all fetch event listener in |service worker| are empty, then the user agent *may* return true.
+
+      Note: it detects something like `onfetch = () => {}`. Some sites have a fetch event listener with empty body to make them recognized as progressive web application (PWA).
+
+      1. return false.
+
   </section>
 
   <section algorithm>
@@ -3041,7 +3061,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Set |registration| to the result of running <a>Match Service Worker Registration</a> given |storage key| and |request|'s [=request/url=].
           1. If |registration| is null or |registration|'s <a>active worker</a> is null, return null.
           1. If |request|'s [=request/destination=] is not {{RequestDestination/"report"}}, set |reservedClient|'s <a>active service worker</a> to |registration|'s <a>active worker</a>.
-          1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, and |registration|'s [=active worker=]'s <a>set of event types to handle</a> [=set/contains=] <code>fetch</code>, then:
+          1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s <a>set of event types to handle</a> [=set/contains=] <code>fetch</code>, and the result of running [=Skippable Fetch Handler=] algorithm with [=active worker=] is false then:
 
               Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.
 
@@ -3076,6 +3096,12 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           * |request| is a [=subresource request=] and |registration| is [=stale=].
       1. If the result of running the [=Should Skip Event=] algorithm with "fetch" and |activeWorker| is true, then:
           1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
+          1. Return null.
+      1. If the result of running [=Skippable Fetch Handler=] algorithm with |activeWorker| is true, then:
+          1. run the following steps [=in parallel=]:
+              1. If |activeWorker|'s state is "activating", wait for |activeWorker|'s state to become "activated".
+              1. Run the [=Run Service Worker=] algorithm with |activeWorker|.
+              1. If |shouldSoftUpdate| is true, then run the [=Soft Update algorithm=] with |registration|.
           1. Return null.
       1. If |useHighResPerformanceTimers| is true, then set |useHighResPerformanceTimers| to |activeWorker|'s [=service worker/global object=]'s [=WorkerGlobalScope/cross-origin isolated capability=].
       1. Let |timingInfo|'s [=service worker timing info/start time=] be the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
@@ -3130,6 +3156,17 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           2. Return a [=network error=].
       1. If |eventHandled| is not null, then [=resolve=] |eventHandled|.
       1. Return |response|.
+  </section>
+
+  <section algorithm>
+    <h3 id="skippable-fetch-handler-algorithm"><dfn>Skippable Fetch Handler</dfn></h3>
+      : Input
+      :: |serviceWorker|, a [=/service worker=]
+      : Output
+      :: a boolean
+
+      1. If |serviceworker| has |has non-no-op fetch listeners flag|, and the value is false, then the user agent *may* return true.
+      1. Return false.
   </section>
 
   <section algorithm>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2987,6 +2987,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   Note: If the global object's associated list of event listeners does not have any event listener added at this moment, the service worker's [=set of event types to handle=] remains an empty set.
 
               1. Set |script|'s <a>has ever been evaluated flag</a>.
+              1. Unset the [=all fetch listeners are empty flag=].
               1. If the [=Empty Fetch Handler Identification=] algorithm with |workerGlobalScope| returns true, the [=all fetch listeners are empty flag=] may be set.
 
               Note: the user agents are encouraged to show warnings that the event listeners are no-op, and their executions can be skipped.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3004,7 +3004,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: a boolean
 
       1. If |workerGlobalScope|'s <a>set of event types to handle</a> does not [=set/contain=] <code>fetch</code>, then returns false.
-      1. set |eventListenerList| to [=map/value=] whose [=map/key=] is <code>fetch</a> in [=workerGlobalScope=]'s <a>set of event types to handle</a>.
+      1. set |eventListenerList| to [=map/value=] whose [=map/key=] is <code>fetch</code> in |workerGlobalScope|'s <a>set of event types to handle</a>.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
           1. If |eventListener|'s [=callback=] is [=EventListener=]:
               1. Set |callback| to |eventListener|'s [=callback=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2987,10 +2987,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   Note: If the global object's associated list of event listeners does not have any event listener added at this moment, the service worker's [=set of event types to handle=] remains an empty set.
 
               1. Set |script|'s <a>has ever been evaluated flag</a>.
-              1. Unset the [=all fetch listeners are empty flag=].
-              1. If the [=Empty Fetch Handler Identification=] algorithm with |workerGlobalScope| returns true, the [=all fetch listeners are empty flag=] may be set.
-
-              Note: the user agents are encouraged to show warnings that the event listeners are no-op, and their executions can be skipped.
+              1. Unset the |serviceWorker|'s [=all fetch listeners are empty flag=].
+              1. The user agent may, if the [=All Fetch Handlers Are Empty=] algorithm with |workerGlobalScope| returns true, set |serviceWorker|'s [=all fetch listeners are empty flag=].
 
           1. Run the <a>responsible event loop</a> specified by |settingsObject| until it is destroyed.
           1. [=map/Clear=] |workerGlobalScope|'s [=map of active timers=].
@@ -3000,7 +2998,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section algorithm>
-    <h3 id="empty-fetch-handler-identification-algorithm"><dfn>Empty Fetch Handler Identification</dfn></h3>
+    <h3 id="all-fetch-handlers-are-empty-algorithm"><dfn>All Fetch Handlers Are Empty</dfn></h3>
 
       : Input
       :: |workerGlobalScope|, a [=service worker/global object=].
@@ -3027,6 +3025,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               Note: it detects something like `onfetch = () => {}`. Some sites have a fetch event listener with empty body to make them recognized as progressive web application (PWA).
 
       1. Return true.
+
+      Note: the user agents are encouraged to show warnings that the event listeners are no-op, and their executions can be skipped.
 
   </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3008,8 +3008,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: a boolean
 
       1. If |workerGlobalScope|'s [=set of event types to handle=] does not [=set/contain=] <code>fetch</code>, then returns false.
+      1. Let |onFetchHandler| be |workerGlobalScope|'s <code>onfetch</code> attribute.
+      1. If |onFetchHandler|'s <a spec="html">listener</a> is null, then return false.
       1. Let |eventListenerList| be an empty [=list=].
-      1. [=list/For each=] |eventListener| of |workerGlobalScope|'s [=set of event types to handle=]:
+      1. [=list/For each=] |eventListener| of [onFetchHandler|'s <a spec="html">listener</a>:
           1. If |eventListener|'s <a spec="dom">type</a> is <code>fetch</code>, then [=list/append=] |eventListener| to |eventListenerList|.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
           1. If |eventListener|'s [=callback=] is not null:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2988,7 +2988,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
               1. Set |script|'s <a>has ever been evaluated flag</a>.
               1. Unset the |serviceWorker|'s [=all fetch listeners are empty flag=].
-              1. The user agent may, if the [=All Fetch Handlers Are Empty=] algorithm with |workerGlobalScope| returns true, set |serviceWorker|'s [=all fetch listeners are empty flag=].
+              1. The user agent may, if the [=All Fetch Listeners Are Empty=] algorithm with |workerGlobalScope| returns true, set |serviceWorker|'s [=all fetch listeners are empty flag=].
 
           1. Run the <a>responsible event loop</a> specified by |settingsObject| until it is destroyed.
           1. [=map/Clear=] |workerGlobalScope|'s [=map of active timers=].
@@ -2998,7 +2998,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section algorithm>
-    <h3 id="all-fetch-handlers-are-empty-algorithm"><dfn>All Fetch Handlers Are Empty</dfn></h3>
+    <h3 id="all-fetch-listeners-are-empty-algorithm"><dfn>All Fetch Listeners Are Empty</dfn></h3>
 
       : Input
       :: |workerGlobalScope|, a [=service worker/global object=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3013,7 +3013,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. If |eventListener|'s <a spec="dom">type</a> is "<code>fetch</code>", then [=list/append=] |eventListener| to |eventListenerList|.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
           1. If |eventListener|'s [=event listener/callback=] is null, then [=continue=].
-          1. If |eventListener| equals |eventHandler|'s <a spec="html">listener</a>, then set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventHandler|'s value to an ECMAScript value.
+          1. If |eventHandler| is not null, and |eventListener| equals |eventHandler|'s <a spec="html">listener</a>, then set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventHandler|'s <a spec="html">listener</a> value to an ECMAScript value.
           1. Otherwise, set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventListener|'s [=callback=] to an ECMAScript value.
           1. If [$IsCallable$](|callback|) is false:
               1. Let |getResult| be [=Completion=]([$Get$](|callback|), <code>handleEvent</code>).

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -51,7 +51,7 @@ spec: infra;
 spec: webidl;
     type: dfn;
         text: resolve;
-	text: idl-callback-interface
+	text: es-callback-interface
 
 spec:csp-next; type:dfn; text:enforced
 </pre>
@@ -3009,11 +3009,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. set |eventListenerList| to [=map/value=] whose [=map/key=] is <code>fetch</code> in |workerGlobalScope|'s <a>set of event types to handle</a>.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
           1. If |eventListener|'s [=callback=] is not null:
-              1. Set |callback| to an ECMAScript object coverted from |eventListener|'s [=callback=], which is [=idl-callback-interface=].
+              1. Set |callback| to an ECMAScript object coverted from |eventListener|'s [=callback=]. It is [=es-callback-interface=].
               1. If |callback| is a [=function=], and [=function body=] is not empty (i.e. either [=statement=] or [=declaration=] exist), then return false.
-              1. If |callback| does not have <code>handleEvent</code> property, then return false.
-              1. If |callback|'s <code>handleEvent</code> property is not a [=function=], then return false.
-              1. If a [=function body=] of |callback|'s <code>handleEvent</code> property is not empty (i.e. either [=statement=] or [=declaration=] exist), return false.
 
               Note: it detects something like `onfetch = () => {}`. Some sites have a fetch event listener with empty body to make them recognized as progressive web application (PWA).
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3087,7 +3087,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Set |registration| to the result of running <a>Match Service Worker Registration</a> given |storage key| and |request|'s [=request/url=].
           1. If |registration| is null or |registration|'s <a>active worker</a> is null, return null.
           1. If |request|'s [=request/destination=] is not {{RequestDestination/"report"}}, set |reservedClient|'s <a>active service worker</a> to |registration|'s <a>active worker</a>.
-          1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and the result of running the [=Skippable Fetch Handler=] algorithm with |registration|'s [=active worker=] is false then:
+          1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
 
               Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.
 
@@ -3122,7 +3122,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If the result of running the [=Should Skip Event=] algorithm with "fetch" and |activeWorker| is true, then:
           1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
           1. Return null.
-      1. If the result of running the [=Skippable Fetch Handler=] algorithm with |activeWorker| is true, then:
+      1. If |activeWorker|'s [=all fetch listeners are empty flag=] is set:
           1. [=In parallel=]:
               1. If |activeWorker|'s [=service worker/state=] is "activating", then wait for |activeWorker|'s [=service worker/state=] to become "activated".
               1. Run the [=Run Service Worker=] algorithm with |activeWorker|.
@@ -3181,17 +3181,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           2. Return a [=network error=].
       1. If |eventHandled| is not null, then [=resolve=] |eventHandled|.
       1. Return |response|.
-  </section>
-
-  <section algorithm>
-    <h3 id="skippable-fetch-handler-algorithm"><dfn>Skippable Fetch Handler</dfn></h3>
-      : Input
-      :: |serviceWorker|, a [=/service worker=]
-      : Output
-      :: a boolean
-
-      1. If |serviceWorker| has [=all fetch listeners are empty flag=] and set, then the user agent return true.
-      1. Return false.
   </section>
 
   <section algorithm>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3007,13 +3007,13 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: a boolean
 
       1. If |workerGlobalScope|'s [=set of event types to handle=] does not [=set/contain=] <code>fetch</code>, then return true.
-      1. Let |eventHandler| be |workerGlobalScope|'s <a spec="html">event handler map</a>["onfetch"]'s value.
+      1. Let |eventHandler| be |workerGlobalScope|'s [=EventTarget/event handler map=]["onfetch"]'s value.
       1. Let |eventListenerList| be an empty [=list=].
       1. [=list/For each=] |eventListener| of |workerGlobalScope|'s [=event listener list=]:
           1. If |eventListener|'s <a spec="dom">type</a> is "<code>fetch</code>", then [=list/append=] |eventListener| to |eventListenerList|.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
           1. If |eventListener|'s [=event listener/callback=] is null, then [=continue=].
-          1. If |eventHandler| is not null, and |eventListener| equals |eventHandler|'s <a spec="html">listener</a>, then set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventHandler|'s <a spec="html">listener</a> value to an ECMAScript value.
+          1. If |eventHandler| is not null, and |eventListener| equals |eventHandler|'s [=event handler/listener=], then set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventHandler|'s [=event handler/listener=] value to an ECMAScript value.
           1. Otherwise, set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventListener|'s [=callback=] to an ECMAScript value.
           1. If [$IsCallable$](|callback|) is false:
               1. Let |getResult| be [=Completion=]([$Get$](|callback|), <code>handleEvent</code>).

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3006,11 +3006,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |eventHandler| be |workerGlobalScope|'s [=EventTarget/event handler map=]["onfetch"]'s value.
       1. Let |eventListenerList| be an empty [=list=].
       1. [=list/For each=] |eventListener| of |workerGlobalScope|'s [=event listener list=]:
-          1. If |eventListener|'s <a spec="dom">type</a> is "<code>fetch</code>", then [=list/append=] |eventListener| to |eventListenerList|.
+          1. If |eventListener|'s [=event listener/type=] is "<code>fetch</code>", then [=list/append=] |eventListener| to |eventListenerList|.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
           1. If |eventListener|'s [=event listener/callback=] is null, then [=continue=].
           1. If |eventHandler| is not null, and |eventListener| equals |eventHandler|'s [=event handler/listener=], then set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventHandler|'s [=event handler/listener=] value to an ECMAScript value.
-          1. Otherwise, set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventListener|'s [=callback=] to an ECMAScript value.
+          1. Otherwise, set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventListener|'s [=event listener/callback=] to an ECMAScript value.
           1. If [$IsCallable$](|callback|) is false:
               1. Let |getResult| be [=Completion=]([$Get$](|callback|), <code>handleEvent</code>).
               1. If |getResult| is [=abrupt completion=], then return false.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3005,7 +3005,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: a boolean
 
-      1. If |workerGlobalScope|'s [=set of event types to handle=] does not [=set/contain=] <code>fetch</code>, then returns false.
+      1. If |workerGlobalScope|'s [=set of event types to handle=] does not [=set/contain=] <code>fetch</code>, then returns true.
       1. Let |onFetchHandler| be |workerGlobalScope|'s <code>onfetch</code> attribute.
       1. If |onFetchHandler|'s <a spec="html">listener</a> is null, then return false.
       1. Let |eventListenerList| be an empty [=list=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -34,6 +34,7 @@ spec: dom;
     type: dfn;
         text: event
         for: event listener; text: callback
+        for: event listener; text: type
 
 spec: fetch;
     type: dfn
@@ -3006,7 +3007,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: a boolean
 
       1. If |workerGlobalScope|'s <a>set of event types to handle</a> does not [=set/contain=] <code>fetch</code>, then returns false.
-      1. set |eventListenerList| to [=map/value=] whose [=map/key=] is <code>fetch</code> in |workerGlobalScope|'s <a>set of event types to handle</a>.
+      1. Let |eventListenerList| be an empty [=list=].
+      1. [=list/For each=] |eventListner| of |workerGlobalScope|'s <a>set of event types to handle</a>:
+          1. If |eventListener|'s <a spec="dom">type</a> is <code>fetch</code>, then [=list/append=] |eventListener| to |eventListenerList|.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
           1. If |eventListener|'s [=callback=] is not null:
               1. Set |callback| to the result of [=converting|convert to an ECMAScript value=] |eventListener|'s [=callback=] to an ECMAScript value.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2984,10 +2984,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. For each |eventType| of |settingsObject|'s [=environment settings object/global object=]'s associated list of <a>event listeners</a>' event types:
                   1. [=set/Append=] |eventType| to |workerGlobalScope|'s associated [=ServiceWorkerGlobalScope/service worker=]'s <a>set of event types to handle</a>.
 
-                  Note: If the global object's associated list of event listeners does not have any event listener added at this moment, the service worker's <a>set of event types to handle</a> remains an empty set.
+                  Note: If the global object's associated list of event listeners does not have any event listener added at this moment, the service worker's [=set of event types to handle=] remains an empty set.
 
               1. Set |script|'s <a>has ever been evaluated flag</a>.
-              1. If the [=Empty Handler identification=] algorithm with |workerGlobalScope| returns true, the [=all fetch listeners are empty flag=] is set.
+              1. If the [=Empty Fetch Handler identification=] algorithm with |workerGlobalScope| returns true, the [=all fetch listeners are empty flag=] may be set.
 
               Note: the user agents are encouraged to show warnings that the event listeners are no-op, and their executions can be skipped.
 
@@ -2999,16 +2999,16 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section algorithm>
-    <h3 id="empty-handler-identification-algorithm"><dfn>Empty Handler identification</dfn></h3>
+    <h3 id="empty-fetch-handler-identification-algorithm"><dfn>Empty Fetch Handler identification</dfn></h3>
 
       : Input
       :: |workerGlobalScope|, a [=service worker/global object=].
       : Output
       :: a boolean
 
-      1. If |workerGlobalScope|'s <a>set of event types to handle</a> does not [=set/contain=] <code>fetch</code>, then returns false.
+      1. If |workerGlobalScope|'s [=set of event types to handle=] does not [=set/contain=] <code>fetch</code>, then returns false.
       1. Let |eventListenerList| be an empty [=list=].
-      1. [=list/For each=] |eventListener| of |workerGlobalScope|'s <a>set of event types to handle</a>:
+      1. [=list/For each=] |eventListener| of |workerGlobalScope|'s [=set of event types to handle=]:
           1. If |eventListener|'s <a spec="dom">type</a> is <code>fetch</code>, then [=list/append=] |eventListener| to |eventListenerList|.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
           1. If |eventListener|'s [=callback=] is not null:
@@ -3083,7 +3083,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Set |registration| to the result of running <a>Match Service Worker Registration</a> given |storage key| and |request|'s [=request/url=].
           1. If |registration| is null or |registration|'s <a>active worker</a> is null, return null.
           1. If |request|'s [=request/destination=] is not {{RequestDestination/"report"}}, set |reservedClient|'s <a>active service worker</a> to |registration|'s <a>active worker</a>.
-          1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s <a>set of event types to handle</a> [=set/contains=] <code>fetch</code>, and the result of running the [=Skippable Fetch Handler=] algorithm with |registration|'s [=active worker=] is false then:
+          1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and the result of running the [=Skippable Fetch Handler=] algorithm with |registration|'s [=active worker=] is false then:
 
               Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.
 
@@ -3186,7 +3186,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: a boolean
 
-      1. If |serviceWorker| has [=all fetch listeners are empty flag=] and set, then the user agent *may* return true.
+      1. If |serviceWorker| has [=all fetch listeners are empty flag=] and set, then the user agent return true.
       1. Return false.
   </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -43,6 +43,7 @@ spec: infra;
 spec: webidl;
     type: dfn;
         text: resolve;
+        text: es-callback-interface;
 </pre>
 
 <pre class="anchors">
@@ -71,6 +72,7 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
         text: Cyclic Module Record; url: sec-cyclic-module-records
         text: function; url: sec-function-definitions
         text: function bodies; url: prod-FunctionBody
+        text: object object; url: sec-object-objects
         url: sec-ecmascript-language-statements-and-declarations
             text: statement
             text: declaration
@@ -126,7 +128,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
 spec: dom; urlPrefix: https://dom.spec.whatwg.org/
     type: dfn
-        text: event listeners; url: concept-event-listener
         text: callback; url: event-listener-callback
 
 </pre>
@@ -2982,10 +2983,10 @@ spec: dom; urlPrefix: https://dom.spec.whatwg.org/
               1. For each |eventType| of |settingsObject|'s [=environment settings object/global object=]'s associated list of <a>event listeners</a>' event types:
                   1. [=set/Append=] |eventType| to |workerGlobalScope|'s associated [=ServiceWorkerGlobalScope/service worker=]'s <a>set of event types to handle</a>.
 
-                  Note: If the global object's associated list of event listeners does not have any event listener added at this moment, the service worker's set of event types to handle remains an empty set.
+                  Note: If the global object's associated list of event listeners does not have any event listener added at this moment, the service worker's <a>set of event types to handle</a> remains an empty set.
 
               1. Set |script|'s <a>has ever been evaluated flag</a>.
-              1. If the [=No-Op Handler identification=] algorithm with |serviceWorker| returns true, the [=all fetch listeners are empty flag=] is set.
+              1. If the [=Empty Handler identification=] algorithm with |serviceWorker| returns true, the [=all fetch listeners are empty flag=] is set.
 
               Note: the user agents are encouraged to show warnings that the event listeners are no-op, and their executions can be skipped.
 
@@ -2997,20 +2998,28 @@ spec: dom; urlPrefix: https://dom.spec.whatwg.org/
   </section>
 
   <section algorithm>
-    <h3 id="empty-handler-identification-algorithm"><dfn>No-Op Handler identification</dfn></h3>
+    <h3 id="empty-handler-identification-algorithm"><dfn>Empty Handler identification</dfn></h3>
 
       : Input
       :: |serviceWorker|, a [=/service worker=]
       : Output
       :: a boolean
 
-      1. If |serviceWorker|'s set of event types to handle does not contain "fetch", then returns false.
-      1. If one of fetch [=event listeners=] in |serviceWorker| is not a [=function=], then return false.
-      1. If the [=callback=]'s [=function bodies=] of all fetch event listener in |serviceWorker| are empty (no [=statement=] or [=declaration=] exist), then the user agent return true.
+      1. If |serviceWorker|'s <a>set of event types to handle</a> does not [=set/contain=] <code>fetch</code>, then returns false.
+      1. set |eventListenerList| to <a>event listeners</a> for |serviceWorker|'s <a>set of event types to handle</a> <code>fetch</code>.
+      1. [=list/For each=] |eventListener| of |eventListenerList|:
+          1. If |eventListener| is null, then return false.
+          1. If |eventListener| is not [=callback=], then return false.
+          1. If |eventListener|'s [=callback=] is not [=es-callback-interface=], then return false.
+          1. If |eventListener|'s [=callback=] is not a [=function=]:
+              1. If |eventListener| is not an [=object object=], return false.
+              1. If |eventListener|'s properties does not contains <code>handleEvent</code> , return false.
+              1. If |evnetListner| <code>handleEvent</code> property's [=function bodies=] is not empty (i.e. either [=statement=] or [=declaration=] exist), return false.
+          1. If |evnetListner| [=callback=]'s [=function bodies=] is not empty (i.e. either [=statement=] or [=declaration=] exist), return false.
 
-      Note: it detects something like `onfetch = () => {}`. Some sites have a fetch event listener with empty body to make them recognized as progressive web application (PWA).
+          Note: it detects something like `onfetch = () => {}`. Some sites have a fetch event listener with empty body to make them recognized as progressive web application (PWA).
 
-      1. Return false.
+      1. Return true.
 
   </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -51,7 +51,6 @@ spec: infra;
 spec: webidl;
     type: dfn;
         text: resolve;
-        text: es-callback-interface;
 
 spec:csp-next; type:dfn; text:enforced
 </pre>
@@ -65,6 +64,8 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
     type: abstract-op
         text: NormalCompletion; url: sec-normalcompletion
         text: ThrowCompletion; url: sec-throwcompletion
+        text: IsCallable; url: sec-iscallable
+        text: Get; url: sec-get-o-p
     type: dfn
         text: Assert; url: sec-algorithm-conventions
         text: [[Call]]; url: sec-ecmascript-function-objects-call-thisargument-argumentslist
@@ -80,10 +81,7 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
         text: Completion; url: sec-completion-record-specification-type
         text: Module Record; url: sec-abstract-module-records
         text: Cyclic Module Record; url: sec-cyclic-module-records
-        text: function; url: sec-function-definitions
         text: function body; url: prod-FunctionBody
-        text: IsCallable; url: sec-iscallable
-        text: Get; url: sec-get-o-p
         url: sec-ecmascript-language-statements-and-declarations
             text: statement
             text: declaration
@@ -3011,13 +3009,13 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. set |eventListenerList| to [=map/value=] whose [=map/key=] is <code>fetch</code> in |workerGlobalScope|'s <a>set of event types to handle</a>.
       1. [=list/For each=] |eventListener| of |eventListenerList|:
           1. If |eventListener|'s [=callback=] is not null:
-              1. Set |callback| to an ECMAScript object coverted from |eventListener|'s [=callback=]. It is [=es-callback-interface=].
-              1. If [=IsCallable=](|callback|) is false:
-                  1. Let |getResult| be [=Completion=]([=Get=](|callback|, <code>handleEvent</code>).
+              1. Set |callback| to an ECMAScript object coverted from |eventListener|'s [=callback=].
+              1. If [$IsCallable$](|callback|) is false:
+                  1. Let |getResult| be [=Completion=]([$Get$](|callback|), <code>handleEvent</code>).
                   1. If |getResult| is [=abrupt completion=], then return false.
                   1. Set |callback| to |getResult|.
-                  1. If [=IsCallable=](|callback|) is false, then return false.
-              1. If |callback| is a [=function=], and [=function body=] is not empty (i.e. either [=statement=] or [=declaration=] exist), then return false.
+              1. If [$IsCallable$](|callback|) is false, then return false.
+              1. If |callback|'s [=function body=] is not empty (i.e. either a [=statement=] or [=declaration=] exist), then return false.
 
               Note: it detects something like `onfetch = () => {}`. Some sites have a fetch event listener with empty body to make them recognized as progressive web application (PWA).
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3188,7 +3188,7 @@ spec: dom; urlPrefix: https://dom.spec.whatwg.org/
       : Output
       :: a boolean
 
-      1. If |serviceworker| has |all fetch listeners are empty flag| and set, then the user agent *may* return true.
+      1. If |serviceWorker| has [=all fetch listeners are empty flag=] and set, then the user agent *may* return true.
       1. Return false.
   </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -191,7 +191,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A [=/service worker=] has an associated <dfn>start status</dfn> which can be null or a [=Completion=]. It is initially null.
 
-    A [=/service worker=] has an associated <dfn>all fetch listeners are no-op flag</dfn>. It is initially null.
+    A [=/service worker=] has an associated <dfn>all fetch listeners are empty flag</dfn>. It is initially unset.
 
     A [=/service worker=] is said to be <dfn>running</dfn> if its [=event loop=] is running.
 
@@ -2975,7 +2975,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   Note: If the global object's associated list of event listeners does not have any event listener added at this moment, the service worker's set of event types to handle remains an empty set.
 
               1. Set |script|'s <a>has ever been evaluated flag</a>.
-              1. If the [=No-Op Handler identification=] algorithm with |serviceWorker| returns true, the [=all fetch listeners are no-op flag=] is set.
+              1. If the [=No-Op Handler identification=] algorithm with |serviceWorker| returns true, the [=all fetch listeners are empty flag=] is set.
           1. Run the <a>responsible event loop</a> specified by |settingsObject| until it is destroyed.
           1. Empty |workerGlobalScope|'s <a>list of active timers</a>.
       1. Wait for |serviceWorker| to be [=running=], or for |startFailed| to be true.
@@ -2984,19 +2984,19 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section algorithm>
-    <h3 id="no-op-handler-identification-algorithm"><dfn>No-Op Handler identification</dfn></h3>
+    <h3 id="empty-handler-identification-algorithm"><dfn>No-Op Handler identification</dfn></h3>
 
       : Input
       :: |serviceWorker|, a [=/service worker=]
       : Output
       :: a boolean
 
-      1. If |service worker|'s set of event types to handle does not contain "fetch", then returns false.
+      1. If |serviceWorker|'s set of event types to handle does not contain "fetch", then returns false.
       1. If the callback's function bodies (https://tc39.es/ecma262/#prod-FunctionBody) of all fetch event listener in |service worker| are empty, then the user agent *may* return true.
 
       Note: it detects something like `onfetch = () => {}`. Some sites have a fetch event listener with empty body to make them recognized as progressive web application (PWA).
 
-      1. return false.
+      1. Return false.
 
   </section>
 
@@ -3097,9 +3097,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If the result of running the [=Should Skip Event=] algorithm with "fetch" and |activeWorker| is true, then:
           1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
           1. Return null.
-      1. If the result of running [=Skippable Fetch Handler=] algorithm with |activeWorker| is true, then:
-          1. run the following steps [=in parallel=]:
-              1. If |activeWorker|'s state is "activating", wait for |activeWorker|'s state to become "activated".
+      1. If the result of running the [=Skippable Fetch Handler=] algorithm with |activeWorker| is true, then:
+          1. [=In parallel=]:
+              1. If |activeWorker|'s [=service worker/state=] is "activating", then wait for |activeWorker|'s [=service worker/state=] to become "activated".
               1. Run the [=Run Service Worker=] algorithm with |activeWorker|.
               1. If |shouldSoftUpdate| is true, then run the [=Soft Update algorithm=] with |registration|.
           1. Return null.
@@ -3165,7 +3165,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: a boolean
 
-      1. If |serviceworker| has |all fetch listeners are no-op flag| and set, then the user agent *may* return true.
+      1. If |serviceworker| has |all fetch listeners are empty flag| and set, then the user agent *may* return true.
       1. Return false.
   </section>
 


### PR DESCRIPTION
Following on from https://github.com/w3c/ServiceWorker/pull/1672


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/pull/1674.html" title="Last updated on Mar 22, 2023, 3:56 PM UTC (a52a9bf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1674/25f60ac...a52a9bf.html" title="Last updated on Mar 22, 2023, 3:56 PM UTC (a52a9bf)">Diff</a>