### PR TITLE
ServiceWorker static routing API

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,9 +1,10 @@
 # Create a file called .github/workflows/auto-publish.yml
 name: CI
 on:
-  pull_request: {}
+  pull_request:
+    branches: [static_routing_api]
   push:
-    branches: [main]
+    branches: [static_routing_api]
 jobs:
   main:
     name: Build, Validate and Deploy Locally

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,10 +1,9 @@
 # Create a file called .github/workflows/auto-publish.yml
 name: CI
 on:
-  pull_request:
-    branches: [static_routing_api]
+  pull_request: {}
   push:
-    branches: [static_routing_api]
+    branches: [main]
 jobs:
   main:
     name: Build, Validate and Deploy Locally

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3162,7 +3162,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |preloadResponse| be a new [=promise=].
       1. Let |workerRealm| be null.
       1. Let |timingInfo| be a new [=service worker timing info=].
-      1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is null.
       1. Assert: |request|'s [=request/destination=] is not "<code>serviceworker</code>".
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
@@ -3212,9 +3211,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. Return |response|.
               1. Return null.
           1. Else if |source| is {{RouterSourceEnum/"race-network-and-fetch-handler"}}, and |request|'s [=request/method=] is \`<code>GET</code>\` then:
+              1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
               1. Let |queue| be an empty [=queue=] of [=/response=].
               1. Let |raceFetchController| be null.
-              1. Set |raceResponse|'s [=race response/value=] to "<code>pending</code>".
+              1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
               1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                   1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                       1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
@@ -3254,7 +3254,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
               1. [=fetch controller/Abort=] |preloadFetchController| with |deserializedError|.
       1. Else, resolve |preloadResponse| with undefined.
-      1. Return the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
+      1. Return the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and null.
   </section>
 
   <section algorithm>
@@ -3267,7 +3267,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: |workerRealm|, a [=relevant realm=] of the [=service worker/global object=]
       :: |reservedClient|, a [=request/reserved client=]
       :: |preloadResponse|, a [=promise=]
-      :: |raceResponse|, a [=race response=]
+      :: |raceResponse|, a [=race response=] or null
       : Output
       :: a [=/response=]
 
@@ -3995,11 +3995,17 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: a [=/response=] or null
 
-      1. If |request|'s [=request/reserved client=] is null, return null.
-      1. Let |storage key| be the result of running [=obtain a storage key=] given |request|'s [=request/reserved client=].
-      1. Let |registration| be the result of running <a>Match Service Worker Registration</a> given |storage key| and |request|'s [=request/url=].
-      1. If |registration| is null or |registration|'s <a>active worker</a> is null, return null.
-      1. Else, let |activeWorker| be |registration|'s <a>active worker</a>.
+      1. Let |registration| be null.
+      1. If |request| is a [=non-subresource request=], then:
+          1. If |request|'s [=request/reserved client=] is null, return null.
+          1. Let |storage key| be the result of running [=obtain a storage key=] given |request|'s [=request/reserved client=].
+          1. Set |registration| to the result of running [=Match Service Worker Registration=] given |storage key| and |request|'s [=request/url=].
+      1. Else if |request| is a [=subresource request=], then:
+          1. Let |client| be |request|'s [=request/client=].
+          1. If |client|'s [=active service worker=] is null, return null.
+          1. Set |registration| to |client|'s [=active service worker=]'s [=containing service worker registration=].
+      1. Otherwise, return null.
+      1. Let |activeWorker| be |registration|'s [=active worker=].
       1. Let |map| be |activeWorker|'s [=service worker/global object=]'s [=race response map=].
       1. If |map|[|request|] [=map/exists=], then:
         1. Let |entry| be |map|[|request|].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1563,6 +1563,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       dictionary RouterCondition {
         URLPatternCompatible urlPattern;
+        USVString requestMethod;
+        RequestMode requestMode;
+        RequestDestination requestDestination;
         RunningStatus runningStatus;
       };
 
@@ -3251,6 +3254,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               Note: Since running a user-defined regular expression has a security concern, it is prohibited.
 
           1. Set |hasCondition| to true.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"] [=map/exists=], set |hasCondition| to true.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"] [=map/exists=], set |hasCondition| to true.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"] [=map/exists=], set |hasCondition| to true.
       1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], set |hasCondition| to true.
       1. Return |hasCondition|.
   </section>
@@ -3271,6 +3277,15 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
               1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
               1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
+          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"] [=map/exists=], then:
+              1. Let |method| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"].
+              1. If |request|'s [=request/method] is not |method|, [=continue=]
+          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"] [=map/exists=], then:
+              1. Let |mode| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"].
+              1. If |request|'s [=request/mode] is not |mode|, [=continue=]
+          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"] [=map/exists=], then:
+              1. Let |destination| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"].
+              1. If |request|'s [=request/destination] is not |destination|, [=continue=]
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
               1. Let |runningStatus| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"].
               1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], [=continue=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3281,7 +3281,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: a boolean
 
-      Note: if there are multiple conditions, all conditions will be matched to return the source.
+      Note: if there are multiple conditions (e.g. `urlPattern`, `runningStatus`, and `requestMethod` are set), all conditions will be matched to return true.
 
       1. If |condition|["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
           1. Let |rawPattern| be |condition|["{{RouterCondition/urlPattern}}"].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1571,8 +1571,14 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         sequence&lt;RouterCondition&gt; _or;
       };
 
+      typedef (RouterSourceDict or RouterSourceEnum) RouterSource;
+
+      dictionary RouterSourceDict {
+        DOMString cacheName;
+      };
+
       enum RunningStatus { "running", "not-running" };
-      enum RouterSource { "cache", "fetch-event", "network" };
+      enum RouterSourceEnum { "cache", "fetch-event", "network" };
     </pre>
 
     <section>
@@ -1588,7 +1594,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1.  For each |rule| of |rules|:
             1. If running [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, [=throw=] a {{TypeError}}.
             1. Append |rule| to |routerRules|.
-        1. If |routerRules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSource/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, [=throw=] a {{TypeError}}.
+        1. If |routerRules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSourceEnum/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, [=throw=] a {{TypeError}}.
         1. Set |serviceWorker|'s [=service worker/list of router rules=] to |routerRules|.
 
     </section>
@@ -3136,15 +3142,18 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |activeWorker| be |registration|'s <a>active worker</a>.
       1. If |activeWorker|'s [=service worker/list of router rules=] is [=list/is not empty=]:
           1. Let |source| be the result of running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
-          1. If |source| is {{RouterSource/"network"}}, return null.
-          1. Else if |source| is {{RouterSource/"cache"}}, then:
-              1. Let |requestResponses| be the result of running [=Query Cache=] with |request|.
-              1. If |requestResponses| is an empty [=list=], return null.
-              1. Else:
-                  1. Let |requestResponse| be the first element of |requestResponses|.
-                  1. Let |response| be |requestResponse|'s response.
-                  1. If |client| is not null, |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |request|'s [=request/origin=], |client|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
-                  1. Return |response|.
+          1. If |source| is {{RouterSourceEnum/"network"}}, return null.
+          1. Else if |source| is {{RouterSourceEnum/"cache"}}, or |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=], then:
+              1. [=map/For each=] |cacheName| &#x2192; |cache| of the [=relevant name to cache map=]:
+                  1. If |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=] and |source|["{{RouterSourceDict/cacheName}}"] does not match |cacheName|, [=continue=].
+                  1. Let |requestResponses| be the result of running [=Query Cache=] with |request|, a new {{CacheQueryOptions}}, and |cache|.
+                  1. If |requestResponses| is an empty [=list=], return null.
+                  1. Else:
+                      1. Let |requestResponse| be the first element of |requestResponses|.
+                      1. Let |response| be |requestResponse|'s response.
+                      1. If |client| is not null, |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |request|'s [=request/origin=], |client|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
+                      1. Return |response|.
+              1. Return null.
       1. If |request| is a <a>non-subresource request</a>, |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
 
           Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3279,13 +3279,13 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"] [=map/exists=], then:
               1. Let |method| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"].
-              1. If |request|'s [=request/method] is not |method|, [=continue=]
+              1. If |request|'s [=request/method] is not |method|, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"] [=map/exists=], then:
               1. Let |mode| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"].
-              1. If |request|'s [=request/mode] is not |mode|, [=continue=]
+              1. If |request|'s [=request/mode] is not |mode|, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"] [=map/exists=], then:
               1. Let |destination| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"].
-              1. If |request|'s [=request/destination] is not |destination|, [=continue=]
+              1. If |request|'s [=request/destination] is not |destination|, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
               1. Let |runningStatus| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"].
               1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], [=continue=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1572,7 +1572,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       };
 
       enum RunningStatus { "running", "not-running" };
-      enum RouterSource { "fetch-event", "network" };
+      enum RouterSource { "cache", "fetch-event", "network" };
     </pre>
 
     <section>
@@ -3117,7 +3117,16 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
       1. Else if |registration|'s <a>active worker</a>'s [=service worker/list of router rules=] is [=list/is not empty=]:
