### PR TITLE
Check requestMethod

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3383,7 +3383,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               Note: Since running a user-defined regular expression has a security concern, it is prohibited.
 
           1. Set |hasCondition| to true.
-      1. If |condition|["{{RouterCondition/requestMethod}}"] [=map/exists=], set |hasCondition| to true.
+      1. If |condition|["{{RouterCondition/requestMethod}}"] [=map/exists=]:
+          1. Let |method| be |condition|["{{RouterCondition/requestMethod}}"].
+          1. If |method| is not a [=/method=], then return false.
+          1. If |method| is a [=forbidden method=], then return false.
+          1. Set |hasCondition| to true.
       1. If |condition|["{{RouterCondition/requestMode}}"] [=map/exists=], set |hasCondition| to true.
       1. If |condition|["{{RouterCondition/requestDestination}}"] [=map/exists=], set |hasCondition| to true.
       1. If |condition|["{{RouterCondition/runningStatus}}"] [=map/exists=], set |hasCondition| to true.
@@ -3435,6 +3439,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If running [=match=] with |pattern| and |request|'s [=request/URL=] returns null, return false.
           1. If |condition|["{{RouterCondition/requestMethod}}"] [=map/exists=], then:
               1. Let |method| be |condition|["{{RouterCondition/requestMethod}}"].
+              1. [=method/Normalize=] |method|.
               1. If |request|'s [=request/method=] is not |method|, return false.
           1. If |condition|["{{RouterCondition/requestMode}}"] [=map/exists=], then:
               1. Let |mode| be |condition|["{{RouterCondition/requestMode}}"].


### PR DESCRIPTION
As suggested in https://github.com/w3c/ServiceWorker/issues/1747, addRoutes() checks requestMethod is valid, and matching will happens with a normalized method.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1748.html" title="Last updated on Jan 23, 2025, 7:54 AM UTC (2f58e56)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1748/e23f928...yoshisatoyanagisawa:2f58e56.html" title="Last updated on Jan 23, 2025, 7:54 AM UTC (2f58e56)">Diff</a>