### PR TITLE
Editorial: fix typo around "mutual exclusive"

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3455,7 +3455,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           1. Return true.
       1. Else:
 
-          Note: The [=Verify Router Condition=] algorithm guarantees that {{RouterCondition/or}} and other conditions are mutual exclusive.
+          Note: The [=Verify Router Condition=] algorithm guarantees that {{RouterCondition/or}}, {{RouterCondition/not}}, and other conditions are mutually exclusive.
 
           1. If |condition|["{{RouterCondition/urlPattern}}"] [=map/exists=], then:
               1. Let |rawPattern| be |condition|["{{RouterCondition/urlPattern}}"].


### PR DESCRIPTION
This is for addressing https://github.com/w3c/ServiceWorker/issues/1716. I also found that "not" should also be an exclusive condition. Let me update.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1754.html" title="Last updated on Feb 14, 2025, 7:24 AM UTC (ed07464)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1754/b8255db...yoshisatoyanagisawa:ed07464.html" title="Last updated on Feb 14, 2025, 7:24 AM UTC (ed07464)">Diff</a>