### PR TITLE
Ensure "race-network-and-fetch-handler" is used with a fetch handler

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1610,7 +1610,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1.  For each |rule| of |rules|:
             1. If running the [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, return [=a promise rejected with=] a {{TypeError}}.
             1. Append |rule| to |routerRules|.
-        1. If |routerRules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSourceEnum/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, return [=a promise rejected with=] a {{TypeError}}.
+        1. If |routerRules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is either of "{{RouterSourceEnum/fetch-event}}" or "{{RouterSourceEnum/race-network-and-fetch-handler}}", and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, return [=a promise rejected with=] a {{TypeError}}.
         1. Set |serviceWorker|'s [=service worker/list of router rules=] to |routerRules|.
         1. Return [=a promise resolved with=] undefined.
 


### PR DESCRIPTION
As covered in https://github.com/WICG/service-worker-static-routing-api?tab=readme-ov-file#how-does-it-work-if-there-is-no-fetch-handler, the fetch handler must exists not only for the "fetch-handler" source but also the "race-network-and-fetch-handler" source.  The "race-network-and-fetch-handler" source was not written in the last update.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1719.html" title="Last updated on Jan 28, 2025, 4:18 AM UTC (5873780)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1719/4e7e0fa...yoshisatoyanagisawa:5873780.html" title="Last updated on Jan 28, 2025, 4:18 AM UTC (5873780)">Diff</a>