### PR TITLE
ServiceWorkerAutoPreload

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3228,6 +3228,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |shouldSoftUpdate| be true if any of the following are true, and false otherwise:
           * |request| is a [=non-subresource request=].
           * |request| is a [=subresource request=] and |registration| is [=stale=].
+      1. Let |raceResponse| be null. 
       1. Let |source| be null.
       1. If |activeWorker|'s [=service worker/list of router rules=] [=list/is not empty=]:
           1. Set |timingInfo|’s [=service worker timing info/worker router evaluation start=] to the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
@@ -3263,7 +3264,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
                   1. Let |queue| be an empty [=queue=] of [=race result=].
                   1. Let |raceFetchController| be null.
-                  1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
+                  1. Set |raceResponse| to be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
                   1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                           1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
@@ -3316,7 +3317,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               Note: A user agent may speculatively dispatch a network request in parallel with creating a fetch event in order to minimize the bootstrap cost.
 
               1. Let |autoPreloadFetchController| be null.
-              1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
+              1. Set |raceResponse| to be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
               1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                   1. Set |autoPreloadFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |autoPreloadRequestResponse|:
                   1. If |autoPreloadRequestResponse|'s [=response/status=] is [=ok status=], set |raceResponse|'s [=race response/value=] to |autoPreloadRequestResponse|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3228,10 +3228,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |shouldSoftUpdate| be true if any of the following are true, and false otherwise:
           * |request| is a [=non-subresource request=].
           * |request| is a [=subresource request=] and |registration| is [=stale=].
-      1. Let |source| be null.
       1. If |activeWorker|'s [=service worker/list of router rules=] [=list/is not empty=]:
           1. Set |timingInfo|’s [=service worker timing info/worker router evaluation start=] to the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
