### PR TITLE
Editorial: Update link texts upon updates in the URLPattern specification

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3357,7 +3357,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: |rawPattern|, a {{URLPatternCompatible}}
       :: |serviceWorker|, a [=/service worker=]
       : Output
-      :: A [=URL pattern=] struct
+      :: A [=URL pattern=]
 
       1. Let |baseURL| be |serviceWorker|'s [=service worker/script url=].
       1. Return the result of [=building a URL pattern from a Web IDL value=] |rawPattern| given |baseURL|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3357,13 +3357,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: |rawPattern|, a {{URLPatternCompatible}}
       :: |serviceWorker|, a [=/service worker=]
       : Output
-      :: {{URLPattern}}
+      :: A [=URL pattern=] struct
 
       1. Let |baseURL| be |serviceWorker|'s [=service worker/script url=].
-      1. Return the result of [=building a URLPattern from a Web IDL value=] |rawPattern| given |baseURL| and |serviceWorker|'s [=service worker/global object=]'s [=relevant realm=].
-
-      Note: Since the [=building a URLPattern from a Web IDL value=] algorithm actually do not depend on the realm, it is  fine to call the algorithm here even if the [=service worker/global object=] may not be ready.
-
+      1. Return the result of [=building a URL pattern from a Web IDL value=] |rawPattern| given |baseURL|.
   </section>
 
   <section algorithm>
@@ -3379,7 +3376,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If |condition|["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
           1. Let |rawPattern| be |condition|["{{RouterCondition/urlPattern}}"].
           1. Let |pattern| be the result of running the <a>Parse URL Pattern</a> algorithm passing |rawPattern| and |serviceWorker|. If this throws an exception, catch it and return false.
-          1. If |pattern| [=URLPattern/has regexp groups=], then return false.
+          1. If |pattern| [=URL pattern/has regexp groups=], then return false.
 
               Note: Since running a user-defined regular expression has a security concern, it is prohibited.
 


### PR DESCRIPTION
Updates in the URLPattern specification was requested during the https://github.com/w3c/ServiceWorker/pull/1701 review.

The issues for the request has been resolved:
- https://github.com/whatwg/urlpattern/issues/217
- https://github.com/whatwg/urlpattern/issues/218

However, during the specification updates, the algorithm names are also updated and arguments are changed.
This is adjustments for them.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1707.html" title="Last updated on Mar 13, 2024, 12:45 PM UTC (96233ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1707/613f5a2...yoshisatoyanagisawa:96233ec.html" title="Last updated on Mar 13, 2024, 12:45 PM UTC (96233ec)">Diff</a>