### PR TITLE
Editorial: Fix bikeshed warning

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3479,7 +3479,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section algorithm>
-    <h3 id="check-router-registration-limit"><dfn>Check Router Registration Limit</dfn></h3>
+    <h3 id="check-router-registration-limit-algorithm"><dfn>Check Router Registration Limit</dfn></h3>
 
       : Input
       :: |routerRules|, a [=list of router rules=]
@@ -3495,10 +3495,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Set |result| to be the result of running [=Count Router Inner Conditions=] with |rule|["{{RouterRule/condition}}"], |result|, and 10.
           1. If |result|'s [=count router condition result/quota exceeded=] is true, return false.
       1. Return true.
-  </section> 
+  </section>
 
   <section algorithm>
-    <h3 id="count-router-inner-conditions"><dfn>Count Router Inner Conditions</dfn></h3>
+    <h3 id="count-router-inner-conditions-algorithm"><dfn>Count Router Inner Conditions</dfn></h3>
 
       : Input
       :: |condition|, a {{RouterCondition}}


### PR DESCRIPTION
Let me fix the following warnings by adding "-algorithm" to the ids.

```
WARNING: Multiple elements have the same id 'check-router-registration-limit':
  <h3> on line 3482, <dfn> on line 3482
Deduping, but this ID may not be stable across revisions. WARNING: Multiple elements have the same id 'count-router-inner-conditions':
  <h3> on line 3501, <dfn> on line 3501
Deduping, but this ID may not be stable across revisions.
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1753.html" title="Last updated on Feb 12, 2025, 9:09 AM UTC (ddc4199)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1753/b05ac32...yoshisatoyanagisawa:ddc4199.html" title="Last updated on Feb 12, 2025, 9:09 AM UTC (ddc4199)">Diff</a>