### PR TITLE
Add limits to the number of router rule registration

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -212,6 +212,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A [=/service worker=] has an associated <dfn>list of router rules</dfn> (a [=list=] of {{RouterRule}}s). It is initially an empty [=list=].
 
+    A [=/service worker=] has an associated <dfn>router rule count</dfn> (the number of registered {{RouterRule}}s). It is initially set to zero.
+
+    Note: [=router rule count=] is defined as the limit of the total number of registered router rules. This prevents the user agent from spending much resources by evaluating too many router rules. The limit is 1024.
+
     A [=/service worker=] is said to be <dfn>running</dfn> if its [=event loop=] is running.
 
     <section>
@@ -3401,9 +3405,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               Note: For ease of understanding the router rule, the "or" condition is mutually exclusive with other conditions.
 
           1. Let |orConditions| be |condition|["{{RouterCondition/_or}}"].
-
+         
               Note: To limit the resource usage and a condition evaluation time, |orConditions|'s [=list/size=] can be limited.
-
+ 
           1. For each |orCondition| of |orConditions|:
               1. If running the [=Verify Router Condition=] algorithm with |orCondition| and |serviceWorker| returns false, return false.
           1. Set |hasCondition| to true.
@@ -3414,6 +3418,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
           1. If running the [=Verify Router Condition=] algorithm with |condition|["{{RouterCondition/not}}"] and |serviceWorker| returns false, return false.
           1. Set |hasCondition| to true.
+      1. If |hasCondition| is true, then:
+          1. Increament |serviceWorker|'s [=service worker/router rule count=] by one.
+          1. If |serviceWorker|'s [=service worker/router rule count=] exceeds 1024, which is the limit of registered router rules, return false.
       1. Return |hasCondition|.
   </section>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1600,6 +1600,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       };
     </pre>
 
+    Note: {{RouterCondition/_or}} and {{RouterCondition/not}} might have the other {{RouterCondition/_or}} or {{RouterCondition/not}} inside. To avoid spending much resources by the nested condition or performance penalty on evaluation, depth of such nested conditions can be limited.
+
     <section>
       <h4 id="register-router-method">{{InstallEvent/addRoutes(rules)|event.addRoutes(rules)}}</h4>
 
@@ -3399,6 +3401,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               Note: For ease of understanding the router rule, the "or" condition is mutually exclusive with other conditions.
 
           1. Let |orConditions| be |condition|["{{RouterCondition/_or}}"].
+
+              Note: To limit the resource usage and a condition evaluation time, |orConditions|'s [=list/size=] can be limited.
+
           1. For each |orCondition| of |orConditions|:
               1. If running the [=Verify Router Condition=] algorithm with |orCondition| and |serviceWorker| returns false, return false.
           1. Set |hasCondition| to true.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3494,7 +3494,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. [=list/For each=] |rule| of |routerRules|:
           1. Set |result| to be the result of running [=Count Router Inner Conditions=] with |rule|["{{RouterRule/condition}}"], |result|, and 10.
           1. If |result|'s [=count router condition result/quota exceeded=] is true, return false.
-      1. return true.
+      1. Return true.
   </section> 
 
   <section algorithm>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -212,10 +212,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A [=/service worker=] has an associated <dfn>list of router rules</dfn> (a [=list=] of {{RouterRule}}s). It is initially an empty [=list=].
 
-    A [=/service worker=] has an associated <dfn>router rule count</dfn> (the number of registered {{RouterRule}}s). It is initially set to zero.
-
-    Note: [=router rule count=] is defined as the limit of the total number of registered router rules. This prevents the user agent from spending much resources by evaluating too many router rules. The limit is 1024.
-
     A [=/service worker=] is said to be <dfn>running</dfn> if its [=event loop=] is running.
 
     <section>
@@ -1604,7 +1600,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       };
     </pre>
 
-    Note: {{RouterCondition/_or}} and {{RouterCondition/not}} might have the other {{RouterCondition/_or}} or {{RouterCondition/not}} inside. To avoid spending much resources by the nested condition or performance penalty on evaluation, depth of such nested conditions can be limited.
+    A <dfn export id="dfn-count-router-condition-result">count router condition result</dfn> is a [=struct=] that consists of:
+      * A <dfn export id="dfn-count-router-condition-result-total-count" for="count router condition result">total count</dfn> (a number).
+      * A <dfn export id="dfn-dfn-count-router-condition-result-depth" for="count router condition result">depth</dfn> (a number).
 
     <section>
       <h4 id="register-router-method">{{InstallEvent/addRoutes(rules)|event.addRoutes(rules)}}</h4>
