### PR TITLE
Update interface for install event in summary table

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1833,7 +1833,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       <tbody>
         <tr>
           <td><dfn event id="service-worker-global-scope-install-event"><code>install</code></dfn></td>
-          <td>{{ExtendableEvent}}</td>
+          <td>{{InstallEvent}}</td>
           <td>[=Lifecycle Event|Lifecycle=]</td>
           <td>The [=ServiceWorkerGlobalScope/service worker=]'s <a>containing service worker registration</a>'s <a>installing worker</a> changes. (See step 11.2 of the <a>Install</a> algorithm.)</td>
         </tr>


### PR DESCRIPTION
Following #1701, the `install` event now uses the `InstallEvent` interface.

(FWIW, I noticed that because our spec crawler parses that table to map events with interfaces and make sure that everything's consistent)

I note that the spec also says in [section 4.4](https://w3c.github.io/ServiceWorker/#ref-for-service-worker-global-scope-install-event%E2%91%A1):

> [Service workers](https://w3c.github.io/ServiceWorker/#dfn-service-worker) have two [lifecycle events](https://w3c.github.io/ServiceWorker/#dfn-lifecycle-events), [install](https://w3c.github.io/ServiceWorker/#service-worker-global-scope-install-event) and [activate](https://w3c.github.io/ServiceWorker/#service-worker-global-scope-activate-event). [Service workers](https://w3c.github.io/ServiceWorker/#dfn-service-worker) use the [ExtendableEvent](https://w3c.github.io/ServiceWorker/#extendableevent) interface for [activate](https://w3c.github.io/ServiceWorker/#service-worker-global-scope-activate-event) event and [install](https://w3c.github.io/ServiceWorker/#service-worker-global-scope-install-event) event.

That's not completely wrong since `InstallEvent` inherits from `ExtendableEvent`, but maybe worth updating as well? The whole paragraph could perhaps be dropped since it does not really add new information: lifecycle events are already defined elsewhere, and the interface used is defined in algorithms (and summarized in the events table).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/ServiceWorker/pull/1706.html" title="Last updated on Feb 22, 2024, 9:44 AM UTC (81398f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1706/8d4b9df...tidoust:81398f7.html" title="Last updated on Feb 22, 2024, 9:44 AM UTC (81398f7)">Diff</a>