-          1. If running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request| returns "network", return null.
+          1. Let |source| be the result of running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
+          1. If |source| is {{RouterSource/"network"}}, return null.
+          1. Else if |source| is {{RouterSource/"cache"}}, then:
+              1. Let |requestResponses| be the result of running [=Query Cache=] with |request|.
+              1. If |requestResponses| is an empty [=list=], return null.
+              1. Else:
+                  1. Let |requestResponse| be the first element of |requestResponses|.
+                  1. Let |response| be |requestResponse|'s response.
+                  1. If |client| is not null, |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |request|'s [=request/origin=], |client|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
+                  1. Return |response|.
       1. Else if |request| is a <a>non-subresource request</a>, then:
           1. If |reservedClient| is not null and is an <a>environment settings object</a>, then:
               1. If |reservedClient| is not a <a>secure context</a>, return null.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1592,7 +1592,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
     <section>
       <h4 id="register-router-method">{{InstallEvent/addRoutes(rules)|event.addRoutes(rules)}}</h4>
 
-      {{InstallEvent/addRoutes(rules)}} registers this service worker the rules to offload simple tasks that the fetch handler does.
+      Note: {{InstallEvent/addRoutes(rules)}} registers rules for this service worker to offload simple tasks that the fetch event handler ordinarily does.
 
       The <dfn method for="InstallEvent"><code>addRoutes(|rules|)</code></dfn> method steps are:
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3109,7 +3109,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Assert: |request|'s [=request/destination=] is not "<code>serviceworker</code>".
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
-      1. Else if |registration|'s <a>active worker</a>'s [=service worker/list of router rules=] is set:
+      1. Else if |registration|'s <a>active worker</a>'s [=service worker/list of router rules=] is [=list/is not empty=]:
           1. If running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request| returns "network", return null.
       1. Else if |request| is a <a>non-subresource request</a>, then:
           1. If |reservedClient| is not null and is an <a>environment settings object</a>, then:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3263,11 +3263,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If |condition|["{{RouterCondition/_or}}"] [=map/exists=], then:
           1. If |hasCondition| is true, return false.
 
-              Note: For ease of understanding the router rule, the "or" condition is mutual exclusive with other conditions.
+              Note: For ease of understanding the router rule, the "or" condition is mutually exclusive with other conditions.
 
-          1. Let |or conditions| be |condition|["{{RouterCondition/_or}}"].
-          1. For each |or condition| of |or conditions|:
-              1. If running [=Verify Router Condition=] algorithm with |or condition| and |serviceWorker| returns false, return false.
+          1. Let |orConditions| be |condition|["{{RouterCondition/_or}}"].
+          1. For each |orCondition| of |orConditions|:
+              1. If running [=Verify Router Condition=] algorithm with |orCondition| and |serviceWorker| returns false, return false.
           1. Set |hasCondition| to true.
       1. Return |hasCondition|.
   </section>
@@ -3301,13 +3301,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], return false.
           1. If |runningStatus| is {{RunningStatus/"not-running"}}, and |serviceWorker| is [=running=], return false.
       1. If |condition|["{{RouterCondition/_or}}"] [=map/exists=], then:
-          1. Let |or conditions| be |condition|["{{RouterCondition/_or}}"].
-          1. Let |or condition matched| be false.
-          1. For each |or condition| of |or conditions|:
-              1. If running [=Match Router Condition=] algorithm with |or condition|, |serviceWorker| and |request| returns true:
-                1. Set |or condition matched| to true.
-                1. [=break=].
-          1. If |or condition matched| is false, return false.
+          1. Let |orConditions| be |condition|["{{RouterCondition/_or}}"].
+          1. For each |orCondition| of |orConditions|:
+              1. If running [=Match Router Condition=] algorithm with |orCondition|, |serviceWorker| and |request| returns true, then return true.
+          1. Return false.
       1. Return true.
   </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3997,7 +3997,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       1. If |request|'s [=request/reserved client=] is null, return null.
       1. Let |storage key| be the result of running [=obtain a storage key=] given |request|'s [=request/reserved client=].
