### PR TITLE
Update editors

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -5,10 +5,12 @@ ED: https://w3c.github.io/ServiceWorker/
 TR: https://www.w3.org/TR/service-workers/
 Shortname: service-workers
 Level:
-Editor: Jake Archibald, w3cid 76394, Google, jakearchibald@chromium.org
-Editor: Marijn Kruisselbrink, w3cid 72440, Google, mek@chromium.org
+Editor: Monica Chintala, w3cid 160353, Microsoft, monicach@microsoft.com
+Editor: Yoshisato Yanagisawa, w3cid 142513, Google, yyanagisawa@chromium.org
 Former Editor: Alex Russell, Google, slightlyoff@chromium.org
+Former Editor: Jake Archibald, w3cid 76394, Google, jakearchibald@chromium.org
 Former Editor: Jungkee Song, Microsoft&sbquo; represented Samsung until April 2018, jungkee.song@microsoft.com
+Former Editor: Marijn Kruisselbrink, w3cid 72440, Google, mek@chromium.org
 Repository: w3c/ServiceWorker
 Group: serviceworkers
 !Tests: <a href=https://github.com/web-platform-tests/wpt/tree/master/service-workers>web-platform-tests service-workers/</a> (<a href=https://github.com/web-platform-tests/wpt/labels/service-workers>ongoing work</a>)


### PR DESCRIPTION
Thanks Jake and Marijn for their great contributions to the ServiceWorker.  Especially, they advised me on standardizing the declarative routing (aka. SW static routing API), which brought me lots of learnings to the ServiceWorker and the standardization process.  I cannot thank you enough for that.

Recently, I and Monica became editors, and this change updates the editor lines.  We are happy to contribute to the specification and improve it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1750.html" title="Last updated on Jan 26, 2025, 11:50 PM UTC (0f8a126)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1750/522a17c...yoshisatoyanagisawa:0f8a126.html" title="Last updated on Jan 26, 2025, 11:50 PM UTC (0f8a126)">Diff</a>