@@ -1620,6 +1618,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
             1. If running the [=Verify Router Condition=] algorithm with |rule|["{{RouterRule/condition}}"] and |serviceWorker| returns false, return [=a promise rejected with=] a {{TypeError}}.
             1. Append |rule| to |routerRules|.
         1. If |routerRules| [=list/contains=] a {{RouterRule}} whose {{RouterRule/source}} is either of "{{RouterSourceEnum/fetch-event}}" or "{{RouterSourceEnum/race-network-and-fetch-handler}}", and |serviceWorker|'s [=set of event types to handle=] does not [=set/contain=] {{ServiceWorkerGlobalScope/fetch!!event}}, return [=a promise rejected with=] a {{TypeError}}.
+        1. If running the [=Check Router Registration Limit=] with |routerRules| returns false, return [=a promise rejected with=] a {{TypeError}}.
         1. Set |serviceWorker|'s [=service worker/list of router rules=] to |routerRules|.
         1. Return [=a promise resolved with=] undefined.
 
@@ -3405,9 +3404,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               Note: For ease of understanding the router rule, the "or" condition is mutually exclusive with other conditions.
 
           1. Let |orConditions| be |condition|["{{RouterCondition/_or}}"].
-         
-              Note: To limit the resource usage and a condition evaluation time, |orConditions|'s [=list/size=] can be limited.
- 
           1. For each |orCondition| of |orConditions|:
               1. If running the [=Verify Router Condition=] algorithm with |orCondition| and |serviceWorker| returns false, return false.
           1. Set |hasCondition| to true.
@@ -3418,9 +3414,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
           1. If running the [=Verify Router Condition=] algorithm with |condition|["{{RouterCondition/not}}"] and |serviceWorker| returns false, return false.
           1. Set |hasCondition| to true.
-      1. If |hasCondition| is true, then:
-          1. Increament |serviceWorker|'s [=service worker/router rule count=] by one.
-          1. If |serviceWorker|'s [=service worker/router rule count=] exceeds 1024, which is the limit of registered router rules, return false.
       1. Return |hasCondition|.
   </section>
 
@@ -3466,6 +3459,57 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. If |runningStatus| is {{RunningStatus/"running"}}, and |serviceWorker| is not [=running=], return false.
               1. If |runningStatus| is {{RunningStatus/"not-running"}}, and |serviceWorker| is [=running=], return false.
           1. Return true.
+  </section>
+
+  <section algorithm>
+    <h3 id="check-router-registration-limit"><dfn>Check Router Registration Limit</dfn></h3>
+
+      : Input
+      :: |routerRules|, a [=list of router rules=]
+      : Output
+      :: a boolean
+
+      Note: Router conditions can be complex and nested using {{RouterCondition/_or}} and {{RouterCondition/not}}. To prevent excessive processing, this algorithm introduces two limits. First, the total number of conditions, counting all nested conditions, cannot exceed 1024. Second, the nesting depth is limited to 10 levels to avoid exponential computation.
+
+      1. Let |result| be a [=count router condition result=].
+      1. Set |result|'s [=count router condition result/total count=] to 0.
+      1. Set |result|'s [=count router condition result/depth=] to 1.
+      1. Let |maxCount| be 1024.
+      1. Let |maxDepth| be 10.
+      1. [=list/For each=] |rule| of |routerRules|:
+          1. Let |currentResult| be the result of running [=Count Router Inner Conditions=] with |rule|["{{RouterRule/condition}}"], |result|, |maxCount|, and |maxDepth|.
+          1. If |currentResult|'s [=count router condition result/total count=] exceeds |maxCount|, return false.
+          1. If |currentResult|'s [=count router condition result/depth=] exceeds |maxDepth|, return false.
+          1. Set |result|'s [=count router condition result/total count=] to |currentResult|'s [=count router condition result/total count=].
+      1. return true.
+  </section> 
+
+  <section algorithm>
+    <h3 id="count-router-inner-conditions"><dfn>Count Router Inner Conditions</dfn></h3>
+
+      : Input
+      :: |condition|, a {{RouterCondition}}
+      :: |result|, a [=count router condition result=]
+      :: |maxCount|, a number
+      :: |maxDepth|, a number
+      : Output
+      :: |result|, a [=count router condition result=]
+
+      1. Increment |result|'s [=count router condition result/total count=] by one.
+      1. If |result|'s [=count router condition result/total count=] exceeds |maxCount|, return |result|.
+      1. If |result|'s [=count router condition result/depth=] exceeds |maxDepth|, return |result|.
+      1. If |condition|["{{RouterCondition/_or}}"] [=map/exists=], then:
+          1. Increment |result|'s [=count router condition result/depth=] by one.
+          1. For each |orCondition| of |condition|["{{RouterCondition/_or}}"]:
+              1. Set |result| to be the result of running [=Count Router Inner Conditions=] with |orCondition|, |result|, |maxCount|, and |maxDepth|.
+              1. If |result|'s [=count router condition result/total count=] exceeds |maxCount|, return |result|.
+              1. If |result|'s [=count router condition result/depth=] exceeds |maxDepth|, return |result|.
+      1. Else if |condition|["{{RouterCondition/not}}"] [=map/exists=], then:
+          1. Increment |result|'s [=count router condition result/depth=] by one.
+          1. Set |result| to be the result of running [=Count Router Inner Conditions=] with |condition|["{{RouterCondition/not}}"], |result|, |maxCount|, and |maxDepth|.
+          1. If |result|'s [=count router condition result/total count=] exceeds |maxCount|, return |result|.
+          1. If |result|'s [=count router condition result/depth=] exceeds |maxDepth|, return |result|. 
+      1. Return |result|.
   </section>
 
   <section algorithm>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1600,9 +1600,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       };
     </pre>
 
