### PR TITLE
Add constructor to InstallEvent

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1563,6 +1563,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
     <pre class="idl">
       [Exposed=ServiceWorker]
       interface InstallEvent : ExtendableEvent {
+        constructor(DOMString type, optional ExtendableEventInit eventInitDict = {});
         Promise&lt;undefined&gt; addRoutes((RouterRule or sequence&lt;RouterRule&gt;) rules);
       };
 


### PR DESCRIPTION
This closes #1713.

Originally InstallEvent was removed in #1207, then added again in #1701, but currently it doesn't have a constructor for no reason.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sisidovski/ServiceWorker/pull/1729.html" title="Last updated on Sep 27, 2024, 7:45 PM UTC (b8bffc9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1729/5408e2e...sisidovski:b8bffc9.html" title="Last updated on Sep 27, 2024, 7:45 PM UTC (b8bffc9)">Diff</a>