### PR TITLE
Flag ServiceWorkerGlobalScope as SecureContext

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1060,7 +1060,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
     <h3 id="serviceworkerglobalscope-interface">{{ServiceWorkerGlobalScope}}</h3>
 
     <pre class="idl">
-      [Global=(Worker,ServiceWorker), Exposed=ServiceWorker]
+      [Global=(Worker,ServiceWorker), Exposed=ServiceWorker, SecureContext]
       interface ServiceWorkerGlobalScope : WorkerGlobalScope {
         [SameObject] readonly attribute Clients clients;
         [SameObject] readonly attribute ServiceWorkerRegistration registration;


### PR DESCRIPTION
Context for this is Open Web Docs people looking into automating the handling of "this feature is available only in secure contexts" banners in MDN pages. This led to the discussion with @annevk in https://github.com/w3c/webref/issues/1142#issuecomment-1927219703

When it is set, the `[SecureContext]` IDL extended attribute explicitly gives the information. That said, to avoid redundancies, that attribute is usually not set on interfaces that are exposed (through `[Exposed=xxx]`) to globals that are already restricted to secure contexts.

The Service workers spec is clear that [service workers must execute in secure contexts](https://w3c.github.io/ServiceWorker/#secure-context). However, it does not fully say so in the IDL itself. More specifically, when an interface defined in another spec has `[Exposed=ServiceWorker]`, that's a reference to the `ServiceWorkerGlobalScope` interface, and that interface does not have a `[SecureContext]` attribute.

This PR proposes to add a `[SecureContext]` attribute to `ServiceWorkerGlobalScope` to make it possible to derive the fact that service workers must execute in secure contexts automatically.

This approach is consistent with the way [`WorkletGlobalScope`](https://html.spec.whatwg.org/multipage/worklets.html#worklets-global), from which a number of other globals inherit, is defined.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/ServiceWorker/pull/1704.html" title="Last updated on Feb 7, 2024, 2:56 PM UTC (0782416)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1704/4711a07...tidoust:0782416.html" title="Last updated on Feb 7, 2024, 2:56 PM UTC (0782416)">Diff</a>