### PR TITLE
Avoid executing the code in the All Fetch Listeners Are Empty algorithm.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3009,7 +3009,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Let |callback| be null.
           1. If |eventHandler| is not null and |eventListenerCallback| equals |eventHandler|'s [=event handler/listener=]'s [=event listener/callback=], then set |callback| to the result of [=convert to an ECMAScript value|converting to an ECMAScript value=] |eventHandler|'s [=event handler/value=].
           1. Otherwise, set |callback| to the result of [=convert to an ECMAScript value|converting to an ECMAScript value=] |eventListenerCallback|.
-          1. If [$IsCallable$](|callback|) is false, then return false.
           1. If [$IsCallable$](|callback|) is false, or |callback|'s [=function body=] is not empty (i.e. either a [=statement=] or [=declaration=] exist), then return false.
 
           Note: This detects "<code>fetch</code>" listeners like `() => {}`. Some sites have a fetch event listener with empty body to make them recognized by Chromium as a progressive web application (PWA).

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3011,7 +3011,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Otherwise, set |callback| to the result of [=convert to an ECMAScript value|converting to an ECMAScript value=] |eventListenerCallback|.
           1. If [$IsCallable$](|callback|) is false, then return false.
 
-          Note: This deliberately ignores the result of [=Completion=]([$Get$](|callback|), <code>handleEvent</code>) because running getters during the check adds a bunch of complexity.
+              Note: [=Event listener/Callback=] objects that use {{handleEvent}} are assumed to be non-empty. This avoids calling the {{handleEvent}} getters, which could modify the event listeners during this check.
 
           1. If |callback|'s [=function body=] is not empty (i.e. either a [=statement=] or [=declaration=] exist), then return false.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3009,10 +3009,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Let |callback| be null.
           1. If |eventHandler| is not null and |eventListenerCallback| equals |eventHandler|'s [=event handler/listener=]'s [=event listener/callback=], then set |callback| to the result of [=convert to an ECMAScript value|converting to an ECMAScript value=] |eventHandler|'s [=event handler/value=].
           1. Otherwise, set |callback| to the result of [=convert to an ECMAScript value|converting to an ECMAScript value=] |eventListenerCallback|.
-          1. If [$IsCallable$](|callback|) is false:
-              1. Let |getResult| be [=Completion=]([$Get$](|callback|), <code>handleEvent</code>).
-              1. If |getResult| is [=abrupt completion=], then return false.
-              1. Set |callback| to |getResult|.
+          1. If [$IsCallable$](|callback|) is false, then return false.
           1. If [$IsCallable$](|callback|) is false, or |callback|'s [=function body=] is not empty (i.e. either a [=statement=] or [=declaration=] exist), then return false.
 
           Note: This detects "<code>fetch</code>" listeners like `() => {}`. Some sites have a fetch event listener with empty body to make them recognized by Chromium as a progressive web application (PWA).

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3009,7 +3009,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Let |callback| be null.
           1. If |eventHandler| is not null and |eventListenerCallback| equals |eventHandler|'s [=event handler/listener=]'s [=event listener/callback=], then set |callback| to the result of [=convert to an ECMAScript value|converting to an ECMAScript value=] |eventHandler|'s [=event handler/value=].
           1. Otherwise, set |callback| to the result of [=convert to an ECMAScript value|converting to an ECMAScript value=] |eventListenerCallback|.
-          1. If [$IsCallable$](|callback|) is false, or |callback|'s [=function body=] is not empty (i.e. either a [=statement=] or [=declaration=] exist), then return false.
+          1. If [$IsCallable$](|callback|) is false, then return false.
+
+          Note: This deliberately ignores the result of [=Completion=]([$Get$](|callback|), <code>handleEvent</code>) because running getters during the check adds a bunch of complexity.
+
+          1. If |callback|'s [=function body=] is not empty (i.e. either a [=statement=] or [=declaration=] exist), then return false.
 
           Note: This detects "<code>fetch</code>" listeners like `() => {}`. Some sites have a fetch event listener with empty body to make them recognized by Chromium as a progressive web application (PWA).
 


### PR DESCRIPTION
This is for stop calling Get for detecting an empty fetch listener.  Benefit of the change is that it won't execute the Javascript, and drawback is that it just ignores an empty fetch listener defined as a handleEvent property.  Since it is rare to configure the fetch event listener with the handleEvent property, not detecting empty function body for it should be negligible coverage reduction.

+@domenic


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1676.html" title="Last updated on Apr 3, 2023, 10:09 AM UTC (2ea42ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1676/4b38437...yoshisatoyanagisawa:2ea42ac.html" title="Last updated on Apr 3, 2023, 10:09 AM UTC (2ea42ac)">Diff</a>