### PR TITLE
Upstream change from Trusted Types

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -713,7 +713,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         readonly attribute ServiceWorker? controller;
         readonly attribute Promise&lt;ServiceWorkerRegistration&gt; ready;
 
-        [NewObject] Promise&lt;ServiceWorkerRegistration&gt; register(USVString scriptURL, optional RegistrationOptions options = {});
+        [NewObject] Promise&lt;ServiceWorkerRegistration&gt; register((TrustedScriptURL or USVString) scriptURL, optional RegistrationOptions options = {});
 
         [NewObject] Promise&lt;(ServiceWorkerRegistration or undefined)&gt; getRegistration(optional USVString clientURL = "");
         [NewObject] Promise&lt;FrozenArray&lt;ServiceWorkerRegistration&gt;&gt; getRegistrations();
@@ -782,6 +782,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       The <dfn method for="ServiceWorkerContainer"><code>register(|scriptURL|, |options|)</code></dfn> method steps are:
 
         1. Let |p| be a <a>promise</a>.
+        1. Set |scriptURL| to the result of invoking [$Get Trusted Type compliant string$] with {{TrustedScriptURL}}, [=this=]'s [=relevant global object=], |scriptURL|, "ServiceWorkerContainer register", and "script".
         1. Let |client| be [=this=]'s [=ServiceWorkerContainer/service worker client=].
         1. Let |scriptURL| be the result of <a lt="URL parser">parsing</a> |scriptURL| with [=this=]'s <a>relevant settings object</a>'s <a>API base URL</a>.
         1. Let |scopeURL| be null.


### PR DESCRIPTION
Changes register to take a union of (TrustedScriptURL or USVString) rather than just a USVString.

Updates the register method steps to call Get Trusted Type compliant string

Tested in https://wpt.live/trusted-types/WorkerGlobalScope-importScripts.html

Fixes https://github.com/w3c/ServiceWorker/issues/1710


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/ServiceWorker/pull/1709.html" title="Last updated on Apr 22, 2024, 1:53 PM UTC (4242fab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1709/613f5a2...lukewarlow:4242fab.html" title="Last updated on Apr 22, 2024, 1:53 PM UTC (4242fab)">Diff</a>