-          1. Set |source| to be the result of running the [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
+          1. Let |source| be the result of running the [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
           1. If |source| is non-null, then:
               1. Set |timingInfo|'s [=service worker timing info/worker matched router source=] be set to |source|, and [=service worker timing info/worker final router source=] be set to {{RouterSourceEnum/"network"}}.
               1. If |source| is {{RouterSourceEnum/"network"}}:
@@ -3312,7 +3311,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. [=If aborted=], then:
                   1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
                   1. [=fetch controller/Abort=] |preloadFetchController| with |deserializedError|.
-          1. Else if |source| is not "{{RouterSourceEnum/fetch-event}}", a user agent may run the following substeps:
+          1. Else if |timingInfo|'s [=service worker timing info/worker matched router source=] is not "{{RouterSourceEnum/fetch-event}}", a user agent may run the following substeps:
 
               Note: A user agent may speculatively dispatch a network request in parallel with creating a fetch event in order to minimize the bootstrap cost.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3228,6 +3228,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |shouldSoftUpdate| be true if any of the following are true, and false otherwise:
           * |request| is a [=non-subresource request=].
           * |request| is a [=subresource request=] and |registration| is [=stale=].
+      1. Let |raceResponse| be null.
       1. If |activeWorker|'s [=service worker/list of router rules=] [=list/is not empty=]:
           1. Set |timingInfo|’s [=service worker timing info/worker router evaluation start=] to the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
           1. Let |source| be the result of running the [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
@@ -3287,29 +3288,43 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Set |routedResponse|'s [=service worker timing info=]'s [=service worker timing info/worker final router source=] be set to |result|'s [=race result/used route=].
                   1. Return |routedResponse|.
               1. Assert: |source| is "{{RouterSourceEnum/fetch-event}}"
-      1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
+      1. If |request| is a [=navigation request=], |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
+          1. If |registration|'s [=navigation preload enabled flag=] is set then: 
 
-          Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.
+              Note: If the above is true except |registration|'s [=active worker=]'s <a>set of event types to handle</a> **does not** contain <code>fetch</code>, then the user agent may wish to show a console warning, as the developer's intent isn't clear.
 
-          1. Let |preloadRequest| be the result of [=request/cloning=] the request |request|.
-          1. Let |preloadRequestHeaders| be |preloadRequest|'s [=request/header list=].
-          1. Let |preloadResponseObject| be a new {{Response}} object associated with a new {{Headers}} object whose [=guard=] is "`immutable`".
-          1. [=header list/Append=] to |preloadRequestHeaders| a new [=header=] whose [=header/name=] is \`<code>Service-Worker-Navigation-Preload</code>\` and [=header/value=] is |registration|'s [=navigation preload header value=].
-          1. Set |preloadRequest|'s [=service-workers mode=] to "`none`".
-          1. Let |preloadFetchController| be null.
-          1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
-              1. Set |preloadFetchController| to the result of [=Fetch|fetching=] |preloadRequest|.
+              1. Let |preloadRequest| be the result of [=request/cloning=] the request |request|.
+              1. Let |preloadRequestHeaders| be |preloadRequest|'s [=request/header list=].
+              1. Let |preloadResponseObject| be a new {{Response}} object associated with a new {{Headers}} object whose [=guard=] is "`immutable`".
+              1. [=header list/Append=] to |preloadRequestHeaders| a new [=header=] whose [=header/name=] is \`<code>Service-Worker-Navigation-Preload</code>\` and [=header/value=] is |registration|'s [=navigation preload header value=].
+              1. Set |preloadRequest|'s [=service-workers mode=] to "`none`".
+              1. Let |preloadFetchController| be null.
+              1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
+                  1. Set |preloadFetchController| to the result of [=Fetch|fetching=] |preloadRequest|.
 
-                  To [=fetch/processResponse=] for |navigationPreloadResponse|, run these substeps:
+                      To [=fetch/processResponse=] for |navigationPreloadResponse|, run these substeps:
 
-                  1. If |navigationPreloadResponse|'s [=response/type=] is "`error`", reject |preloadResponse| with a `TypeError` and terminate these substeps.
-                  1. Associate |preloadResponseObject| with |navigationPreloadResponse|.
-                  1. Resolve |preloadResponse| with |preloadResponseObject|.
-          1. [=If aborted=], then:
-              1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
-              1. [=fetch controller/Abort=] |preloadFetchController| with |deserializedError|.
+                      1. If |navigationPreloadResponse|'s [=response/type=] is "`error`", reject |preloadResponse| with a `TypeError` and terminate these substeps.
+                      1. Associate |preloadResponseObject| with |navigationPreloadResponse|.
+                      1. Resolve |preloadResponse| with |preloadResponseObject|.
+              1. [=If aborted=], then:
+                  1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
+                  1. [=fetch controller/Abort=] |preloadFetchController| with |deserializedError|.
+          1. Else, a user agent may run the following substeps:
+
+              Note: A user agent may speculatively dispatch a network request in parallel with creating a fetch event in order to minimize the bootstrap cost.
+
+              1. Let |autoPreloadFetchController| be null.
+              1. Set |raceResponse| to be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
+              1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
+                  1. Set |autoPreloadFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |autoPreloadRequestResponse|:
+                  1. If |autoPreloadRequestResponse|'s [=response/status=] is [=ok status=], set |raceResponse|'s [=race response/value=] to |autoPreloadRequestResponse|.
+              1. [=If aborted=] and |autoPreloadFetchController| is not null, then:
+                  1. [=fetch controller/Abort=] |autoPreloadFetchController|.
+                  1. Set |raceResponse| to a [=race response=] whose [=race response/value=] is null.
+              1. Resolve |preloadResponse| with undefined.
       1. Else, resolve |preloadResponse| with undefined.
-      1. Let |fetchResult| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and null.
+      1. Let |fetchResult| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
       1. If |timingInfo|'s [=service worker timing info/worker final router source=] is not an empty string:
           1. Assert |timingInfo|'s [=service worker timing info/worker final router source=] is {{RouterSourceEnum/"network"}}.
           1. If |fetchResult| is null, then return |timingInfo|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3228,7 +3228,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |shouldSoftUpdate| be true if any of the following are true, and false otherwise:
           * |request| is a [=non-subresource request=].
           * |request| is a [=subresource request=] and |registration| is [=stale=].
-      1. Let |raceResponse| be null.
       1. Let |source| be null.
       1. If |activeWorker|'s [=service worker/list of router rules=] [=list/is not empty=]:
           1. Set |timingInfo|’s [=service worker timing info/worker router evaluation start=] to the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
@@ -3317,7 +3316,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               Note: A user agent may speculatively dispatch a network request in parallel with creating a fetch event in order to minimize the bootstrap cost.
 
               1. Let |autoPreloadFetchController| be null.
-              1. Set |raceResponse| to be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
+              1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
               1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                   1. Set |autoPreloadFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |autoPreloadRequestResponse|:
                   1. If |autoPreloadRequestResponse|'s [=response/status=] is [=ok status=], set |raceResponse|'s [=race response/value=] to |autoPreloadRequestResponse|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3315,12 +3315,12 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
               Note: A user agent may speculatively dispatch a network request in parallel with creating a fetch event in order to minimize the bootstrap cost.
 
-              1. Assert: [=service worker timing info/worker matched router source=] is null.
+              1. Assert: |timingInfo|'s [=service worker timing info/worker matched router source=] is null.
               1. Let |autoPreloadFetchController| be null.
               1. Set |responseForAutoPreload| to be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
               1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                   1. Set |autoPreloadFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |autoPreloadRequestResponse|:
-                  1. Set |responseForAutoPreload|'s [=race response/value=] to |autoPreloadRequestResponse|.
+                    1. Set |responseForAutoPreload|'s [=race response/value=] to |autoPreloadRequestResponse|.
               1. [=If aborted=] and |autoPreloadFetchController| is not null, then:
                   1. [=fetch controller/Abort=] |autoPreloadFetchController|.
                   1. Set |responseForAutoPreload| to a [=race response=] whose [=race response/value=] is null.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3315,6 +3315,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
               Note: A user agent may speculatively dispatch a network request in parallel with creating a fetch event in order to minimize the bootstrap cost.
 
+              1. Assert: [=service worker timing info/worker matched router source=] is null.
               1. Let |autoPreloadFetchController| be null.
               1. Set |responseForAutoPreload| to be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
               1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3228,7 +3228,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |shouldSoftUpdate| be true if any of the following are true, and false otherwise:
           * |request| is a [=non-subresource request=].
           * |request| is a [=subresource request=] and |registration| is [=stale=].
-      1. Let |raceResponse| be null. 
       1. Let |source| be null.
       1. If |activeWorker|'s [=service worker/list of router rules=] [=list/is not empty=]:
           1. Set |timingInfo|’s [=service worker timing info/worker router evaluation start=] to the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
@@ -3264,7 +3263,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
                   1. Let |queue| be an empty [=queue=] of [=race result=].
                   1. Let |raceFetchController| be null.
-                  1. Set |raceResponse| to be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
+                  1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
                   1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                           1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
@@ -3290,6 +3289,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Set |routedResponse|'s [=service worker timing info=]'s [=service worker timing info/worker final router source=] be set to |result|'s [=race result/used route=].
                   1. Return |routedResponse|.
               1. Assert: |source| is "{{RouterSourceEnum/fetch-event}}"
+      1. Let |responseForAutoPreload| be null.
       1. If |request| is a [=navigation request=], |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
           1. If |registration|'s [=navigation preload enabled flag=] is set then: 
 
@@ -3317,16 +3317,16 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               Note: A user agent may speculatively dispatch a network request in parallel with creating a fetch event in order to minimize the bootstrap cost.
 
               1. Let |autoPreloadFetchController| be null.
-              1. Set |raceResponse| to be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
+              1. Set |responseForAutoPreload| to be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
               1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                   1. Set |autoPreloadFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |autoPreloadRequestResponse|:
-                  1. If |autoPreloadRequestResponse|'s [=response/status=] is [=ok status=], set |raceResponse|'s [=race response/value=] to |autoPreloadRequestResponse|.
+                  1. If |autoPreloadRequestResponse|'s [=response/status=] is [=ok status=], set |responseForAutoPreload|'s [=race response/value=] to |autoPreloadRequestResponse|.
               1. [=If aborted=] and |autoPreloadFetchController| is not null, then:
                   1. [=fetch controller/Abort=] |autoPreloadFetchController|.
-                  1. Set |raceResponse| to a [=race response=] whose [=race response/value=] is null.
+                  1. Set |responseForAutoPreload| to a [=race response=] whose [=race response/value=] is null.
               1. Resolve |preloadResponse| with undefined.
       1. Else, resolve |preloadResponse| with undefined.
-      1. Let |fetchResult| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
+      1. Let |fetchResult| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |responseForAutoPreload|.
       1. If |timingInfo|'s [=service worker timing info/worker final router source=] is not an empty string:
           1. Assert |timingInfo|'s [=service worker timing info/worker final router source=] is {{RouterSourceEnum/"network"}}.
           1. If |fetchResult| is null, then return |timingInfo|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3229,9 +3229,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           * |request| is a [=non-subresource request=].
           * |request| is a [=subresource request=] and |registration| is [=stale=].
       1. Let |raceResponse| be null.
+      1. Let |source| be null.
       1. If |activeWorker|'s [=service worker/list of router rules=] [=list/is not empty=]:
           1. Set |timingInfo|’s [=service worker timing info/worker router evaluation start=] to the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
-          1. Let |source| be the result of running the [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
+          1. Set |source| to be the result of running the [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
           1. If |source| is non-null, then:
               1. Set |timingInfo|'s [=service worker timing info/worker matched router source=] be set to |source|, and [=service worker timing info/worker final router source=] be set to {{RouterSourceEnum/"network"}}.
               1. If |source| is {{RouterSourceEnum/"network"}}:
@@ -3310,7 +3311,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. [=If aborted=], then:
                   1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
                   1. [=fetch controller/Abort=] |preloadFetchController| with |deserializedError|.
-          1. Else, a user agent may run the following substeps:
+          1. Else if |source| is not "{{RouterSourceEnum/fetch-event}}", a user agent may run the following substeps:
 
               Note: A user agent may speculatively dispatch a network request in parallel with creating a fetch event in order to minimize the bootstrap cost.
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3319,7 +3319,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Set |responseForAutoPreload| to be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
               1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                   1. Set |autoPreloadFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |autoPreloadRequestResponse|:
-                  1. If |autoPreloadRequestResponse|'s [=response/status=] is [=ok status=], set |responseForAutoPreload|'s [=race response/value=] to |autoPreloadRequestResponse|.
+                  1. Set |responseForAutoPreload|'s [=race response/value=] to |autoPreloadRequestResponse|.
               1. [=If aborted=] and |autoPreloadFetchController| is not null, then:
                   1. [=fetch controller/Abort=] |autoPreloadFetchController|.
                   1. Set |responseForAutoPreload| to a [=race response=] whose [=race response/value=] is null.


### PR DESCRIPTION
This is the PR to support [ServiceWorkerAutoPreload](https://github.com/explainers-by-googlers/service-worker-auto-preload).

ServiceWorkerAutoPreload is defined as an optional browser optimization so that the browser minimizes the cost of the bootstrap by dispatching the navigational network request before starting the service worker. The dispatched network request is consumed by `fetch(e.request)` in the fetch handler after the bootstrap, or consumed by the client as a fallback request if the fetch handler doesn't call `respondWith()`.

The developer can disable this optimization by opting out via setting the router rule provided by the static routing API.  Specifically, the router source "network" works as an opt-out signal.

Please read [the explainer](https://github.com/WICG/service-worker-auto-preload) for more detail.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sisidovski/ServiceWorker/pull/1756.html" title="Last updated on Jul 28, 2025, 3:15 AM UTC (3daef71)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1756/a402c93...sisidovski:3daef71.html" title="Last updated on Jul 28, 2025, 3:15 AM UTC (3daef71)">Diff</a>