### PR TITLE
Use an AbortController instead of signaling abort on AbortSignal

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3131,7 +3131,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. [=Queue a task=] |task| to run the following substeps:
               1. Let |e| be the result of <a>creating an event</a> with {{FetchEvent}}.
               1. Let |controller| be a [=new=] {{AbortController}} object with |workerRealm|.
-              1. Let |requestObject| be the result of [=Request/creating=] a {{Request}} object, given |request|, a new {{Headers}} object's [=guard=] which is "`immutable`", |controller|.{{AbortController/signal}}, and |workerRealm|.
+              1. Let |requestObject| be the result of [=Request/creating=] a {{Request}} object, given |request|, a new {{Headers}} object's [=guard=] which is "`immutable`", |controller|'s [=AbortController/signal=], and |workerRealm|.
               1. Initialize |e|’s {{Event/type}} attribute to {{fetch!!event}}.
               1. Initialize |e|’s {{Event/cancelable}} attribute to true.
               1. Initialize |e|’s {{FetchEvent/request}} attribute to |requestObject|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3130,8 +3130,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Set |eventHandled| to [=a new promise=] in |workerRealm|.
           1. [=Queue a task=] |task| to run the following substeps:
               1. Let |e| be the result of <a>creating an event</a> with {{FetchEvent}}.
-              1. Let |signal| be a [=new=] {{AbortSignal}} object with |workerRealm|.
-              1. Let |requestObject| be the result of [=Request/creating=] a {{Request}} object, given |request|, a new {{Headers}} object's [=guard=] which is "`immutable`", |signal|, and |workerRealm|.
+              1. Let |controller| be a [=new=] {{AbortController}} object with |workerRealm|.
+              1. Let |requestObject| be the result of [=Request/creating=] a {{Request}} object, given |request|, a new {{Headers}} object's [=guard=] which is "`immutable`", |controller|.{{AbortController/signal}}, and |workerRealm|.
               1. Initialize |e|’s {{Event/type}} attribute to {{fetch!!event}}.
               1. Initialize |e|’s {{Event/cancelable}} attribute to true.
               1. Initialize |e|’s {{FetchEvent/request}} attribute to |requestObject|.
@@ -3156,7 +3156,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If |controller| [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then:
                   1. Let |deserializedError| be a "{{AbortError}}" {{DOMException}}.
                   1. If |controller|'s [=fetch controller/serialized abort reason=] is non-null, set |deserializedError| to the result of calling [$StructuredDeserialize$] with |controller|'s [=fetch controller/serialized abort reason=] and |workerRealm|. If that threw an exception or returns undefined, then set |deserializedError| to a "{{AbortError}}" {{DOMException}}.
-                  1. [=Queue a task=] to [=AbortSignal/signal abort=] on |signal| with |deserializedError|.
+                  1. [=Queue a task=] to [=AbortController/signal abort=] on |controller| with |deserializedError|.
 
              If |task| is discarded, set |handleFetchFailed| to true.
 


### PR DESCRIPTION
For https://github.com/whatwg/dom/issues/1194. Replaces the AbortSignal created inside of "Handle Fetch" with an AbortController, signaling abort on it instead and passing its signal when creating a Request.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaseley/ServiceWorker/pull/1683.html" title="Last updated on May 30, 2023, 8:41 PM UTC (3dd9c2c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1683/e8e2b81...shaseley:3dd9c2c.html" title="Last updated on May 30, 2023, 8:41 PM UTC (3dd9c2c)">Diff</a>