### PR TITLE
Allow the addRoutes() to be called during installing

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1564,7 +1564,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       [Exposed=ServiceWorker]
       interface InstallEvent : ExtendableEvent {
         constructor(DOMString type, optional ExtendableEventInit eventInitDict = {});
-        Promise&lt;undefined&gt; addRoutes(Promise&lt;(RouterRule or sequence&lt;RouterRule&gt;)&gt; rules);
+        Promise&lt;undefined&gt; addRoutes((RouterRule or sequence&lt;RouterRule&gt;) rules);
       };
 
       dictionary RouterRule {
@@ -1607,23 +1607,25 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
         1. Let |event| be [=this=].
         1. If |event|'s [=dispatch flag=] is unset, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
-        1. [=ExtendableEvent/Add lifetime promise=] |rules| to |event|.
+        1. If |rules| is not either of a {{RouterRule}} dictionary or a sequence of {{RouterRule}} dictionaries, then return [=a promise rejected with=] a {{TypeError}}.
+        1. If |rules| is a {{RouterRule}} dictionary, set |rules| to &#x00AB; |rules| &#x00BB;.
+        1.  For each |rule| of |rules|:
+            1. If running the [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, return [=a promise rejected with=] a {{TypeError}}.
+        1. If |rules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSourceEnum/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, return [=a promise rejected with=] a {{TypeError}}.
+        1. Let |promise| be a new [=promise=].
+        1. Run the following substeps [=in parallel=]:
+            1. [=ExtendableEvent/Add lifetime promise=] |promise| to |event|.
 
-            Note: {{InstallEvent/addRoutes(r)|event.addRoutes(r)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(r)}} is called.
+                Note: {{InstallEvent/addRoutes(rules)|event.addRoutes(rules)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(promise)}} is called.
 
-        1. Let |serviceWorker| be the [=current global object=]'s associated [=ServiceWorkerGlobalScope/service worker=].
-        1. Let |allRules| be a copy of |serviceWorker|'s [=list of router rules=].
-        1. [=Upon rejection=] of |rules|:
-            1. Return [=a promise rejected with=] a {{TypeError}}.
-        1. [=Upon fulfillment=] of |rules| with |routerRules|:
-            1. If |routerRules| is not either of a {{RouterRule}} dictionary or a sequence of {{RouterRule}} dictionaries, then return [=a promise rejected with=] a {{TypeError}}.
-            1. If |routerRules| is a {{RouterRule}} dictionary, set |routerRules| to &#x00AB; |routerRules| &#x00BB;.
-            1.  For each |rule| of |routerRules|:
-                1. If running the [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, return [=a promise rejected with=] a {{TypeError}}.
+            1. Let |serviceWorker| be the [=current global object=]'s associated [=ServiceWorkerGlobalScope/service worker=].
+            1. Let |allRules| be a copy of |serviceWorker|'s [=list of router rules=].
+            1.  For each |rule| of |rules|:
                 1. Append |rule| to |allRules|.
-            1. If |allRules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSourceEnum/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, return [=a promise rejected with=] a {{TypeError}}.
+
             1. Set |serviceWorker|'s [=service worker/list of router rules=] to |allRules|.
-            1. Return [=a promise resolved with=] undefined.
+            1. Resolve |promise| with undefined.
+        1. Return |promise|.
 
     </section>
   </section>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1605,15 +1605,13 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       The <dfn method for="InstallEvent"><code>addRoutes(|rules|)</code></dfn> method steps are:
 
-        1. Let |event| be [=this=].
-        1. If |event|'s [=dispatch flag=] is unset, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
         1. If |rules| is a {{RouterRule}} dictionary, set |rules| to &#x00AB; |rules| &#x00BB;.
         1. Let |serviceWorker| be the [=current global object=]'s associated [=ServiceWorkerGlobalScope/service worker=].
         1.  For each |rule| of |rules|:
             1. If running the [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, return [=a promise rejected with=] a {{TypeError}}.
             1. If |rule|["{{RouterRule/source}}"] is "{{RouterSourceEnum/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, return [=a promise rejected with=] a {{TypeError}}.
         1. Let |lifetimePromise| be a new [=promise=].
-        1. [=ExtendableEvent/Add lifetime promise=] |lifetimePromise| to |event|.
+        1. [=ExtendableEvent/Add lifetime promise=] |lifetimePromise| to [=this=].
 
             Note: {{InstallEvent/addRoutes(rules)|event.addRoutes(rules)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(promise)}} is called.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1609,16 +1609,16 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. If |event|'s [=dispatch flag=] is unset, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
         1. If |rules| is not either of a {{RouterRule}} dictionary or a sequence of {{RouterRule}} dictionaries, then return [=a promise rejected with=] a {{TypeError}}.
         1. If |rules| is a {{RouterRule}} dictionary, set |rules| to &#x00AB; |rules| &#x00BB;.
+        1. Let |serviceWorker| be the [=current global object=]'s associated [=ServiceWorkerGlobalScope/service worker=].
         1.  For each |rule| of |rules|:
             1. If running the [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, return [=a promise rejected with=] a {{TypeError}}.
         1. If |rules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSourceEnum/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, return [=a promise rejected with=] a {{TypeError}}.
         1. Let |promise| be a new [=promise=].
+        1. [=ExtendableEvent/Add lifetime promise=] |promise| to |event|.
+
+            Note: {{InstallEvent/addRoutes(rules)|event.addRoutes(rules)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(promise)}} is called.
+
         1. Run the following substeps [=in parallel=]:
-            1. [=ExtendableEvent/Add lifetime promise=] |promise| to |event|.
-
-                Note: {{InstallEvent/addRoutes(rules)|event.addRoutes(rules)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(promise)}} is called.
-
-            1. Let |serviceWorker| be the [=current global object=]'s associated [=ServiceWorkerGlobalScope/service worker=].
             1. Let |allRules| be a copy of |serviceWorker|'s [=list of router rules=].
             1.  For each |rule| of |rules|:
                 1. Append |rule| to |allRules|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1618,10 +1618,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
             Note: {{InstallEvent/addRoutes(rules)|event.addRoutes(rules)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(promise)}} is called.
 
         1. Let |promise| be a new [=promise=].
-        1. [=In parallel=]:
-            1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |promise|, resolve |lifetimePromise| with undefined.
+        1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |promise|, resolve |lifetimePromise| with undefined.
 
-                Note: this step is for making |lifetimePromise| always fullfilled to avoid the install event failure.
+            Note: this step is for making |lifetimePromise| always fullfilled to avoid the install event failure.
 
         1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
         1. [=Queue a task=] to run the following steps on |serviceWorkerEventLoop| using the [=DOM manipulation task source=]:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -214,6 +214,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A [=/service worker=] is said to be <dfn>running</dfn> if its [=event loop=] is running.
 
+    A [=/service worker=] has an associated <dfn>[[service worker queue]]</dfn> (a [=parallel queue=]).
+
     <section>
       <h4 id="service-worker-lifetime">Lifetime</h4>
 
@@ -1622,8 +1624,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
             Note: this step is for making |lifetimePromise| always fullfilled to avoid the install event failure.
 
-        1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
-        1. [=Queue a task=] to run the following steps on |serviceWorkerEventLoop| using the [=DOM manipulation task source=]:
+        1. [=queue/Enqueue=] the following steps to [=[[service worker queue]]=]:
             1. Let |allRules| be a copy of |serviceWorker|'s [=list of router rules=].
             1.  For each |rule| of |rules|:
                 1. Append |rule| to |allRules|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1612,10 +1612,16 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1.  For each |rule| of |rules|:
             1. If running the [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, return [=a promise rejected with=] a {{TypeError}}.
             1. If |rule|["{{RouterRule/source}}"] is "{{RouterSourceEnum/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, return [=a promise rejected with=] a {{TypeError}}.
-        1. Let |promise| be a new [=promise=].
-        1. [=ExtendableEvent/Add lifetime promise=] |promise| to |event|.
+        1. Let |lifetimePromise| be a new [=promise=].
+        1. [=ExtendableEvent/Add lifetime promise=] |lifetimePromise| to |event|.
 
             Note: {{InstallEvent/addRoutes(rules)|event.addRoutes(rules)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(promise)}} is called.
+
+        1. Let |promise| be a new [=promise=].
+        1. [=In parallel=]:
+            1. Upon [=upon fulfillment|fulfillment=] or [=upon rejection|rejection=] of |promise|, resolve |lifetimePromise| with undefined.
+
+                Note: this step is for making |lifetimePromise| always fullfilled to avoid the install event failure.
 
         1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
         1. [=Queue a task=] to run the following steps on |serviceWorkerEventLoop| using the [=DOM manipulation task source=]:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1630,7 +1630,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                 1. Append |rule| to |allRules|.
 
             1. Set |serviceWorker|'s [=service worker/list of router rules=] to |allRules|.
-            1. Resolve |promise| with undefined.
+            1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
+            1. [=Queue a task=] to run the following steps on |serviceWorkerEventLoop| using the [=DOM manipulation task source=]:
+                1. Resolve |promise| with undefined.
         1. Return |promise|.
     </section>
   </section>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1607,12 +1607,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
         1. Let |event| be [=this=].
         1. If |event|'s [=dispatch flag=] is unset, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
-        1. If |rules| is not either of a {{RouterRule}} dictionary or a sequence of {{RouterRule}} dictionaries, then return [=a promise rejected with=] a {{TypeError}}.
         1. If |rules| is a {{RouterRule}} dictionary, set |rules| to &#x00AB; |rules| &#x00BB;.
         1. Let |serviceWorker| be the [=current global object=]'s associated [=ServiceWorkerGlobalScope/service worker=].
         1.  For each |rule| of |rules|:
             1. If running the [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, return [=a promise rejected with=] a {{TypeError}}.
-        1. If |rules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSourceEnum/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, return [=a promise rejected with=] a {{TypeError}}.
+            1. If |rule|["{{RouterRule/source}}"] is "{{RouterSourceEnum/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, return [=a promise rejected with=] a {{TypeError}}.
         1. Let |promise| be a new [=promise=].
         1. [=ExtendableEvent/Add lifetime promise=] |promise| to |event|.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1564,7 +1564,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       [Exposed=ServiceWorker]
       interface InstallEvent : ExtendableEvent {
         constructor(DOMString type, optional ExtendableEventInit eventInitDict = {});
-        Promise&lt;undefined&gt; addRoutes((RouterRule or sequence&lt;RouterRule&gt;) rules);
+        Promise&lt;undefined&gt; addRoutes(Promise&lt;(RouterRule or sequence&lt;RouterRule&gt;)&gt; rules);
       };
 
       dictionary RouterRule {
@@ -1605,15 +1605,25 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       The <dfn method for="InstallEvent"><code>addRoutes(|rules|)</code></dfn> method steps are:
 
+        1. Let |event| be [=this=].
+        1. If |event|'s [=dispatch flag=] is unset, [=throw=] an "{{InvalidStateError}}" {{DOMException}}.
+        1. [=ExtendableEvent/Add lifetime promise=] |rules| to |event|.
+
+            Note: {{InstallEvent/addRoutes(r)|event.addRoutes(r)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(r)}} is called.
+
         1. Let |serviceWorker| be the [=current global object=]'s associated [=ServiceWorkerGlobalScope/service worker=].
-        1. Let |routerRules| be a copy of |serviceWorker|'s [=list of router rules=].
-        1. If |rules| is a {{RouterRule}} dictionary, set |rules| to &#x00AB; |rules| &#x00BB;.
-        1.  For each |rule| of |rules|:
-            1. If running the [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, return [=a promise rejected with=] a {{TypeError}}.
-            1. Append |rule| to |routerRules|.
-        1. If |routerRules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSourceEnum/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, return [=a promise rejected with=] a {{TypeError}}.
-        1. Set |serviceWorker|'s [=service worker/list of router rules=] to |routerRules|.
-        1. Return [=a promise resolved with=] undefined.
+        1. Let |allRules| be a copy of |serviceWorker|'s [=list of router rules=].
+        1. [=Upon rejection=] of |rules|:
+            1. Return [=a promise rejected with=] a {{TypeError}}.
+        1. [=Upon fulfillment=] of |rules| with |routerRules|:
+            1. If |routerRules| is not either of a {{RouterRule}} dictionary or a sequence of {{RouterRule}} dictionaries, then return [=a promise rejected with=] a {{TypeError}}.
+            1. If |routerRules| is a {{RouterRule}} dictionary, set |routerRules| to &#x00AB; |routerRules| &#x00BB;.
+            1.  For each |rule| of |routerRules|:
+                1. If running the [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, return [=a promise rejected with=] a {{TypeError}}.
+                1. Append |rule| to |allRules|.
+            1. If |allRules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is "{{RouterSourceEnum/fetch-event}}" and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, return [=a promise rejected with=] a {{TypeError}}.
+            1. Set |serviceWorker|'s [=service worker/list of router rules=] to |allRules|.
+            1. Return [=a promise resolved with=] undefined.
 
     </section>
   </section>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1617,7 +1617,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
             Note: {{InstallEvent/addRoutes(rules)|event.addRoutes(rules)}} extends the lifetime of the event by default as if {{ExtendableEvent/waitUntil()|event.waitUntil(promise)}} is called.
 
-        1. Run the following substeps [=in parallel=]:
+        1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
+        1. [=Queue a task=] to run the following steps on |serviceWorkerEventLoop| using the [=DOM manipulation task source=]:
             1. Let |allRules| be a copy of |serviceWorker|'s [=list of router rules=].
             1.  For each |rule| of |rules|:
                 1. Append |rule| to |allRules|.


### PR DESCRIPTION
This is a fix for https://github.com/w3c/ServiceWorker/issues/1742 and https://github.com/w3c/ServiceWorker/issues/1743.

Currently, it is technically possible to call `addRoutes()` outside of the install event.  This change follows how `FetchEvent.respondWith()` deal with the case, and prevents the `addRoutes()` method to be called outside of the install event.
At the same time, the event wait until a promise returned by `addRoutes()` resolves.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1744.html" title="Last updated on Jan 30, 2025, 1:06 AM UTC (b8ab89e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1744/0c42aff...yoshisatoyanagisawa:b8ab89e.html" title="Last updated on Jan 30, 2025, 1:06 AM UTC (b8ab89e)">Diff</a>