### PR TITLE
Filter out no-cors requests from the race-network-request

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3237,7 +3237,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. If |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |globalObject|'s [=environment settings object/origin=], |globalObject|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
                       1. Return |response|.
               1. Return null.
-          1. Else if |source| is {{RouterSourceEnum/"race-network-and-fetch-handler"}}, and |request|'s [=request/method=] is \`<code>GET</code>\` then:
+          1. Else if |source| is {{RouterSourceEnum/"race-network-and-fetch-handler"}}, |request|'s [=request/mode=] is not "no-cors", and |request|'s [=request/method=] is \`<code>GET</code>\` then:
               1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
               1. Let |queue| be an empty [=queue=] of [=/response=].
               1. Let |raceFetchController| be null.
@@ -4078,6 +4078,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: a [=/response=] or null
 
+      1. Assert: |request|'s [=request/mode=] is not "no-cors".
       1. Let |registration| be null.
       1. If |request| is a [=non-subresource request=], then:
           1. If |request|'s [=request/reserved client=] is null, return null.


### PR DESCRIPTION
This will address the comment in https://github.com/whatwg/fetch/pull/1737#issuecomment-2385734506.

When "race-network-request" is matched as the router rule, the service worker starts a network request in parallel with dispatching the fetch event. The response is keyed by request and managed in [race response map](https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope-race-response-map). And the fetch API will check this map whether the request is already started by the service worker, and use its response if the corresponding entry is found.

We use [ok-status](https://fetch.spec.whatwg.org/#ok-status) to tell if the response is successful or not, and use the response only when the status is ok-status. This is needed to support the offline capability. However, with the request mode "no-cors", the response will be [filtered](https://fetch.spec.whatwg.org/#concept-filtered-response-opaque). The filtered response's status is always 0, so this is handled as a failure in "race-network-request" even without this change. But it would be better that we explicitly filter out "no-cors" in the handle fetch algorithm.

Once we get an agreement to this change, I'll add a WPT and fix Chrome behavior.