### PR TITLE
Editorial: Fix linking errors on [=document=]

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -329,13 +329,13 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       When a [=window client=] is [created](https://html.spec.whatwg.org/#set-up-a-window-environment-settings-object) in the process of a [=/browsing context=] [creation](https://html.spec.whatwg.org/#creating-a-new-browsing-context):
 
       If the [=/browsing context=]'s initial [=active document=]'s [=/origin=] is an [=opaque origin=], the [=window client=]'s [=active service worker=] is set to null.
-      Otherwise, it is set to the creator [=document=]'s [=/service worker client=]'s [=active service worker=].
+      Otherwise, it is set to the creator [=/document=]'s [=/service worker client=]'s [=active service worker=].
 
       When a [=window client=] is [created](https://html.spec.whatwg.org/#set-up-a-window-environment-settings-object) in the process of the [=/browsing context=]'s [=navigate|navigation=]:
 
       If the [=fetch=] is routed through [=/HTTP fetch=], the [=window client=]'s [=active service worker=] is set to the result of the <a lt="Match Service Worker Registration">service worker registration matching</a>.
-      Otherwise, if the created [=document=]'s [=/origin=] is an [=opaque origin=] or not the [=same origin|same=] as its creator [=document=]'s [=/origin=], the [=window client=]'s [=active service worker=] is set to null.
-      Otherwise, it is set to the creator [=document=]'s [=/service worker client=]'s [=active service worker=].
+      Otherwise, if the created [=/document=]'s [=/origin=] is an [=opaque origin=] or not the [=same origin|same=] as its creator [=/document=]'s [=/origin=], the [=window client=]'s [=active service worker=] is set to null.
+      Otherwise, it is set to the creator [=/document=]'s [=/service worker client=]'s [=active service worker=].
 
       Note: For an initial replacement [=navigate|navigation=], the initial [=window client=] that was [created](https://html.spec.whatwg.org/#set-up-a-window-environment-settings-object) when the [=/browsing context=] was [created](https://html.spec.whatwg.org/#creating-a-new-browsing-context) is reused, but the [=active service worker=] is determined by the same behavior as above.
 
@@ -354,7 +354,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       Otherwise, it is set to the [=active service worker=] of the [=environment settings object=] of the last [=set/item=] in the [=worker client=]'s [=/global object=]'s [=owner set=].
     </section>
 
-    Note: [=Window clients=] and [=worker clients=] with a [data: URL](https://tools.ietf.org/html/rfc2397#section-2) result in having the [=active service worker=] value of null as their [=/origin=] is an [=opaque origin=]. [=Window clients=] and [=worker clients=] with a [=blob URL=] can inherit the [=active service worker=] of their creator [=document=] or owner, but if the [=/request=]'s [=request/origin=] is not the [=same origin|same=] as the [=/origin=] of their creator [=document=] or owner, the [=active service worker=] is set to null.
+    Note: [=Window clients=] and [=worker clients=] with a [data: URL](https://tools.ietf.org/html/rfc2397#section-2) result in having the [=active service worker=] value of null as their [=/origin=] is an [=opaque origin=]. [=Window clients=] and [=worker clients=] with a [=blob URL=] can inherit the [=active service worker=] of their creator [=/document=] or owner, but if the [=/request=]'s [=request/origin=] is not the [=same origin|same=] as the [=/origin=] of their creator [=/document=] or owner, the [=active service worker=] is set to null.
   </section>
 
   <section>


### PR DESCRIPTION
Bikeshed originally said:

>  Multiple possible 'document' dfn refs.
>  Arbitrarily chose https://dom.spec.whatwg.org/#clone-a-node-document
>  To auto-select one of the following refs, insert one of these lines into a `<pre class=link-defaults>` block:
>  spec:dom; type:dfn; for:clone a node; text:document
>  spec:dom; type:dfn; for:/; text:document
>  [=document=]

I think all of them are intended to be [=/document=] instead of [=clone a node/document=].


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1751.html" title="Last updated on Jan 29, 2025, 4:27 AM UTC (e359b0a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1751/a14460b...yoshisatoyanagisawa:e359b0a.html" title="Last updated on Jan 29, 2025, 4:27 AM UTC (e359b0a)">Diff</a>