### PR TITLE
Editorial: correct rendering of nested algo steps

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -961,10 +961,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
         1. Let |promise| be [=a new promise=].
         1. Run the following steps [=in parallel=]:
-          1. Let |registration| be [=this=]'s associated [=/service worker registration=].
-          1. If |registration|'s [=active worker=] is null, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
-          1. Set |registration|'s [=navigation preload enabled flag=].
-          1. Resolve |promise| with undefined.
+            1. Let |registration| be [=this=]'s associated [=/service worker registration=].
+            1. If |registration|'s [=active worker=] is null, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
+            1. Set |registration|'s [=navigation preload enabled flag=].
+            1. Resolve |promise| with undefined.
         1. Return |promise|.
     </section>
 
@@ -975,10 +975,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
         1. Let |promise| be [=a new promise=].
         1. Run the following steps [=in parallel=]:
-          1. Let |registration| be [=this=]'s associated [=/service worker registration=].
-          1. If |registration|'s [=active worker=] is null, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
-          1. Unset |registration|'s [=navigation preload enabled flag=].
-          1. Resolve |promise| with undefined.
+            1. Let |registration| be [=this=]'s associated [=/service worker registration=].
+            1. If |registration|'s [=active worker=] is null, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
+            1. Unset |registration|'s [=navigation preload enabled flag=].
+            1. Resolve |promise| with undefined.
         1. Return |promise|.
     </section>
 
@@ -989,10 +989,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
         1. Let |promise| be [=a new promise=].
         1. Run the following steps [=in parallel=]:
-          1. Let |registration| be [=this=]'s associated [=/service worker registration=].
-          1. If |registration|'s [=active worker=] is null, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
-          1. Set |registration|'s [=navigation preload header value=] to |value|.
-          1. Resolve |promise| with undefined.
+            1. Let |registration| be [=this=]'s associated [=/service worker registration=].
+            1. If |registration|'s [=active worker=] is null, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
+            1. Set |registration|'s [=navigation preload header value=] to |value|.
+            1. Resolve |promise| with undefined.
         1. Return |promise|.
     </section>
 
@@ -1003,11 +1003,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
         1. Let |promise| be [=a new promise=].
         1. Run the following steps [=in parallel=]:
-          1. Let |registration| be [=this=]'s associated [=/service worker registration=].
-          1. Let |state| be a new {{NavigationPreloadState}} dictionary.
-          1. If |registration|'s [=navigation preload enabled flag=] is set, set |state|["{{NavigationPreloadState/enabled}}"] to true.
-          1. Set |state|["{{NavigationPreloadState/headerValue}}"] to |registration|'s [=navigation preload header value=].
-          1. Resolve |promise| with |state|.
+            1. Let |registration| be [=this=]'s associated [=/service worker registration=].
+            1. Let |state| be a new {{NavigationPreloadState}} dictionary.
+            1. If |registration|'s [=navigation preload enabled flag=] is set, set |state|["{{NavigationPreloadState/enabled}}"] to true.
+            1. Set |state|["{{NavigationPreloadState/headerValue}}"] to |registration|'s [=navigation preload header value=].
+            1. Resolve |promise| with |state|.
         1. Return |promise|.
     </section>
 


### PR DESCRIPTION
Bikeshed version 3.14.5 (the lastest at the time of writing) requires four spaces of indentation for a list item to be rendered as part of a nested list. This specification inconsistently uses just two spaces of indentation, resulting innacurracies in the rendered document.

For instances, [the enable()
method](https://w3c.github.io/ServiceWorker/#navigation-preload-manager-enable) appears as a flat list of sequential steps:

>  1. Let promise be a new promise.
>  2. Run the following steps in parallel:
>  3. Let registration be this's associated service worker registration.
>  4. If registration’s active worker is null, reject promise with an "InvalidStateError" DOMException, and abort these steps.
>  5. Set registration’s navigation preload enabled flag.
>  6. Resolve promise with undefined.
>  7. Return promise.

Insert additional spaces so that nested lists are rendered appropriately in the published document.