-    A <dfn export id="dfn-count-router-condition-result">count router condition result</dfn> is a [=struct=] that consists of:
-      * A <dfn export id="dfn-count-router-condition-result-total-count" for="count router condition result">total count</dfn> (a number).
-      * A <dfn export id="dfn-dfn-count-router-condition-result-depth" for="count router condition result">depth</dfn> (a number).
+    A <dfn id="dfn-count-router-condition-result">count router condition result</dfn> is a [=struct=] that consists of:
+      * A <dfn id="dfn-count-router-condition-result-total-count" for="count router condition result">total count</dfn> (a number).
+      * A <dfn id="dfn-dfn-count-router-condition-result-depth" for="count router condition result">depth</dfn> (a number).
 
     <section>
       <h4 id="register-router-method">{{InstallEvent/addRoutes(rules)|event.addRoutes(rules)}}</h4>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1601,8 +1601,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
     </pre>
 
     A <dfn id="dfn-count-router-condition-result">count router condition result</dfn> is a [=struct=] that consists of:
-      * A <dfn id="dfn-count-router-condition-result-total-count" for="count router condition result">total count</dfn> (a number).
-      * A <dfn id="dfn-dfn-count-router-condition-result-depth" for="count router condition result">depth</dfn> (a number).
+      * A <dfn id="dfn-count-router-condition-result-condition-count" for="count router condition result">condition count</dfn> (a number).
+      * A <dfn id="dfn-dfn-count-router-condition-result-quota-exceeded" for="count router condition result">quota exceeded</dfn> (a boolean).
 
     <section>
       <h4 id="register-router-method">{{InstallEvent/addRoutes(rules)|event.addRoutes(rules)}}</h4>
@@ -3472,15 +3472,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       Note: Router conditions can be complex and nested using {{RouterCondition/_or}} and {{RouterCondition/not}}. To prevent excessive processing, this algorithm introduces two limits. First, the total number of conditions, counting all nested conditions, cannot exceed 1024. Second, the nesting depth is limited to 10 levels to avoid exponential computation.
 
       1. Let |result| be a [=count router condition result=].
-      1. Set |result|'s [=count router condition result/total count=] to 0.
-      1. Set |result|'s [=count router condition result/depth=] to 1.
-      1. Let |maxCount| be 1024.
-      1. Let |maxDepth| be 10.
+      1. Set |result|'s [=count router condition result/condition count=] to 1024.
+      1. Set |result|'s [=count router condition result/quota exceeded=] to false.
       1. [=list/For each=] |rule| of |routerRules|:
-          1. Let |currentResult| be the result of running [=Count Router Inner Conditions=] with |rule|["{{RouterRule/condition}}"], |result|, |maxCount|, and |maxDepth|.
-          1. If |currentResult|'s [=count router condition result/total count=] exceeds |maxCount|, return false.
-          1. If |currentResult|'s [=count router condition result/depth=] exceeds |maxDepth|, return false.
-          1. Set |result|'s [=count router condition result/total count=] to |currentResult|'s [=count router condition result/total count=].
+          1. Set |result| to be the result of running [=Count Router Inner Conditions=] with |rule|["{{RouterRule/condition}}"], |result|, and 10.
+          1. If |result|'s [=count router condition result/quota exceeded=] is true, return false.
       1. return true.
   </section> 
 
@@ -3490,25 +3486,23 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Input
       :: |condition|, a {{RouterCondition}}
       :: |result|, a [=count router condition result=]
-      :: |maxCount|, a number
-      :: |maxDepth|, a number
+      :: |depth|, a number
       : Output
       :: |result|, a [=count router condition result=]
 
-      1. Increment |result|'s [=count router condition result/total count=] by one.
-      1. If |result|'s [=count router condition result/total count=] exceeds |maxCount|, return |result|.
-      1. If |result|'s [=count router condition result/depth=] exceeds |maxDepth|, return |result|.
+      1. Decrement |result|'s [=count router condition result/condition count=] by one.
+      1. If |result|'s [=count router condition result/condition count=] is zero, or |depth| is zero, then:
+          1. Set |result|'s [=count router condition result/quota exceeded=] to be true.
+          1. Return |result|.
       1. If |condition|["{{RouterCondition/_or}}"] [=map/exists=], then:
