### PR TITLE
Correct ServiceWorkerRegistration Web IDL

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -556,7 +556,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         readonly attribute USVString scope;
         readonly attribute ServiceWorkerUpdateViaCache updateViaCache;
 
-        [NewObject] Promise&lt;undefined&gt; update();
+        [NewObject] Promise&lt;ServiceWorkerRegistration&gt; update();
         [NewObject] Promise&lt;boolean&gt; unregister();
 
         // event


### PR DESCRIPTION
As mentioned in https://github.com/w3c/ServiceWorker/issues/1472, https://w3c.github.io/ServiceWorker/#resolve-job-promise-algorithm is written to return Promise<ServiceWorkerRegistration>. Also, according to https://wpt.fyi/results/service-workers/service-worker/update-result.https.html?label=experimental&label=master&aligned, all implementations are actually returning a `Promise<ServiceWorkerRegistration>`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1767.html" title="Last updated on May 1, 2025, 2:24 AM UTC (6495b0f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1767/479b8ae...yoshisatoyanagisawa:6495b0f.html" title="Last updated on May 1, 2025, 2:24 AM UTC (6495b0f)">Diff</a>