-      1. Let |registration| be the result of running <a>Match Service Worker Registration</a> given |storage key| and |url|.
+      1. Let |registration| be the result of running <a>Match Service Worker Registration</a> given |storage key| and |request|'s [=request/url=].
       1. If |registration| is null or |registration|'s <a>active worker</a> is null, return null.
       1. Else, let |activeWorker| be |registration|'s <a>active worker</a>.
       1. Let |map| be |activeWorker|'s [=service worker/global object=]'s [=race response map=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3116,17 +3116,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Assert: |request|'s [=request/destination=] is not "<code>serviceworker</code>".
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
-      1. Else if |registration|'s <a>active worker</a>'s [=service worker/list of router rules=] is [=list/is not empty=]:
-          1. Let |source| be the result of running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
-          1. If |source| is {{RouterSource/"network"}}, return null.
-          1. Else if |source| is {{RouterSource/"cache"}}, then:
-              1. Let |requestResponses| be the result of running [=Query Cache=] with |request|.
-              1. If |requestResponses| is an empty [=list=], return null.
-              1. Else:
-                  1. Let |requestResponse| be the first element of |requestResponses|.
-                  1. Let |response| be |requestResponse|'s response.
-                  1. If |client| is not null, |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |request|'s [=request/origin=], |client|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
-                  1. Return |response|.
       1. Else if |request| is a <a>non-subresource request</a>, then:
           1. If |reservedClient| is not null and is an <a>environment settings object</a>, then:
               1. If |reservedClient| is not a <a>secure context</a>, return null.
@@ -3138,28 +3127,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Set |registration| to the result of running <a>Match Service Worker Registration</a> given |storage key| and |request|'s [=request/url=].
           1. If |registration| is null or |registration|'s <a>active worker</a> is null, return null.
           1. If |request|'s [=request/destination=] is not {{RequestDestination/"report"}}, set |reservedClient|'s <a>active service worker</a> to |registration|'s <a>active worker</a>.
-          1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
-
-              Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.
-
-              1. Let |preloadRequest| be the result of [=request/cloning=] the request |request|.
-              1. Let |preloadRequestHeaders| be |preloadRequest|'s [=request/header list=].
-              1. Let |preloadResponseObject| be a new {{Response}} object associated with a new {{Headers}} object whose [=guard=] is "`immutable`".
-              1. [=header list/Append=] to |preloadRequestHeaders| a new [=header=] whose [=header/name=] is \`<code>Service-Worker-Navigation-Preload</code>\` and [=header/value=] is |registration|'s [=navigation preload header value=].
-              1. Set |preloadRequest|'s [=service-workers mode=] to "`none`".
-              1. Let |preloadFetchController| be null.
-              1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
-                  1. Set |preloadFetchController| to the result of [=Fetch|fetching=] |preloadRequest|.
-
-                      To [=fetch/processResponse=] for |navigationPreloadResponse|, run these substeps:
-
-                      1. If |navigationPreloadResponse|'s [=response/type=] is "`error`", reject |preloadResponse| with a `TypeError` and terminate these substeps.
-                      1. Associate |preloadResponseObject| with |navigationPreloadResponse|.
-                      1. Resolve |preloadResponse| with |preloadResponseObject|.
-              1. [=If aborted=], then:
-                  1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
-                  1. [=fetch controller/Abort=] |preloadFetchController| with |deserializedError|.
-          1. Else, resolve |preloadResponse| with undefined.
 
           Note: From this point, the [=/service worker client=] starts to <a>use</a> its <a>active service worker</a>'s <a>containing service worker registration</a>.
 
@@ -3167,6 +3134,39 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. If |client|'s <a>active service worker</a> is non-null, set |registration| to |client|'s <a>active service worker</a>'s <a>containing service worker registration</a>.
           1. Else, return null.
       1. Let |activeWorker| be |registration|'s <a>active worker</a>.
+      1. If |activeWorker|'s [=service worker/list of router rules=] is [=list/is not empty=]:
+          1. Let |source| be the result of running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
+          1. If |source| is {{RouterSource/"network"}}, return null.
+          1. Else if |source| is {{RouterSource/"cache"}}, then:
+              1. Let |requestResponses| be the result of running [=Query Cache=] with |request|.
+              1. If |requestResponses| is an empty [=list=], return null.
+              1. Else:
+                  1. Let |requestResponse| be the first element of |requestResponses|.
+                  1. Let |response| be |requestResponse|'s response.
+                  1. If |client| is not null, |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |request|'s [=request/origin=], |client|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
+                  1. Return |response|.
+      1. If |request| is a <a>non-subresource request</a>, |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
+
+          Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.
+
+          1. Let |preloadRequest| be the result of [=request/cloning=] the request |request|.
+          1. Let |preloadRequestHeaders| be |preloadRequest|'s [=request/header list=].
+          1. Let |preloadResponseObject| be a new {{Response}} object associated with a new {{Headers}} object whose [=guard=] is "`immutable`".
+          1. [=header list/Append=] to |preloadRequestHeaders| a new [=header=] whose [=header/name=] is \`<code>Service-Worker-Navigation-Preload</code>\` and [=header/value=] is |registration|'s [=navigation preload header value=].
+          1. Set |preloadRequest|'s [=service-workers mode=] to "`none`".
+          1. Let |preloadFetchController| be null.
+          1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
+              1. Set |preloadFetchController| to the result of [=Fetch|fetching=] |preloadRequest|.
+
+                  To [=fetch/processResponse=] for |navigationPreloadResponse|, run these substeps:
+
+                  1. If |navigationPreloadResponse|'s [=response/type=] is "`error`", reject |preloadResponse| with a `TypeError` and terminate these substeps.
+                  1. Associate |preloadResponseObject| with |navigationPreloadResponse|.
+                  1. Resolve |preloadResponse| with |preloadResponseObject|.
+          1. [=If aborted=], then:
+              1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
+              1. [=fetch controller/Abort=] |preloadFetchController| with |deserializedError|.
+      1. Else, resolve |preloadResponse| with undefined.
       1. Let |shouldSoftUpdate| be true if any of the following are true, and false otherwise:
           * |request| is a [=non-subresource request=].
           * |request| is a [=subresource request=] and |registration| is [=stale=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3271,7 +3271,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |shouldSoftUpdate| be true if any of the following are true, and false otherwise:
           * |request| is a [=non-subresource request=].
           * |request| is a [=subresource request=] and |registration| is [=stale=].
-      1. Let |raceResponseMap| be |activeWorker|'s [=service worker/global object=]'s [=race response map=].
       1. If the result of running the [=Should Skip Event=] algorithm with "fetch" and |activeWorker| is true, then:
           1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
           1. Return null.
@@ -3288,7 +3287,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Else:
           1. Set |workerRealm| to the [=relevant realm=] of the |activeWorker|'s [=service worker/global object=].
           1. Set |eventHandled| to [=a new promise=] in |workerRealm|.
-          1. If |raceResponse| is not null, [=map/set=] |raceResponseMap|[|request|] to |raceResponse|.
+          1. If |raceResponse| is not null, [=map/set=] |activeWorker|'s [=service worker/global object=]'s [=race response map=][|request|] to |raceResponse|.
           1. [=Queue a task=] |task| to run the following substeps:
               1. Let |e| be the result of <a>creating an event</a> with {{FetchEvent}}.
               1. Let |controller| be a [=new=] {{AbortController}} object with |workerRealm|.
@@ -3325,7 +3324,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       1. Wait for |task| to have executed or for |handleFetchFailed| to be true.
       1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
-      1. If |raceResponseMap|[|request|] [=map/exists=], [=map/remove=] |raceResponseMap|[|request|].
+      1. If |activeWorker|'s [=service worker/global object=]'s [=race response map=][|request|] [=map/exists=], [=map/remove=] |activeWorker|'s [=service worker/global object=]'s [=race response map=][|request|].
       1. If |respondWithEntered| is false, then:
           1. If |eventCanceled| is true, then:
               1. If |eventHandled| is not null, then [=reject=] |eventHandled| with a "{{NetworkError}}" {{DOMException}} in |workerRealm|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2993,9 +2993,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Input
       :: |serviceWorker|, a [=/service worker=]
       : Output
-      :: a boolean
+      :: a {{ServiceWorkerGlobalScope}} object or null
 
-      Note: This algorithm returns true if |serviceWorker| has a {{ServiceWorkerGlobalScope}} usable for a CSP check.
+      Note: This algorithm returns a {{ServiceWorkerGlobalScope}} usable for a CSP check, or null. If |serviceWorker| has an active {{ServiceWorkerGlobalScope}}, then it is returned. Otherwise, the object will be newly created.
 
       <div class="note">
         This algorithm does the minimal setup for the service worker that is necessary to create something usable for security checks like CSP and COEP. This specification ensures that this algorithm is called before any such checks are performed.
@@ -3004,11 +3004,12 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       </div>
 
       1. Let |unsafeCreationTime| be the [=unsafe shared current time=].
-      1. If |serviceWorker| is [=running=], then return true.
-      1. If |serviceWorker|'s [=service worker/state=] is "`redundant`", then return false.
-      1. If |serviceWorker|'s [=service worker/global object=] is not null, then return true.
+      1. If |serviceWorker| is [=running=], then return |serviceWorker|'s [=service worker/global object=].
+      1. If |serviceWorker|'s [=service worker/state=] is "`redundant`", then return null.
+      1. If |serviceWorker|'s [=service worker/global object=] is not null, then return |serviceWorker|'s [=service worker/global object=].
       1. Assert: |serviceWorker|'s [=start status=] is null.
       1. Let |setupFailed| be false.
+      1. Let |globalObject| be null.
       1. Let |agent| be the result of [=obtain a service worker agent|obtaining a service worker agent=], and run the following steps in that context:
           1. Let |realmExecutionContext| be the result of [=creating a new realm=] given |agent| and the following customizations:
               * For the global object, create a new {{ServiceWorkerGlobalScope}} object. Let |workerGlobalScope| be the created object.
@@ -3033,10 +3034,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/type=] to |serviceWorker|'s [=service worker/type=].
           1. Create a new {{WorkerLocation}} object and associate it with |workerGlobalScope|.
           1. If the [=run CSP initialization for a global object=] algorithm returns "<code>Blocked</code>" when executed upon |workerGlobalScope|, set |setupFailed| to true and abort these steps.
-          1. Set |serviceWorker|'s [=service worker/global object=] to |workerGlobalScope|.
-      1. Wait for |serviceWorker|'s [=service worker/global object=] is not null, or for |setupFailed| to be true.
-      1. If |setupFailed| is true, then return false.
-      1. Return true.
+          1. Set |globalObject| to |workerGlobalScope|.
+      1. Wait for |globalObject| is not null, or for |setupFailed| to be true.
+      1. If |setupFailed| is true, then return null.
+      1. Return |globalObject|.
   </section>
 
   <section algorithm>
@@ -3056,10 +3057,12 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |script| be |serviceWorker|'s [=service worker/script resource=].
       1. Assert: |script| is not null.
       1. Let |startFailed| be false.
-      1. If |serviceWorker|'s [=service worker/global object=] is null:
-          1. If run the [=Setup ServiceWorkerGlobalScope=] algorithm with |serviceWorker| returns false, then return *failure*.
-      1. Obtain agent for |serviceWorker|'s [=service worker/global object=]'s [=environment settings object/realm execution context=], and run the following steps in that context:
-          1. Let |workerGlobalScope| be |serviceWorker|'s [=service worker/global object=].
+      1. Let |workerGlobalScope| be |serviceWorker|'s [=service worker/global object=].
+      1. If |workerGlobalScope| is null:
+          1. Set |workerGlobalScope| to be the result of running the [=Setup ServiceWorkerGlobalScope=] algorithm with |serviceWorker|.
+          1. If |workerGlobalScope| is null, then return *failure*.
+          1. Set |serviceWorker|'s [=service worker/global object=] to |workerGlobalScope|.
+      1. Obtain agent for |workerGlobalScope|'s [=environment settings object/realm execution context=], and run the following steps in that context:
           1. Set |workerGlobalScope|'s [=ServiceWorkerGlobalScope/force bypass cache for import scripts flag=] if |forceBypassCache| is true.
           1. If |serviceWorker| is an <a>active worker</a>, and there are any <a>tasks</a> queued in |serviceWorker|'s <a>containing service worker registration</a>'s [=service worker registration/task queues=], <a lt="queue a task">queue</a> them to |serviceWorker|'s <a>event loop</a>'s [=/task queues=] in the same order using their original <a>task sources</a>.
           1. Let |evaluationStatus| be null.
@@ -3198,13 +3201,14 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Else:
                       1. Let |requestResponse| be the first element of |requestResponses|.
                       1. Let |response| be |requestResponse|'s response.
-                      1. If |activeWorker|'s [=service worker/global object=] is null:
-                          1. If the result of running the [=Setup ServiceWorkerGlobalScope=] algorithm with |activeWorker| is false, then return null.
+                      1. Let |globalObject| be |activeWorker|'s [=service worker/global object=].
+                      1. If |globalObject| is null:
+                          1. Set |globalObject| to the result of running [=Setup ServiceWorkerGlobalScope=] with |activeWorker|.
+                      1. If |globalObject| is null, return null.
 
-                          Note: If this step succeeds, then |activeWorker|'s [=relevant settings object=] is now ready to use.
+                      Note: This only creates a ServiceWorkerGlobalScope because CORS checks require that. It is not expected that implementations will actually create a ServiceWorkerGlobalScope here.
 
-                      1. Let |settingsObject| be |activeWorker|'s [=relevant settings object=].
-                      1. If |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |settingsObject|'s [=environment settings object/origin=], |settingsObject|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
+                      1. If |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |globalObject|'s [=environment settings object/origin=], |globalObject|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
                       1. Return |response|.
               1. Return null.
           1. Else if |source| is {{RouterSourceEnum/"race-network-and-fetch-handler"}}, and |request|'s [=request/method=] is \`<code>GET</code>\` then:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3266,14 +3266,17 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: {{RouterSource}} or null
 
       1. [=list/For each=] |rule| of |serviceWorker|'s [=service worker/list of router rules=]:
+
+          Note: if there are multiple conditions in a rule, all conditions should be matched to return the source.
+
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
               1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
               1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
               1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
               1. Let |runningStatus| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"].
-              1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], continue.
-              1. If |runningStatus| is {{RunningStatus/"not-running"}}, and |serviceWorker| is [=running=], continue.
+              1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], [=continue=].
+              1. If |runningStatus| is {{RunningStatus/"not-running"}}, and |serviceWorker| is [=running=], [=continue=].
           1. Return |rule|["{{RouterRule/source}}"].
 
       1. Return null.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -207,7 +207,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A [=/service worker=] has an associated <dfn>all fetch listeners are empty flag</dfn>. It is initially unset.
 
-    A [=/service worker=] has an associated <dfn>list of router rules</dfn>. It is initially unset.
+    A [=/service worker=] has an associated <dfn>list of router rules</dfn>. It is initially an empty [=list=].
 
     A [=/service worker=] is said to be <dfn>running</dfn> if its [=event loop=] is running.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1080,7 +1080,13 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       };
     </pre>
 
-    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn export for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]). A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for import scripts flag</dfn>. A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">race response map</dfn> which is an [=ordered map=] where the [=map/keys=] are [=/requests=] and the [=map/values=] are [=race response=]. It is initially unset.
+    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=].
+
+    A {{ServiceWorkerGlobalScope}} object has an associated <dfn export for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]).
+
+    A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for import scripts flag</dfn>. It is initially unset.
+
+    A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">race response map</dfn> which is an [=ordered map=] where the [=map/keys=] are [=/requests=] and the [=map/values=] are [=race response=].
 
     A <dfn id="dfn-race-response">race response</dfn> is a [=struct=] used to contain the network response when {{RouterSourceEnum/"race-network-and-fetch-handler"}} performs. It has a <dfn for="race response">value</dfn>, which is a [=/response=], "<code>pending</code>", or null.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3352,6 +3352,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       1. Let |baseURL| be |serviceWorker|'s [=service worker/script url=].
       1. Return the result of [=building a URLPattern from a Web IDL value=] |rawPattern| given |baseURL| and |serviceWorker|'s [=service worker/global object=]'s [=relevant realm=].
+
+      Note: Since the [=building a URLPattern from a Web IDL value=] algorithm actually do not depend on the realm, it is  fine to call the algorithm here even if the [=service worker/global object=] may not be ready.
+
   </section>
 
   <section algorithm>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -66,6 +66,7 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
         text: IsCallable; url: sec-iscallable
         text: Get; url: sec-get-o-p
     type: dfn
+        text: agent;
         text: Assert; url: sec-algorithm-conventions
         text: \[[Call]]; url: sec-ecmascript-function-objects-call-thisargument-argumentslist
         text: promise; url: sec-promise-objects
@@ -207,11 +208,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A [=/service worker=] has an associated <dfn>all fetch listeners are empty flag</dfn>. It is initially unset.
 
-    A [=/service worker=] has an associated <dfn>list of router rules</dfn>. It is initially an empty [=list=].
+    A [=/service worker=] has an associated <dfn>list of router rules</dfn> (a [=list=] of {{RouterRule}}s). It is initially an empty [=list=].
 
     A [=/service worker=] is said to be <dfn>running</dfn> if its [=event loop=] is running.
 
-    A [=/service worker=] has an associated <dfn>ServiceWorkerGlobalScope is ready</dfn>. It is initially unset.
+    A [=/service worker=] has an associated <dfn>ServiceWorkerGlobalScope is ready flag</dfn>. It is initially unset.
 
     <section>
       <h4 id="service-worker-lifetime">Lifetime</h4>
@@ -1594,10 +1595,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. Let |routerRules| be a copy of |serviceWorker|'s [=list of router rules=].
         1. If |rules| is a {{RouterRule}} dictionary, set |rules| to &#x00AB; |rules| &#x00BB;.
         1.  For each |rule| of |rules|:
-            1. If running [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, [=throw=] a {{TypeError}}.
+            1. If running [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, return [=a promise rejected with=] a {{TypeError}}.
             1. Append |rule| to |routerRules|.
-        1. If |routerRules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSourceEnum/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, [=throw=] a {{TypeError}}.
+        1. If |routerRules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSourceEnum/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, return [=a promise rejected with=] a {{TypeError}}.
         1. Set |serviceWorker|'s [=service worker/list of router rules=] to |routerRules|.
+        1. Return [=a promise resolved with=] undefined.
 
     </section>
   </section>
@@ -2987,13 +2989,13 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       <div class="note">
         This algorithm does the minimal setup for the service worker that is necessary to create something usable for security checks like CSP and COEP. This specification ensures that this algorithm is called before any such checks are performed.
 
-        In specifications, such security checks require creating a {{ServiceWorkerGlobalScope}}, a [=relevant settings object=], a [=realm=], and an [=agent=]. In implementations, the amount of work required might be much less. Therefore, implementations could do less work in their equivalent of this algorithm, and more work in [=Run Service Worker=], as long as the results are observably equivalent. (And in particular, as long as all security checks have the same result.)
+        In specifications, such security checks require creating a {{ServiceWorkerGlobalScope}}, a [=relevant settings object=], a [=global object/realm=], and an [=agent=]. In implementations, the amount of work required might be much less. Therefore, implementations could do less work in their equivalent of this algorithm, and more work in [=Run Service Worker=], as long as the results are observably equivalent. (And in particular, as long as all security checks have the same result.)
       </div>
 
       1. Let |unsafeCreationTime| be the [=unsafe shared current time=].
       1. If |serviceWorker| is [=running=], then return true.
       1. If |serviceWorker|'s [=service worker/state=] is "`redundant`", then return false.
-      1. If |serviceWorker|'s [=ServiceWorkerGlobalScope is ready=] is set, then return true.
+      1. If |serviceWorker|'s [=ServiceWorkerGlobalScope is ready flag=] is set, then return true.
       1. Assert: |serviceWorker|'s [=start status=] is null.
       1. Let |setupFailed| be false.
       1. Let |agent| be the result of [=obtain a service worker agent|obtaining a service worker agent=], and run the following steps in that context:
@@ -3021,8 +3023,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/type=] to |serviceWorker|'s [=service worker/type=].
           1. Create a new {{WorkerLocation}} object and associate it with |workerGlobalScope|.
           1. If the [=run CSP initialization for a global object=] algorithm returns "<code>Blocked</code>" when executed upon |workerGlobalScope|, set |setupFailed| to true and abort these steps.
-          1. Set |serviceWorker|'s [=ServiceWorkerGlobalScope is ready=].
-      1. Wait for |serviceWorker|'s [=ServiceWorkerGlobalScope is ready=] is set, or for |setupFailed| to be true.
+          1. Set |serviceWorker|'s [=ServiceWorkerGlobalScope is ready flag=].
+      1. Wait for |serviceWorker|'s [=ServiceWorkerGlobalScope is ready flag=] is set, or for |setupFailed| to be true.
       1. If |setupFailed| is true, then return false.
       1. Return true.
   </section>
@@ -3044,7 +3046,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |script| be |serviceWorker|'s [=service worker/script resource=].
       1. Assert: |script| is not null.
       1. Let |startFailed| be false.
-      1. If |serviceWorker|'s [=ServiceWorkerGlobalScope is ready=] is not set:
+      1. If |serviceWorker|'s [=ServiceWorkerGlobalScope is ready flag=] is not set:
           1. If run the [=Setup ServiceWorkerGlobalScope=] algorithm with |serviceWorker| returns false, then return *failure*.
       1. Obtain agent for |serviceWorker|'s [=service worker/global object=]'s [=environment settings object/realm execution context=], and run the following steps in that context:
           1. Let |workerGlobalScope| be |serviceWorker|'s [=service worker/global object=].
@@ -3127,6 +3129,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
           1. [=Abort a running script|Abort the script=] currently running in |serviceWorker|.
           1. Set |serviceWorker|'s [=start status=] to null.
+          1. Unset |serviceWorker|'s [=ServiceWorkerGlobalScope is ready flag=].
   </section>
 
   <section algorithm>
@@ -3173,18 +3176,24 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. If |client|'s <a>active service worker</a> is non-null, set |registration| to |client|'s <a>active service worker</a>'s <a>containing service worker registration</a>.
           1. Else, return null.
       1. Let |activeWorker| be |registration|'s <a>active worker</a>.
-      1. If |activeWorker|'s [=service worker/list of router rules=] is [=list/is not empty=]:
-          1. Let |source| be the result of running [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
-          1. If |source| is {{RouterSourceEnum/"network"}}, return null.
+      1. Let |shouldSoftUpdate| be true if any of the following are true, and false otherwise:
+          * |request| is a [=non-subresource request=].
+          * |request| is a [=subresource request=] and |registration| is [=stale=].
+      1. If |activeWorker|'s [=service worker/list of router rules=] [=list/is not empty=]:
+          1. Let |source| be the result of running the [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
+          1. If |source| is {{RouterSourceEnum/"network"}}:
+              1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
+              1. Return null.
           1. Else if |source| is {{RouterSourceEnum/"cache"}}, or |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=], then:
-              1. [=map/For each=] |cacheName| &#x2192; |cache| of the [=relevant name to cache map=]:
-                  1. If |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=] and |source|["{{RouterSourceDict/cacheName}}"] does not match |cacheName|, [=continue=].
+              1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
+              1. [=map/For each=] |cacheName| &#x2192; |cache| of the |registration|'s [=service worker registration/storage key=]'s [=name to cache map=].
+                  1. If |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=] and |source|["{{RouterSourceDict/cacheName}}"] [=string/is=] not |cacheName|, [=continue=].
                   1. Let |requestResponses| be the result of running [=Query Cache=] with |request|, a new {{CacheQueryOptions}}, and |cache|.
                   1. If |requestResponses| is an empty [=list=], return null.
                   1. Else:
                       1. Let |requestResponse| be the first element of |requestResponses|.
                       1. Let |response| be |requestResponse|'s response.
-                      1. If |activeWorker| is not [=running=] or |activeWorker|'s [=ServiceWorkerGlobalScope is ready=] is not set:
+                      1. If |activeWorker| is not [=running=] or |activeWorker|'s [=ServiceWorkerGlobalScope is ready flag=] is not set:
                           1. If the result of running the [=Setup ServiceWorkerGlobalScope=] algorithm with |activeWorker| is false, then return null.
 
                           Note: If this step succeeds, then |activeWorker|'s [=relevant settings object=] is now ready to use.
@@ -3193,7 +3202,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. If |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |settingsObject|'s [=environment settings object/origin=], |settingsObject|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
                       1. Return |response|.
               1. Return null.
-      1. If |request| is a <a>non-subresource request</a>, |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
+          1. Assert: |source| is "{{RouterSourceEnum/fetch-event}}"
+      1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
 
           Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.
 
@@ -3215,9 +3225,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
               1. [=fetch controller/Abort=] |preloadFetchController| with |deserializedError|.
       1. Else, resolve |preloadResponse| with undefined.
-      1. Let |shouldSoftUpdate| be true if any of the following are true, and false otherwise:
-          * |request| is a [=non-subresource request=].
-          * |request| is a [=subresource request=] and |registration| is [=stale=].
       1. If the result of running the [=Should Skip Event=] algorithm with "fetch" and |activeWorker| is true, then:
           1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
           1. Return null.
@@ -3338,31 +3345,35 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: a boolean
 
-      Note: if there are multiple conditions (e.g. `urlPattern`, `runningStatus`, and `requestMethod` are set), all conditions will be matched to return true.
+      Note: if there are multiple conditions (e.g. `urlPattern`, `runningStatus`, and `requestMethod` are set), all conditions need to match for true to be returned.
 
-      1. If |condition|["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
-          1. Let |rawPattern| be |condition|["{{RouterCondition/urlPattern}}"].
-          1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
-          1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, return false.
-      1. If |condition|["{{RouterCondition/requestMethod}}"] [=map/exists=], then:
-          1. Let |method| be |condition|["{{RouterCondition/requestMethod}}"].
-          1. If |request|'s [=request/method=] is not |method|, return false.
-      1. If |condition|["{{RouterCondition/requestMode}}"] [=map/exists=], then:
-          1. Let |mode| be |condition|["{{RouterCondition/requestMode}}"].
-          1. If |request|'s [=request/mode=] is not |mode|, return false.
-      1. If |condition|["{{RouterCondition/requestDestination}}"] [=map/exists=], then:
-          1. Let |destination| be |condition|["{{RouterCondition/requestDestination}}"].
-          1. If |request|'s [=request/destination=] is not |destination|, return false.
-      1. If |condition|["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
-          1. Let |runningStatus| be |condition|["{{RouterCondition/runningStatus}}"].
-          1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], return false.
-          1. If |runningStatus| is {{RunningStatus/"not-running"}}, and |serviceWorker| is [=running=], return false.
-      1. If |condition|["{{RouterCondition/_or}}"] [=map/exists=], then:
-          1. Let |orConditions| be |condition|["{{RouterCondition/_or}}"].
+      1. If |condition|["{{RouterCondition/or}}"] [=map/exists=], then:
+          1. Let |orConditions| be |condition|["{{RouterCondition/or}}"].
           1. For each |orCondition| of |orConditions|:
               1. If running [=Match Router Condition=] algorithm with |orCondition|, |serviceWorker| and |request| returns true, then return true.
           1. Return false.
-      1. Return true.
+      1. Else:
+
+          Note: The [=Verify Router Condition=] algorithm guarantees that {{RouterCondition/or}} and other conditions are mutual exclusive.
+
+          1. If |condition|["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
+              1. Let |rawPattern| be |condition|["{{RouterCondition/urlPattern}}"].
+              1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
+              1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, return false.
+          1. If |condition|["{{RouterCondition/requestMethod}}"] [=map/exists=], then:
+              1. Let |method| be |condition|["{{RouterCondition/requestMethod}}"].
+              1. If |request|'s [=request/method=] is not |method|, return false.
+          1. If |condition|["{{RouterCondition/requestMode}}"] [=map/exists=], then:
+              1. Let |mode| be |condition|["{{RouterCondition/requestMode}}"].
+              1. If |request|'s [=request/mode=] is not |mode|, return false.
+          1. If |condition|["{{RouterCondition/requestDestination}}"] [=map/exists=], then:
+              1. Let |destination| be |condition|["{{RouterCondition/requestDestination}}"].
+              1. If |request|'s [=request/destination=] is not |destination|, return false.
+          1. If |condition|["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
+              1. Let |runningStatus| be |condition|["{{RouterCondition/runningStatus}}"].
+              1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], return false.
+              1. If |runningStatus| is {{RunningStatus/"not-running"}}, and |serviceWorker| is [=running=], return false.
+          1. Return true.
   </section>
 
   <section algorithm>
@@ -3374,8 +3385,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: {{RouterSource}} or null
 
       1. [=list/For each=] |rule| of |serviceWorker|'s [=service worker/list of router rules=]:
-          1. If running [=Match Router Condition=] with |rule|["{{RouterRule/condition}}"], |serviceWorker| and |request| returns false, [=continue=].
-          1. Return |rule|["{{RouterRule/source}}"].
+          1. If running the [=Match Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"], |serviceWorker| and |request| returns true, then return |rule|["{{RouterRule/source}}"].
 
       1. Return null.
   </section>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3251,9 +3251,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               Note: Since running a user-defined regular expression has a security concern, it is prohibited.
 
           1. Set |hasCondition| to true.
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
-          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] is neither of  {{RunningStatus/"running"}} nor {{RunningStatus/"not-running"}}, return false.
-          1. Set |hasCondition| to true.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], set |hasCondition| to true.
       1. Return |hasCondition|.
   </section>
 
@@ -3267,7 +3265,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       1. [=list/For each=] |rule| of |serviceWorker|'s [=service worker/list of router rules=]:
 
-          Note: if there are multiple conditions in a rule, all conditions should be matched to return the source.
+          Note: if there are multiple conditions in a rule, all conditions will be matched to return the source.
 
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
               1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1602,7 +1602,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. Let |routerRules| be a copy of |serviceWorker|'s [=list of router rules=].
         1. If |rules| is a {{RouterRule}} dictionary, set |rules| to &#x00AB; |rules| &#x00BB;.
         1.  For each |rule| of |rules|:
-            1. If running [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, return [=a promise rejected with=] a {{TypeError}}.
+            1. If running the [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, return [=a promise rejected with=] a {{TypeError}}.
             1. Append |rule| to |routerRules|.
         1. If |routerRules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSourceEnum/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, return [=a promise rejected with=] a {{TypeError}}.
         1. Set |serviceWorker|'s [=service worker/list of router rules=] to |routerRules|.
@@ -3370,7 +3370,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |hasCondition| be false.
       1. If |condition|["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
           1. Let |rawPattern| be |condition|["{{RouterCondition/urlPattern}}"].
-          1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
+          1. Let |pattern| be the result of running the <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
           1. If |pattern| [=URLPattern/has regexp groups=], then return false.
 
               Note: Since running a user-defined regular expression has a security concern, it is prohibited.
@@ -3387,7 +3387,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
           1. Let |orConditions| be |condition|["{{RouterCondition/_or}}"].
           1. For each |orCondition| of |orConditions|:
-              1. If running [=Verify Router Condition=] algorithm with |orCondition| and |serviceWorker| returns false, return false.
+              1. If running the [=Verify Router Condition=] algorithm with |orCondition| and |serviceWorker| returns false, return false.
           1. Set |hasCondition| to true.
       1. Return |hasCondition|.
   </section>
@@ -3406,7 +3406,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If |condition|["{{RouterCondition/or}}"] [=map/exists=], then:
           1. Let |orConditions| be |condition|["{{RouterCondition/or}}"].
           1. For each |orCondition| of |orConditions|:
-              1. If running [=Match Router Condition=] algorithm with |orCondition|, |serviceWorker| and |request| returns true, then return true.
+              1. If running the [=Match Router Condition=] algorithm with |orCondition|, |serviceWorker| and |request| returns true, then return true.
           1. Return false.
       1. Else:
 
@@ -3414,7 +3414,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
           1. If |condition|["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
               1. Let |rawPattern| be |condition|["{{RouterCondition/urlPattern}}"].
-              1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
+              1. Let |pattern| be the result of running the <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
               1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, return false.
           1. If |condition|["{{RouterCondition/requestMethod}}"] [=map/exists=], then:
               1. Let |method| be |condition|["{{RouterCondition/requestMethod}}"].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -212,8 +212,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A [=/service worker=] is said to be <dfn>running</dfn> if its [=event loop=] is running.
 
-    A [=/service worker=] has an associated <dfn>ServiceWorkerGlobalScope is ready flag</dfn>. It is initially unset.
-
     <section>
       <h4 id="service-worker-lifetime">Lifetime</h4>
 
@@ -3002,13 +3000,12 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |unsafeCreationTime| be the [=unsafe shared current time=].
       1. If |serviceWorker| is [=running=], then return true.
       1. If |serviceWorker|'s [=service worker/state=] is "`redundant`", then return false.
-      1. If |serviceWorker|'s [=ServiceWorkerGlobalScope is ready flag=] is set, then return true.
+      1. If |serviceWorker|'s [=service worker/global object=] is not null, then return true.
       1. Assert: |serviceWorker|'s [=start status=] is null.
       1. Let |setupFailed| be false.
       1. Let |agent| be the result of [=obtain a service worker agent|obtaining a service worker agent=], and run the following steps in that context:
           1. Let |realmExecutionContext| be the result of [=creating a new realm=] given |agent| and the following customizations:
               * For the global object, create a new {{ServiceWorkerGlobalScope}} object. Let |workerGlobalScope| be the created object.
-          1. Set |serviceWorker|'s [=service worker/global object=] to |workerGlobalScope|.
           1. Let |settingsObject| be a new <a>environment settings object</a> whose algorithms are defined as follows:
 
               : The [=environment settings object/realm execution context=]
@@ -3030,8 +3027,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/type=] to |serviceWorker|'s [=service worker/type=].
           1. Create a new {{WorkerLocation}} object and associate it with |workerGlobalScope|.
           1. If the [=run CSP initialization for a global object=] algorithm returns "<code>Blocked</code>" when executed upon |workerGlobalScope|, set |setupFailed| to true and abort these steps.
-          1. Set |serviceWorker|'s [=ServiceWorkerGlobalScope is ready flag=].
-      1. Wait for |serviceWorker|'s [=ServiceWorkerGlobalScope is ready flag=] is set, or for |setupFailed| to be true.
+          1. Set |serviceWorker|'s [=service worker/global object=] to |workerGlobalScope|.
+      1. Wait for |serviceWorker|'s [=service worker/global object=] is not null, or for |setupFailed| to be true.
       1. If |setupFailed| is true, then return false.
       1. Return true.
   </section>
@@ -3053,7 +3050,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |script| be |serviceWorker|'s [=service worker/script resource=].
       1. Assert: |script| is not null.
       1. Let |startFailed| be false.
-      1. If |serviceWorker|'s [=ServiceWorkerGlobalScope is ready flag=] is not set:
+      1. If |serviceWorker|'s [=service worker/global object=] is null:
           1. If run the [=Setup ServiceWorkerGlobalScope=] algorithm with |serviceWorker| returns false, then return *failure*.
       1. Obtain agent for |serviceWorker|'s [=service worker/global object=]'s [=environment settings object/realm execution context=], and run the following steps in that context:
           1. Let |workerGlobalScope| be |serviceWorker|'s [=service worker/global object=].
@@ -3136,7 +3133,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
           1. [=Abort a running script|Abort the script=] currently running in |serviceWorker|.
           1. Set |serviceWorker|'s [=start status=] to null.
-          1. Unset |serviceWorker|'s [=ServiceWorkerGlobalScope is ready flag=].
   </section>
 
   <section algorithm>
@@ -3196,7 +3192,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Else:
                       1. Let |requestResponse| be the first element of |requestResponses|.
                       1. Let |response| be |requestResponse|'s response.
-                      1. If |activeWorker| is not [=running=] or |activeWorker|'s [=ServiceWorkerGlobalScope is ready flag=] is not set:
+                      1. If |activeWorker|'s [=service worker/global object=] is null:
                           1. If the result of running the [=Setup ServiceWorkerGlobalScope=] algorithm with |activeWorker| is false, then return null.
 
                           Note: If this step succeeds, then |activeWorker|'s [=relevant settings object=] is now ready to use.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1563,8 +1563,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       dictionary RouterCondition {
         URLPatternCompatible urlPattern;
+        RunningStatus runningStatus;
       };
 
+      enum RunningStatus { "running", "not-running" };
       enum RouterSource { "fetch-event", "network" };
     </pre>
 
@@ -3240,14 +3242,19 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: a boolean
 
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exist=], return false.
-      1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-      1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
-      1. If |pattern| [=URLPattern/has regexp groups=], then return false.
+      1. Let |hasCondition| be false.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
+          1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
+          1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
+          1. If |pattern| [=URLPattern/has regexp groups=], then return false.
 
-          Note: Since running a user-defined regular expression has a security concern, it is prohibited.
+              Note: Since running a user-defined regular expression has a security concern, it is prohibited.
 
-      1. Return true.
+          1. Set |hasCondition| to true.
+      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
+          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] is neither of  {{RunningStatus/"running"}} nor {{RunningStatus/"not-running"}}, return false.
+          1. Set |hasCondition| to true.
+      1. Return |hasCondition|.
   </section>
 
   <section algorithm>
@@ -3259,10 +3266,14 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: {{RouterSource}} or null
 
       1. [=list/For each=] |rule| of |serviceWorker|'s [=service worker/list of router rules=]:
-          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] does not [=map/exist=], continue.
-          1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-          1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
-          1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
+          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
+              1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
+              1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
+              1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
+          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
+              1. Let |runningStatus| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"].
+              1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], continue.
+              1. If |runningStatus| is {{RunningStatus/"not-running"}}, and |serviceWorker| is [=running=], continue.
           1. Return |rule|["{{RouterRule/source}}"].
 
       1. Return null.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1567,6 +1567,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         RequestMode requestMode;
         RequestDestination requestDestination;
         RunningStatus runningStatus;
+
+        sequence&lt;RouterCondition&gt; _or;
       };
 
       enum RunningStatus { "running", "not-running" };
@@ -1584,7 +1586,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. Let |routerRules| be a copy of |serviceWorker|'s [=list of router rules=].
         1. If |rules| is a {{RouterRule}} dictionary, set |rules| to &#x00AB; |rules| &#x00BB;.
         1.  For each |rule| of |rules|:
-            1. If running [=Verify Router Rule=] algorithm with |rule| and |serviceWorker| returns false, [=throw=] a {{TypeError}}.
+            1. If running [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, [=throw=] a {{TypeError}}.
             1. Append |rule| to |routerRules|.
         1. If |routerRules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSource/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, [=throw=] a {{TypeError}}.
         1. Set |serviceWorker|'s [=service worker/list of router rules=] to |routerRules|.
@@ -3237,28 +3239,76 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section algorithm>
-    <h3 id="verify-router-rule-algorithm"><dfn>Verify Router Rule</dfn></h3>
+    <h3 id="verify-router-rule-algorithm"><dfn>Verify Router Condition</dfn></h3>
 
       : Input
-      :: |rule|, a {{RouterRule}}
+      :: |condition|, a {{RouterCondition}}
       :: |serviceWorker|, a [=/service worker=]
       : Output
       :: a boolean
 
       1. Let |hasCondition| be false.
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
-          1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
+      1. If |condition|["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
+          1. Let |rawPattern| be |condition|["{{RouterCondition/urlPattern}}"].
           1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
           1. If |pattern| [=URLPattern/has regexp groups=], then return false.
 
               Note: Since running a user-defined regular expression has a security concern, it is prohibited.
 
           1. Set |hasCondition| to true.
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"] [=map/exists=], set |hasCondition| to true.
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"] [=map/exists=], set |hasCondition| to true.
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"] [=map/exists=], set |hasCondition| to true.
-      1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], set |hasCondition| to true.
+      1. If |condition|["{{RouterCondition/requestMethod}}"] [=map/exists=], set |hasCondition| to true.
+      1. If |condition|["{{RouterCondition/requestMode}}"] [=map/exists=], set |hasCondition| to true.
+      1. If |condition|["{{RouterCondition/requestDestination}}"] [=map/exists=], set |hasCondition| to true.
+      1. If |condition|["{{RouterCondition/runningStatus}}"] [=map/exists=], set |hasCondition| to true.
+      1. If |condition|["{{RouterCondition/_or}}"] [=map/exists=], then:
+          1. If |hasCondition| is true, return false.
+
+              Note: For ease of understanding the router rule, the "or" condition is mutual exclusive with other conditions.
+
+          1. Let |or conditions| be |condition|["{{RouterCondition/_or}}"].
+          1. For each |or condition| of |or conditions|:
+              1. If running [=Verify Router Condition=] algorithm with |or condition| and |serviceWorker| returns false, return false.
+          1. Set |hasCondition| to true.
       1. Return |hasCondition|.
+  </section>
+
+  <section algorithm>
+    <h3 id="match-router-condition-algorithm"><dfn>Match Router Condition</dfn></h3>
+      : Input
+      :: |condition|, a {{RouterCondition}}
+      :: |serviceWorker|, a [=/service worker=]
+      :: |request|, a [=/request=]
+      : Output
+      :: a boolean
+
+      Note: if there are multiple conditions, all conditions will be matched to return the source.
+
+      1. If |condition|["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
+          1. Let |rawPattern| be |condition|["{{RouterCondition/urlPattern}}"].
+          1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
+          1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, return false.
+      1. If |condition|["{{RouterCondition/requestMethod}}"] [=map/exists=], then:
+          1. Let |method| be |condition|["{{RouterCondition/requestMethod}}"].
+          1. If |request|'s [=request/method=] is not |method|, return false.
+      1. If |condition|["{{RouterCondition/requestMode}}"] [=map/exists=], then:
+          1. Let |mode| be |condition|["{{RouterCondition/requestMode}}"].
+          1. If |request|'s [=request/mode=] is not |mode|, return false.
+      1. If |condition|["{{RouterCondition/requestDestination}}"] [=map/exists=], then:
+          1. Let |destination| be |condition|["{{RouterCondition/requestDestination}}"].
+          1. If |request|'s [=request/destination=] is not |destination|, return false.
+      1. If |condition|["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
+          1. Let |runningStatus| be |condition|["{{RouterCondition/runningStatus}}"].
+          1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], return false.
+          1. If |runningStatus| is {{RunningStatus/"not-running"}}, and |serviceWorker| is [=running=], return false.
+      1. If |condition|["{{RouterCondition/_or}}"] [=map/exists=], then:
+          1. Let |or conditions| be |condition|["{{RouterCondition/_or}}"].
+          1. Let |or condition matched| be false.
+          1. For each |or condition| of |or conditions|:
+              1. If running [=Match Router Condition=] algorithm with |or condition|, |serviceWorker| and |request| returns true:
+                1. Set |or condition matched| to true.
+                1. [=break=].
+          1. If |or condition matched| is false, return false.
+      1. Return true.
   </section>
 
   <section algorithm>
@@ -3270,26 +3320,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: {{RouterSource}} or null
 
       1. [=list/For each=] |rule| of |serviceWorker|'s [=service worker/list of router rules=]:
-
-          Note: if there are multiple conditions in a rule, all conditions will be matched to return the source.
-
-          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
-              1. Let |rawPattern| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/urlPattern}}"].
-              1. Let |pattern| be the result of running <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|.
-              1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
-          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"] [=map/exists=], then:
-              1. Let |method| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"].
-              1. If |request|'s [=request/method=] is not |method|, [=continue=].
-          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"] [=map/exists=], then:
-              1. Let |mode| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"].
-              1. If |request|'s [=request/mode=] is not |mode|, [=continue=].
-          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"] [=map/exists=], then:
-              1. Let |destination| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"].
-              1. If |request|'s [=request/destination=] is not |destination|, [=continue=].
-          1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
-              1. Let |runningStatus| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"].
-              1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], [=continue=].
-              1. If |runningStatus| is {{RunningStatus/"not-running"}}, and |serviceWorker| is [=running=], [=continue=].
+          1. If running [=Match Router Condition=] with |rule|["{{RouterRule/condition}}"], |serviceWorker| and |request| returns false, [=continue=].
           1. Return |rule|["{{RouterRule/source}}"].
 
       1. Return null.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1082,7 +1082,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       };
     </pre>
 
-    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn export for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]). A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for import scripts flag</dfn>. It is initially unset.
+    A {{ServiceWorkerGlobalScope}} object represents the global execution context of a [=/service worker=]. A {{ServiceWorkerGlobalScope}} object has an associated <dfn export for="ServiceWorkerGlobalScope">service worker</dfn> (a [=/service worker=]). A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for import scripts flag</dfn>. A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">race response map</dfn> which is an [=ordered map=] where the [=map/keys=] are [=/requests=] and the [=map/values=] are [=race response=]. It is initially unset.
+
+    A <dfn id="dfn-race-response">race response</dfn> is a [=struct=] used to contain the network response when {{RouterSourceEnum/"race-network-and-fetch-handler"}} performs. It has a <dfn for="race response">value</dfn>, which is a [=/response=], "<code>pending</code>", or null.
 
     Note: {{ServiceWorkerGlobalScope}} object provides generic, event-driven, time-limited script execution contexts that run at an origin. Once successfully <a>registered</a>, a [=/service worker=] is started, kept alive and killed by their relationship to events, not [=/service worker clients=]. Any type of synchronous requests must not be initiated inside of a [=/service worker=].
 
@@ -1581,7 +1583,12 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       };
 
       enum RunningStatus { "running", "not-running" };
-      enum RouterSourceEnum { "cache", "fetch-event", "network" };
+      enum RouterSourceEnum {
+        "cache",
+        "fetch-event",
+        "network",
+        "race-network-and-fetch-handler"
+      };
     </pre>
 
     <section>
@@ -3142,19 +3149,15 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: |controller|, a [=fetch controller=]
       :: |useHighResPerformanceTimers|, a boolean
       : Output
-      :: |response|, a [=/response=]
+      :: a [=/response=]
 
-      1. Let |handleFetchFailed| be false.
-      1. Let |respondWithEntered| be false.
-      1. Let |eventCanceled| be false.
-      1. Let |response| be null.
       1. Let |registration| be null.
       1. Let |client| be |request|'s [=request/client=].
       1. Let |reservedClient| be |request|'s [=request/reserved client=].
       1. Let |preloadResponse| be a new [=promise=].
       1. Let |workerRealm| be null.
-      1. Let |eventHandled| be null.
       1. Let |timingInfo| be a new [=service worker timing info=].
+      1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is null.
       1. Assert: |request|'s [=request/destination=] is not "<code>serviceworker</code>".
       1. If |request|'s [=request/destination=] is either "<code>embed</code>" or "<code>object</code>", then:
           1. Return null.
@@ -3202,6 +3205,26 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. If |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |settingsObject|'s [=environment settings object/origin=], |settingsObject|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
                       1. Return |response|.
               1. Return null.
+          1. Else if |source| is {{RouterSourceEnum/"race-network-and-fetch-handler"}}, and |request|'s [=request/method=] is \`<code>GET</code>\` then:
+              1. Let |queue| be an empty [=queue=] of [=/response=].
+              1. Let |raceFetchController| be null.
+              1. Set |raceResponse|'s [=race response/value=] to "<code>pending</code>".
+              1. Run the following substeps [=in parallel=], but [=abort when=] |controller|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
+                  1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
+                      1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
+                          1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
+                          1. [=queue/Enqueue=] |raceNetworkRequestResponse| to |queue|.
+                      1. Otherwise, set |raceResponse|'s [=race response/value=] to a [=network error=].
+              1. [=If aborted=] and |raceFetchController| is not null, then:
+                  1. [=fetch controller/Abort=] |raceFetchController|.
+                  1. Set |raceResponse| to a [=race response=] whose [=race response/value=] is null.
+              1. Resolve |preloadResponse| with undefined.
+              1. Run the following substeps [=in parallel=]:
+                  1. Let |fetchHandlerResponse| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
+                  1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
+                  1. [=queue/Enqueue=] |fetchHandlerResponse| to |queue|.
+              1. Wait until |queue| is not empty.
+              1. Return the result of [=dequeue=] |queue|.
           1. Assert: |source| is "{{RouterSourceEnum/fetch-event}}"
       1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
 
@@ -3225,6 +3248,34 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
               1. [=fetch controller/Abort=] |preloadFetchController| with |deserializedError|.
       1. Else, resolve |preloadResponse| with undefined.
+      1. Return the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
+  </section>
+
+  <section algorithm>
+    <h3 id="create-fetch-event-and-dispatch-algorithm"><dfn>Create Fetch Event and Dispatch</dfn></h3>
+      : Input
+      :: |request|, a [=/request=]
+      :: |registration|, a [=/service worker registration=]
+      :: |useHighResPerformanceTimers|, a boolean
+      :: |timingInfo|, a [=service worker timing info=]
+      :: |workerRealm|, a [=relevant realm=] of the [=service worker/global object=]
+      :: |reservedClient|, a [=request/reserved client=]
+      :: |preloadResponse|, a [=promise=]
+      :: |raceResponse|, a [=race response=]
+      : Output
+      :: a [=/response=]
+
+      1. Let |response| be null.
+      1. Let |eventCanceled| be false.
+      1. Let |client| be |request|'s [=request/client=].
+      1. Let |activeWorker| be |registration|'s <a>active worker</a>.
+      1. Let |eventHandled| be null.
+      1. Let |handleFetchFailed| be false.
+      1. Let |respondWithEntered| be false.
+      1. Let |shouldSoftUpdate| be true if any of the following are true, and false otherwise:
+          * |request| is a [=non-subresource request=].
+          * |request| is a [=subresource request=] and |registration| is [=stale=].
+      1. Let |raceResponseMap| be |activeWorker|'s [=service worker/global object=]'s [=race response map=].
       1. If the result of running the [=Should Skip Event=] algorithm with "fetch" and |activeWorker| is true, then:
           1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
           1. Return null.
@@ -3241,6 +3292,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Else:
           1. Set |workerRealm| to the [=relevant realm=] of the |activeWorker|'s [=service worker/global object=].
           1. Set |eventHandled| to [=a new promise=] in |workerRealm|.
+          1. If |raceResponse| is not null, [=map/set=] |raceResponseMap|[|request|] to |raceResponse|.
           1. [=Queue a task=] |task| to run the following substeps:
               1. Let |e| be the result of <a>creating an event</a> with {{FetchEvent}}.
               1. Let |controller| be a [=new=] {{AbortController}} object with |workerRealm|.
@@ -3277,11 +3329,15 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       1. Wait for |task| to have executed or for |handleFetchFailed| to be true.
       1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
+      1. If |raceResponseMap|[|request|] [=map/exists=], [=map/remove=] |raceResponseMap|[|request|].
       1. If |respondWithEntered| is false, then:
           1. If |eventCanceled| is true, then:
               1. If |eventHandled| is not null, then [=reject=] |eventHandled| with a "{{NetworkError}}" {{DOMException}} in |workerRealm|.
               2. Return a [=network error=].
           1. If |eventHandled| is not null, then [=resolve=] |eventHandled|.
+          1. If |raceResponse|'s [=race response/value=] is not null, then:
+              1. Wait until |raceResponse|'s [=race response/value=] is not "<code>pending</code>".
+              1. If |raceResponse|'s [=race response/value=] is a [=/response=], return |raceResponse|'s [=race response/value=].
           1. Return null.
       1. If |handleFetchFailed| is true, then:
           1. If |eventHandled| is not null, then [=reject=] |eventHandled| with a "{{NetworkError}}" {{DOMException}} in |workerRealm|.
@@ -3921,6 +3977,28 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If [=Is Async Module=] for |moduleMap|[|url|]'s [=script/record=], |moduleMap|, |base|, and |seen| is true, then:
                   1. Return true.
       1. Return false.
+  </section>
+
+  <section algorithm>
+    <h3 id="lookup-race-response-algorithm"><dfn export>Lookup Race Response</dfn></h3>
+
+      : Input
+      :: |request|, a [=/request=]
+      : Output
+      :: a [=/response=] or null
+
+      1. If |request|'s [=request/reserved client=] is null, return null.
+      1. Let |storage key| be the result of running [=obtain a storage key=] given |request|'s [=request/reserved client=].
+      1. Let |registration| be the result of running <a>Match Service Worker Registration</a> given |storage key| and |url|.
+      1. If |registration| is null or |registration|'s <a>active worker</a> is null, return null.
+      1. Else, let |activeWorker| be |registration|'s <a>active worker</a>.
+      1. Let |map| be |activeWorker|'s [=service worker/global object=]'s [=race response map=].
+      1. If |map|[|request|] [=map/exists=], then:
+        1. Let |entry| be |map|[|request|].
+        1. [=map/Remove=] |map|[|request|].
+        1. Wait until |entry|'s [=race response/value=] is not "<code>pending</code>"
+        1. If |entry|'s [=race response/value=] is [=/response=], return |entry|'s [=race response/value=].
+      1. Return null.
   </section>
 </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -211,6 +211,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A [=/service worker=] is said to be <dfn>running</dfn> if its [=event loop=] is running.
 
+    A [=/service worker=] has an associated <dfn>ServiceWorkerGlobalScope is ready</dfn>. It is initially unset.
+
     <section>
       <h4 id="service-worker-lifetime">Lifetime</h4>
 
@@ -2973,23 +2975,27 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section algorithm>
-    <h3 id="run-service-worker-algorithm"><dfn>Run Service Worker</dfn></h3>
+    <h3 id="setup-serviceworkerglobalscope"><dfn>Setup ServiceWorkerGlobalScope</dfn></h3>
 
       : Input
       :: |serviceWorker|, a [=/service worker=]
-      :: |forceBypassCache|, an optional boolean, false by default
       : Output
-      :: a [=Completion=] or *failure*
+      :: a boolean
 
-      Note: This algorithm blocks until the service worker is [=running=] or fails to start.
+      Note: This algorithm returns true if |serviceWorker| has a {{ServiceWorkerGlobalScope}} usable for a CSP check.
+
+      <div class="note">
+        This algorithm does the minimal setup for the service worker that is necessary to create something usable for security checks like CSP and COEP. This specification ensures that this algorithm is called before any such checks are performed.
+
+        In specifications, such security checks require creating a {{ServiceWorkerGlobalScope}}, a [=relevant settings object=], a [=realm=], and an [=agent=]. In implementations, the amount of work required might be much less. Therefore, implementations could do less work in their equivalent of this algorithm, and more work in [=Run Service Worker=], as long as the results are observably equivalent. (And in particular, as long as all security checks have the same result.)
+      </div>
 
       1. Let |unsafeCreationTime| be the [=unsafe shared current time=].
-      1. If |serviceWorker| is [=running=], then return |serviceWorker|'s [=start status=].
-      1. If |serviceWorker|'s [=service worker/state=] is "`redundant`", then return *failure*.
+      1. If |serviceWorker| is [=running=], then return true.
+      1. If |serviceWorker|'s [=service worker/state=] is "`redundant`", then return false.
+      1. If |serviceWorker|'s [=ServiceWorkerGlobalScope is ready=] is set, then return true.
       1. Assert: |serviceWorker|'s [=start status=] is null.
-      1. Let |script| be |serviceWorker|'s [=service worker/script resource=].
-      1. Assert: |script| is not null.
-      1. Let |startFailed| be false.
+      1. Let |setupFailed| be false.
       1. Let |agent| be the result of [=obtain a service worker agent|obtaining a service worker agent=], and run the following steps in that context:
           1. Let |realmExecutionContext| be the result of [=creating a new realm=] given |agent| and the following customizations:
               * For the global object, create a new {{ServiceWorkerGlobalScope}} object. Let |workerGlobalScope| be the created object.
@@ -3013,9 +3019,36 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/url=] to |serviceWorker|'s [=service worker/script url=].
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/policy container=] to |serviceWorker|'s <a>script resource</a>'s [=script resource/policy container=].
           1. Set |workerGlobalScope|'s [=WorkerGlobalScope/type=] to |serviceWorker|'s [=service worker/type=].
-          1. Set |workerGlobalScope|'s [=ServiceWorkerGlobalScope/force bypass cache for import scripts flag=] if |forceBypassCache| is true.
           1. Create a new {{WorkerLocation}} object and associate it with |workerGlobalScope|.
-          1. If the [=run CSP initialization for a global object=] algorithm returns "<code>Blocked</code>" when executed upon |workerGlobalScope|, set |startFailed| to true and abort these steps.
+          1. If the [=run CSP initialization for a global object=] algorithm returns "<code>Blocked</code>" when executed upon |workerGlobalScope|, set |setupFailed| to true and abort these steps.
+          1. Set |serviceWorker|'s [=ServiceWorkerGlobalScope is ready=].
+      1. Wait for |serviceWorker|'s [=ServiceWorkerGlobalScope is ready=] is set, or for |setupFailed| to be true.
+      1. If |setupFailed| is true, then return false.
+      1. Return true.
+  </section>
+
+  <section algorithm>
+    <h3 id="run-service-worker-algorithm"><dfn>Run Service Worker</dfn></h3>
+
+      : Input
+      :: |serviceWorker|, a [=/service worker=]
+      :: |forceBypassCache|, an optional boolean, false by default
+      : Output
+      :: a [=Completion=] or *failure*
+
+      Note: This algorithm blocks until the service worker is [=running=] or fails to start.
+
+      1. If |serviceWorker| is [=running=], then return |serviceWorker|'s [=start status=].
+      1. If |serviceWorker|'s [=service worker/state=] is "`redundant`", then return *failure*.
+      1. Assert: |serviceWorker|'s [=start status=] is null.
+      1. Let |script| be |serviceWorker|'s [=service worker/script resource=].
+      1. Assert: |script| is not null.
+      1. Let |startFailed| be false.
+      1. If |serviceWorker|'s [=ServiceWorkerGlobalScope is ready=] is not set:
+          1. If run the [=Setup ServiceWorkerGlobalScope=] algorithm with |serviceWorker| returns false, then return *failure*.
+      1. Obtain agent for |serviceWorker|'s [=service worker/global object=]'s [=environment settings object/realm execution context=], and run the following steps in that context:
+          1. Let |workerGlobalScope| be |serviceWorker|'s [=service worker/global object=].
+          1. Set |workerGlobalScope|'s [=ServiceWorkerGlobalScope/force bypass cache for import scripts flag=] if |forceBypassCache| is true.
           1. If |serviceWorker| is an <a>active worker</a>, and there are any <a>tasks</a> queued in |serviceWorker|'s <a>containing service worker registration</a>'s [=service worker registration/task queues=], <a lt="queue a task">queue</a> them to |serviceWorker|'s <a>event loop</a>'s [=/task queues=] in the same order using their original <a>task sources</a>.
           1. Let |evaluationStatus| be null.
           1. If |script| is a [=classic script=], then:
@@ -3151,7 +3184,13 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Else:
                       1. Let |requestResponse| be the first element of |requestResponses|.
                       1. Let |response| be |requestResponse|'s response.
-                      1. If |client| is not null, |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |request|'s [=request/origin=], |client|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
+                      1. If |activeWorker| is not [=running=] or |activeWorker|'s [=ServiceWorkerGlobalScope is ready=] is not set:
+                          1. If the result of running the [=Setup ServiceWorkerGlobalScope=] algorithm with |activeWorker| is false, then return null.
+
+                          Note: If this step succeeds, then |activeWorker|'s [=relevant settings object=] is now ready to use.
+
+                      1. Let |settingsObject| be |activeWorker|'s [=relevant settings object=].
+                      1. If |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |settingsObject|'s [=environment settings object/origin=], |settingsObject|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
                       1. Return |response|.
               1. Return null.
       1. If |request| is a <a>non-subresource request</a>, |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1563,7 +1563,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       dictionary RouterCondition {
         URLPatternCompatible urlPattern;
-        USVString requestMethod;
+        ByteString requestMethod;
         RequestMode requestMode;
         RequestDestination requestDestination;
         RunningStatus runningStatus;
@@ -3279,13 +3279,13 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"] [=map/exists=], then:
               1. Let |method| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMethod}}"].
-              1. If |request|'s [=request/method] is not |method|, [=continue=].
+              1. If |request|'s [=request/method=] is not |method|, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"] [=map/exists=], then:
               1. Let |mode| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestMode}}"].
-              1. If |request|'s [=request/mode] is not |mode|, [=continue=].
+              1. If |request|'s [=request/mode=] is not |mode|, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"] [=map/exists=], then:
               1. Let |destination| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/requestDestination}}"].
-              1. If |request|'s [=request/destination] is not |destination|, [=continue=].
+              1. If |request|'s [=request/destination=] is not |destination|, [=continue=].
           1. If |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"] [=map/exists=], then:
               1. Let |runningStatus| be |rule|["{{RouterRule/condition}}"]["{{RouterCondition/runningStatus}}"].
               1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], [=continue=].


### PR DESCRIPTION
This API allows developers to configure the routing, and allows them to offload simple things ServiceWorkers do. If the condition matches, the navigation happens without starting ServiceWorkers or executing JavaScript, which allows web pages to avoid performance penalties due to ServiceWorker interceptions.

Explainer: https://github.com/WICG/service-worker-static-routing-api
TAG review: https://github.com/w3ctag/design-reviews/issues/863


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 503 Service Unavailable :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 22, 2024, 12:13 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL]([object Object])

```
<html><body><h1>503 Service Unavailable</h1>
No server is available to handle this request.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/ServiceWorker%231701.)._
</details>
