### PR TITLE
Editorial: Add notice on the _or condition depth.

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1596,6 +1596,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       };
     </pre>
 
+    Note: {{RouterCondition/_or}} and {{RouterCondition/not}} might have the other {{RouterCondition/_or}} or {{RouterCondition/not}} inside. To avoid spending much resources by the nested condition or performance penalty on evaluation, depth of such nested conditions can be limited.
+
     <section>
       <h4 id="register-router-method">{{InstallEvent/addRoutes(rules)|event.addRoutes(rules)}}</h4>
 
@@ -3392,6 +3394,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               Note: For ease of understanding the router rule, the "or" condition is mutually exclusive with other conditions.
 
           1. Let |orConditions| be |condition|["{{RouterCondition/_or}}"].
+
+              Note: To limit the resource usage and a condition evaluation time, |orConditions|'s [=list/size=] can be limited.
+
           1. For each |orCondition| of |orConditions|:
               1. If running the [=Verify Router Condition=] algorithm with |orCondition| and |serviceWorker| returns false, return false.
           1. Set |hasCondition| to true.


### PR DESCRIPTION
In https://github.com/WICG/service-worker-static-routing-api/issues/5 and https://github.com/WICG/service-worker-static-routing-api/issues/6, it was suggested to limit the number of conditions in the or condition syntax, and depth of nested and/or conditions.

This PR adds notice on such limitations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1714.html" title="Last updated on Apr 30, 2024, 6:04 AM UTC (ab80a3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1714/8d64a5c...yoshisatoyanagisawa:ab80a3c.html" title="Last updated on Apr 30, 2024, 6:04 AM UTC (ab80a3c)">Diff</a>