-          1. Increment |result|'s [=count router condition result/depth=] by one.
+          1. Decrement |depth| by one.
           1. For each |orCondition| of |condition|["{{RouterCondition/_or}}"]:
-              1. Set |result| to be the result of running [=Count Router Inner Conditions=] with |orCondition|, |result|, |maxCount|, and |maxDepth|.
-              1. If |result|'s [=count router condition result/total count=] exceeds |maxCount|, return |result|.
-              1. If |result|'s [=count router condition result/depth=] exceeds |maxDepth|, return |result|.
+              1. Set |result| to be the result of running [=Count Router Inner Conditions=] with |orCondition|, |result|, and |depth|.
+              1. If |result|'s [=count router condition result/quota exceeded=] is true, return |result|.
       1. Else if |condition|["{{RouterCondition/not}}"] [=map/exists=], then:
-          1. Increment |result|'s [=count router condition result/depth=] by one.
-          1. Set |result| to be the result of running [=Count Router Inner Conditions=] with |condition|["{{RouterCondition/not}}"], |result|, |maxCount|, and |maxDepth|.
-          1. If |result|'s [=count router condition result/total count=] exceeds |maxCount|, return |result|.
-          1. If |result|'s [=count router condition result/depth=] exceeds |maxDepth|, return |result|. 
+          1. Decrement |depth| by one.
+          1. Set |result| to be the result of running [=Count Router Inner Conditions=] with |condition|["{{RouterCondition/not}}"], |result|, and |depth|.
+          1. If |result|'s [=count router condition result/quota exceeded=] is true, return |result|.
       1. Return |result|.
   </section>
 


### PR DESCRIPTION
In https://github.com/w3c/ServiceWorker/issues/1746, we discussed if the spec should give guidelines about the limit of added routes, and how the user agent should behave if the added routes exceeds the limit.

We have an agreement that we're willing to pick some specific limits. This PR proposes 1024 as the total number of router conditions, and 10 as the max depth of router condition nesting level. If it exceeds those limits, the user agent throws a TypeError.

For the counting conditions part, let me clarify how we calculate the total count as this a bit tricky.

Assuming that router conditions can be nested by using `or` and `not` syntaxes. We count every sub router conditions inside the parent `or` or `not` condition, including the parent condition itself. 

Here are some examples.

```js
self.addEventListener('install', event => {
  // The condition count of this addRoutes() is 1.
  //
  // The max nesting level is 1.
  event.addRoutes({
    condition: {
      urlPattern: { pathname: "/form/*" },
    },
    source: "network"
  });

  // The condition count of this addRoutes() is 1.
  // Even though there are multiple fields in one router condition, we treat is as 1.
  //
  // The max nesting level is 1.
  event.addRoutes({
    condition: {
      urlPattern: { pathname: "/form/*" },
      requestMethod: "post",
      requestMode: "navigation",
      runningStatus: "running"
    },
    source: "network"
  });

  // The condition count of this addRoutes() is 2.
  //
  // The max nesting level is 1.
  event.addRoutes([
    {
      condition: { requestMethod: "post" },
      source: "network"
    },
    {
      condition: { requestMethod: "get" },
      source: "network"
    }
  ]);

  // The condition count of this addRoutes() is 4.
  // `or` condition itself is inluded in the total count.
  //
  // The max nesting level is 2.
  event.addRoutes([
    {
      condition: {
        or: [
          { urlPattern: { pathname: "/form/*" } },
          { requestMethod: "post" },
          { requestMode: "navigate" },
        ]
      },
      source: "network"
    }
  ]);

  // The condition count of this addRoutes() is 7.
  // 3 `or` + 1 `not` + 1 `requestMethod` + 1 `requestMode` + 1 `runningStatus` = 7
  //
  // The max nesting level is 5.
  event.addRoutes([
    {
      condition: {
        or: [
          {
            or: [{
              or: [
                { requestMethod: 'get' },
                {
                  not: {
                    requestMode: 'navigate'
                  }
                }
              ]
            }]
          },
          { runningStatus: 'running' }
        ]
      },
      source: "network"
    }
  ]);

  // In total, 15 router conditions are registered in the install event.
  // Max nesting level is 5.
});
```


https://github.com/w3c/ServiceWorker/pull/1714 will be migrated into this PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sisidovski/ServiceWorker/pull/1752.html" title="Last updated on Feb 6, 2025, 5:43 AM UTC (645a400)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1752/b6ac20c...sisidovski:645a400.html" title="Last updated on Feb 6, 2025, 5:43 AM UTC (645a400)">Diff</a>