### PR TITLE
Add new fields and getter steps for static routing resource timing

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3259,7 +3259,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Return null.
               1. Else if |source| is {{RouterSourceEnum/"race-network-and-fetch-handler"}}, and |request|'s [=request/method=] is \`<code>GET</code>\` then:
                   1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
-                  1. Let |queue| be an empty [=queue=] of tuple of [=race result=].
+                  1. Let |queue| be an empty [=queue=] of [=race result=].
                   1. Let |raceFetchController| be null.
                   1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
                   1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3272,7 +3272,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. [=queue/Enqueue=] |fetchHandlerResponse| as [=/response=] and {{RouterSourceEnum/"fetch-event"}} as [=RouterSourceEnum/used route=] to |queue|.
                   1. Wait until |queue| is not empty.
                   1. Let |result| be the result of [=dequeue=] |queue|.
-                  1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to [=result/used route=] in |result|.
+                  1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to [=result/used route=] in |result|
                   1. Return the [=result/response=] in |result|.
               1. Assert: |source| is "{{RouterSourceEnum/fetch-event}}"
       1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3280,8 +3280,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. [=queue/Enqueue=] |raceFetchHandlerResult| to |queue|.
                   1. Wait until |queue| is not empty.
                   1. Let |result| be the result of [=dequeue=] |queue|.
-                  1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to [=/used route=] in |result|.
-                  1. Return the [=/race response=] in |result|.
+                  1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to |result|'s [=/used route=].
+                  1. Return |result|'s [=/race response=].
               1. Assert: |source| is "{{RouterSourceEnum/fetch-event}}"
       1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3266,7 +3266,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                           1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
                               1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
-                              1. Let |raceNetworkResult| be a [=race result=] whose [=/race response=] is |raceNetworkRequestResponse| and [=/used route=] is {{RouterSourceEnum/"network"}}.
+                              1. Let |raceNetworkResult| be a [=race result=] whose [=race result/race response=] is |raceNetworkRequestResponse| and [=race result/used route=] is {{RouterSourceEnum/"network"}}.
                               1. [=queue/Enqueue=] |raceNetworkResult| to |queue|.
                           1. Otherwise, set |raceResponse|'s [=race response/value=] to a [=network error=].
                   1. [=If aborted=] and |raceFetchController| is not null, then:
@@ -3276,7 +3276,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Run the following substeps [=in parallel=]:
                       1. Let |fetchHandlerResponse| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
                       1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
-                      1. Let |raceFetchHandlerResult| be a [=race result=] whose [=/race response=] is |fetchHandlerResponse| and [=/used route=] is {{RouterSourceEnum/"fetch-event"}}.
+                      1. Let |raceFetchHandlerResult| be a [=race result=] whose [=race result/race response=] is |fetchHandlerResponse| and [=race result/used route=] is {{RouterSourceEnum/"fetch-event"}}.
                       1. [=queue/Enqueue=] |raceFetchHandlerResult| to |queue|.
                   1. Wait until |queue| is not empty.
                   1. Let |result| be the result of [=dequeue=] |queue|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -255,9 +255,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         : <dfn export>worker cache lookup start</dfn>
         :: A {{DOMHighResTimeStamp}}, initially 0.
         : <dfn export>worker matched router source</dfn>
-        :: A string, initially empty string.
+        :: A {{DOMString}}, initially empty string.
         : <dfn export>worker final router source</dfn>
-        :: A string, initially empty string.
+        :: A {{DOMString}}, initially empty string.
     </section>
   </section>
 
@@ -2565,11 +2565,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
         Note: Keep this definition in sync with [=fetch a classic worker-imported script=].
 
-  A <dfn id="dfn-race-result">race result</dfn> is a tuple of a [=/race response=] and [=/used route=].
+  A <dfn export for="race result">race response</dfn> is a [=tuple=] of a [=/race response=] and [=/used route=].
 
-  A [=/race result=] has an associated <dfn export id="dfn-race-response">race response</dfn> (a [=/response=]).
+  A [=/race result=] has an associated <dfn export for="race result">race response</dfn> (a [=/response=]).
 
-  A [=/race result=] has an associated <dfn export id="dfn-used-route">used route</dfn> (a [=RouterSourceEnum=]).
+  A [=/race result=] has an associated <dfn export for="race result">used route</dfn> (a {{RouterSourceEnum}}).
 
   <section algorithm>
     <h3 id="create-job-algorithm"><dfn>Create Job</dfn></h3>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2565,7 +2565,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
         Note: Keep this definition in sync with [=fetch a classic worker-imported script=].
 
-  A <dfn id="dfn-race-result">race result</dfn> is a tuple of a [=race result/race response=] and [=race result/used route=].
+  A <dfn id="dfn-race-result">race result</dfn> is a tuple of a [=/race response=] and [=/used route=].
 
   A [=/race result=] has an associated <dfn export id="dfn-race-response">race response</dfn> (a [=/response=]).
 
@@ -3266,7 +3266,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                           1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
                               1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
-                              1. Let |raceNetworkResult| be a [==race result==] whose [==race result/race response==] is |raceNetworkRequestResponse| and [=race result/used route=] is {{RouterSourceEnum/"network"}}.
+                              1. Let |raceNetworkResult| be a [=race result=] whose [=/race response=] is |raceNetworkRequestResponse| and [=/used route=] is {{RouterSourceEnum/"network"}}.
                               1. [=queue/Enqueue=] |raceNetworkResult| to |queue|.
                           1. Otherwise, set |raceResponse|'s [=race response/value=] to a [=network error=].
                   1. [=If aborted=] and |raceFetchController| is not null, then:
@@ -3276,12 +3276,12 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Run the following substeps [=in parallel=]:
                       1. Let |fetchHandlerResponse| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
                       1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
-                      1. Let |raceFetchHandlerResult| be a [==race result==] whose [==race result/race response==] is |fetchHandlerResponse| and [=race result/used route=] is {{RouterSourceEnum/"fetch-event"}}.
+                      1. Let |raceFetchHandlerResult| be a [=race result=] whose [=/race response=] is |fetchHandlerResponse| and [=/used route=] is {{RouterSourceEnum/"fetch-event"}}.
                       1. [=queue/Enqueue=] |raceFetchHandlerResult| to |queue|.
                   1. Wait until |queue| is not empty.
                   1. Let |result| be the result of [=dequeue=] |queue|.
-                  1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to [=result/used route=] in |result|.
-                  1. Return the [=result/response=] in |result|.
+                  1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to [=/used route=] in |result|.
+                  1. Return the [=/race response=] in |result|.
               1. Assert: |source| is "{{RouterSourceEnum/fetch-event}}"
       1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3300,13 +3300,15 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
                   1. If |navigationPreloadResponse|'s [=response/type=] is "`error`", reject |preloadResponse| with a `TypeError` and terminate these substeps.
                   1. Associate |preloadResponseObject| with |navigationPreloadResponse|.
-                  1. If |timingInfo|'s [=service worker timing info/worker final router source=]is set to {{RouterSourceEnum/"network"}}, Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to {{RouterSourceEnum/"fetch-event"}}.
                   1. Resolve |preloadResponse| with |preloadResponseObject|.
           1. [=If aborted=], then:
               1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.
               1. [=fetch controller/Abort=] |preloadFetchController| with |deserializedError|.
       1. Else, resolve |preloadResponse| with undefined.
-      1. Return the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and null.
+      1. Let |fetchResult| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and null.
+      1. If |fetchResult| is not null and |timingInfo|'s [=service worker timing info/worker final router source=] is set to {{RouterSourceEnum/"network"}}:
+        1. Set |timingInfo|'s [=service worker timing info/worker final router source=] to {{RouterSourceEnum/"fetch-event"}}.
+      1. Return |fetchResult|.
   </section>
 
   <section algorithm>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2565,7 +2565,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
         Note: Keep this definition in sync with [=fetch a classic worker-imported script=].
 
-  A <dfn export for="race result">race response</dfn> is a [=tuple=] of a [=/race response=] and [=/used route=].
+  A <dfn id="dfn-race-result">race result</dfn> is a [=tuple=] of a [=race result/race response=] and [=/used route=].
 
   A [=/race result=] has an associated <dfn export for="race result">race response</dfn> (a [=/response=]).
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2565,9 +2565,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
         Note: Keep this definition in sync with [=fetch a classic worker-imported script=].
 
-  A <dfn id="dfn-race-result">race result</dfn> is a tuple of a [=/response=] and [=race result/used route=].
+  A <dfn id="dfn-race-result">race result</dfn> is a tuple of a [=race result/race response=] and [=race result/used route=].
 
-  A [=/race result=] has an associated <dfn export id="dfn-used-route">used route</dfn> (a [=/RouterSourceEnum=]).
+  A [=/race result=] has an associated <dfn export id="dfn-race-response">race response</dfn> (a [=/response=]).
+
+  A [=/race result=] has an associated <dfn export id="dfn-used-route">used route</dfn> (a [=RouterSourceEnum=]).
 
   <section algorithm>
     <h3 id="create-job-algorithm"><dfn>Create Job</dfn></h3>
@@ -3264,7 +3266,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                           1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
                               1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
-                              1. [=queue/Enqueue=] |raceNetworkRequestResponse| as [=/response=] and {{RouterSourceEnum/"network"}} as [=/used route=] to |queue|.
+                              1. [=queue/Enqueue=] |raceNetworkRequestResponse| as [=race result/race response=] and {{RouterSourceEnum/"network"}} as [=race result/used route=] to |queue|.
                           1. Otherwise, set |raceResponse|'s [=race response/value=] to a [=network error=].
                   1. [=If aborted=] and |raceFetchController| is not null, then:
                       1. [=fetch controller/Abort=] |raceFetchController|.
@@ -3273,7 +3275,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Run the following substeps [=in parallel=]:
                       1. Let |fetchHandlerResponse| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
                       1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
-                      1. [=queue/Enqueue=] |fetchHandlerResponse| as [=/response=] and {{RouterSourceEnum/"fetch-event"}} as [=/used route=] to |queue|.
+                      1. [=queue/Enqueue=] |fetchHandlerResponse| as [=race result/race response=] and {{RouterSourceEnum/"fetch-event"}} as [=race result/used route=] to |queue|.
                   1. Wait until |queue| is not empty.
                   1. Let |result| be the result of [=dequeue=] |queue|.
                   1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to [=result/used route=] in |result|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2565,6 +2565,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
         Note: Keep this definition in sync with [=fetch a classic worker-imported script=].
 
+  A <dfn id="dfn-race-result">race result</dfn> is a tuple of a [=/response=] and [=race result/used route=].
+
+  A [=/race result=] has an associated <dfn export id="dfn-used-route">used route</dfn> (a [=/RouterSourceEnum=]).
+
   <section algorithm>
     <h3 id="create-job-algorithm"><dfn>Create Job</dfn></h3>
 
@@ -3223,16 +3227,16 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           * |request| is a [=non-subresource request=].
           * |request| is a [=subresource request=] and |registration| is [=stale=].
       1. If |activeWorker|'s [=service worker/list of router rules=] [=list/is not empty=]:
-          1. Let |source| be the result of running the [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
           1. Set |timingInfo|’s [=service worker timing info/worker router evaluation start=] to the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
+          1. Let |source| be the result of running the [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
           1. If |source| is non-null, then:
               1. Set |timingInfo|'s [=service worker timing info/worker matched router source=] be set to |source|, and [=service worker timing info/worker final router source=] be set to {{RouterSourceEnum/"network"}}.
               1. If |source| is {{RouterSourceEnum/"network"}}:
                   1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
                   1. Return null.
               1. Else if |source| is {{RouterSourceEnum/"cache"}}, or |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=], then:
-                  1. Set |timingInfo|’s [=service worker timing info/worker cache lookup start=] to the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
                   1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
+                  1. Set |timingInfo|’s [=service worker timing info/worker cache lookup start=] to the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
                   1. [=map/For each=] |cacheName| &#x2192; |cache| of the |registration|'s [=service worker registration/storage key=]'s [=name to cache map=].
                       1. If |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=] and |source|["{{RouterSourceDict/cacheName}}"] [=string/is=] not |cacheName|, [=continue=].
                       1. Let |requestResponses| be the result of running [=Query Cache=] with |request|, a new {{CacheQueryOptions}}, and |cache|.
@@ -3253,14 +3257,14 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Return null.
               1. Else if |source| is {{RouterSourceEnum/"race-network-and-fetch-handler"}}, and |request|'s [=request/method=] is \`<code>GET</code>\` then:
                   1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
-                  1. Let |queue| be an empty [=queue=] of tuple of a [=/response=] and a [=RouterSourceEnum/used route=].
+                  1. Let |queue| be an empty [=queue=] of tuple of [=race result=].
                   1. Let |raceFetchController| be null.
                   1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
                   1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                           1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
                               1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
-                              1. [=queue/Enqueue=] |raceNetworkRequestResponse| as [=/response=] and {{RouterSourceEnum/"network"}} as [=RouterSourceEnum/used route=] to |queue|.
+                              1. [=queue/Enqueue=] |raceNetworkRequestResponse| as [=/response=] and {{RouterSourceEnum/"network"}} as [=/used route=] to |queue|.
                           1. Otherwise, set |raceResponse|'s [=race response/value=] to a [=network error=].
                   1. [=If aborted=] and |raceFetchController| is not null, then:
                       1. [=fetch controller/Abort=] |raceFetchController|.
@@ -3269,7 +3273,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Run the following substeps [=in parallel=]:
                       1. Let |fetchHandlerResponse| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
                       1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
-                      1. [=queue/Enqueue=] |fetchHandlerResponse| as [=/response=] and {{RouterSourceEnum/"fetch-event"}} as [=RouterSourceEnum/used route=] to |queue|.
+                      1. [=queue/Enqueue=] |fetchHandlerResponse| as [=/response=] and {{RouterSourceEnum/"fetch-event"}} as [=/used route=] to |queue|.
                   1. Wait until |queue| is not empty.
                   1. Let |result| be the result of [=dequeue=] |queue|.
                   1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to [=result/used route=] in |result|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -241,7 +241,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   <section>
     <h3 id="service-worker-timing">Service Worker Timing</h3>
 
-    Service workers mark certain points in time that are later exposed by the <a interface lt="PerformanceNavigationTiming">navigation timing</a> API and <a interface lt="PerformanceResourceTiming"> resource timing</a> API.
+    Service workers mark certain points in time that are later exposed by the <a interface lt="PerformanceNavigationTiming">navigation timing</a> API and <a interface lt="PerformanceResourceTiming">resource timing</a> API.
 
     A <dfn export>service worker timing info</dfn> is a [=/struct=]. It has the following [=struct/items=]:
 
@@ -255,9 +255,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         : <dfn export>worker cache lookup start</dfn>
         :: A {{DOMHighResTimeStamp}}, initially 0.
         : <dfn export>worker matched router source</dfn>
-        :: A {{DOMString}}, initially empty string.
+        :: A {{DOMString}}, initially an empty string.
         : <dfn export>worker final router source</dfn>
-        :: A {{DOMString}}, initially empty string.
+        :: A {{DOMString}}, initially an empty string.
     </section>
   </section>
 
@@ -2565,7 +2565,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
         Note: Keep this definition in sync with [=fetch a classic worker-imported script=].
 
-  A <dfn id="dfn-race-result">race result</dfn> is a [=tuple=] of a [=race result/race response=] and [=race result/used route=].
+  A <dfn id="dfn-race-result">race result</dfn> is a [=tuple=] of a [=race result/routed response=] and [=race result/used route=].
 
   A [=/race result=] has an associated <dfn export for="race result">routed response</dfn> (a [=/response=]).
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1100,7 +1100,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">force bypass cache for import scripts flag</dfn>. It is initially unset.
 
-    A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">race response map</dfn> which is an [=ordered map=] where the [=map/keys=] are [=/requests=] and the [=map/values=] are [=race response=].
+    A {{ServiceWorkerGlobalScope}} object has an associated <dfn for="ServiceWorkerGlobalScope">race response map</dfn> which is an [=ordered map=] where the [=map/keys=] are [=/requests=] and the [=map/values=] are [=/race response=].
 
     A <dfn id="dfn-race-response">race response</dfn> is a [=struct=] used to contain the network response when {{RouterSourceEnum/"race-network-and-fetch-handler"}} performs. It has a <dfn for="race response">value</dfn>, which is a [=/response=], "<code>pending</code>", or null.
 
@@ -2567,7 +2567,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
   A <dfn id="dfn-race-result">race result</dfn> is a [=tuple=] of a [=race result/race response=] and [=race result/used route=].
 
-  A [=/race result=] has an associated <dfn export for="race result">race response</dfn> (a [=/response=]).
+  A [=/race result=] has an associated <dfn export for="race result">routed response</dfn> (a [=/response=]).
 
   A [=/race result=] has an associated <dfn export for="race result">used route</dfn> (a {{RouterSourceEnum}}).
 
@@ -3266,7 +3266,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                           1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
                               1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
-                              1. Let |raceNetworkResult| be a [=race result=] whose [=race result/race response=] is |raceNetworkRequestResponse| and [=race result/used route=] is {{RouterSourceEnum/"network"}}.
+                              1. Let |raceNetworkResult| be a [=race result=] whose [=race result/routed response=] is |raceNetworkRequestResponse| and [=race result/used route=] is {{RouterSourceEnum/"network"}}.
                               1. [=queue/Enqueue=] |raceNetworkResult| to |queue|.
                           1. Otherwise, set |raceResponse|'s [=race response/value=] to a [=network error=].
                   1. [=If aborted=] and |raceFetchController| is not null, then:
@@ -3276,11 +3276,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Run the following substeps [=in parallel=]:
                       1. Let |fetchHandlerResponse| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
                       1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
-                      1. Let |raceFetchHandlerResult| be a [=race result=] whose [=race result/race response=] is |fetchHandlerResponse| and [=race result/used route=] is {{RouterSourceEnum/"fetch-event"}}.
+                      1. Let |raceFetchHandlerResult| be a [=race result=] whose [=race result/routed response=] is |fetchHandlerResponse| and [=race result/used route=] is {{RouterSourceEnum/"fetch-event"}}.
                       1. [=queue/Enqueue=] |raceFetchHandlerResult| to |queue|.
                   1. Wait until |queue| is not empty.
                   1. Let |result| be the result of [=dequeue=] |queue|.
-                  1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to |result|'s [=/used route=].
+                  1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to |result|'s [=race result/used route=].
                   1. Return |result|'s [=/race response=].
               1. Assert: |source| is "{{RouterSourceEnum/fetch-event}}"
       1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3266,7 +3266,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                           1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
                               1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
-                              1. [=queue/Enqueue=] |raceNetworkRequestResponse| as [=race result/race response=] and {{RouterSourceEnum/"network"}} as [=race result/used route=] to |queue|.
+                              1. Let |raceNetworkResult| be a [==race result==] whose [==race result/race response==] is |raceNetworkRequestResponse| and [=race result/used route=] is {{RouterSourceEnum/"network"}}.
+                              1. [=queue/Enqueue=] |raceNetworkResult| to |queue|.
                           1. Otherwise, set |raceResponse|'s [=race response/value=] to a [=network error=].
                   1. [=If aborted=] and |raceFetchController| is not null, then:
                       1. [=fetch controller/Abort=] |raceFetchController|.
@@ -3275,7 +3276,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Run the following substeps [=in parallel=]:
                       1. Let |fetchHandlerResponse| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
                       1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
-                      1. [=queue/Enqueue=] |fetchHandlerResponse| as [=race result/race response=] and {{RouterSourceEnum/"fetch-event"}} as [=race result/used route=] to |queue|.
+                      1. Let |raceFetchHandlerResult| be a [==race result==] whose [==race result/race response==] is |fetchHandlerResponse| and [=race result/used route=] is {{RouterSourceEnum/"fetch-event"}}.
+                      1. [=queue/Enqueue=] |raceFetchHandlerResult| to |queue|.
                   1. Wait until |queue| is not empty.
                   1. Let |result| be the result of [=dequeue=] |queue|.
                   1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to [=result/used route=] in |result|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -241,7 +241,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   <section>
     <h3 id="service-worker-timing">Service Worker Timing</h3>
 
-    Service workers mark certain points in time that are later exposed by the <a interface lt="PerformanceNavigationTiming">navigation timing</a> API.
+    Service workers mark certain points in time that are later exposed by the <a interface lt="PerformanceNavigationTiming">navigation timing</a> API and <a interface lt="PerformanceResourceTiming"> resource timing</a> API.
 
     A <dfn export>service worker timing info</dfn> is a [=/struct=]. It has the following [=struct/items=]:
 
@@ -250,6 +250,14 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         :: A {{DOMHighResTimeStamp}}, initially 0.
         : <dfn export>fetch event dispatch time</dfn>
         :: A {{DOMHighResTimeStamp}}, initially 0.
+        : <dfn export>worker router evaluation start</dfn>
+        :: A {{DOMHighResTimeStamp}}, initially 0.
+        : <dfn export>worker cache lookup start</dfn>
+        :: A {{DOMHighResTimeStamp}}, initially 0.
+        : <dfn export>worker matched router source</dfn>
+        :: A string, initially empty string.
+        : <dfn export>worker final router source</dfn>
+        :: A string, initially empty string.
     </section>
   </section>
 
@@ -3216,11 +3224,14 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           * |request| is a [=subresource request=] and |registration| is [=stale=].
       1. If |activeWorker|'s [=service worker/list of router rules=] [=list/is not empty=]:
           1. Let |source| be the result of running the [=Get Router Source=] algorithm with |registration|'s <a>active worker</a> and |request|.
+          1. Set |timingInfo|’s [=service worker timing info/worker router evaluation start=] to the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
           1. If |source| is non-null, then:
+              1. Set |timingInfo|'s [=service worker timing info/worker matched router source=] be set to |source|, and [=service worker timing info/worker final router source=] be set to {{RouterSourceEnum/"network"}}.
               1. If |source| is {{RouterSourceEnum/"network"}}:
                   1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
                   1. Return null.
               1. Else if |source| is {{RouterSourceEnum/"cache"}}, or |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=], then:
+                  1. Set |timingInfo|’s [=service worker timing info/worker cache lookup start=] to the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
                   1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
                   1. [=map/For each=] |cacheName| &#x2192; |cache| of the |registration|'s [=service worker registration/storage key=]'s [=name to cache map=].
                       1. If |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=] and |source|["{{RouterSourceDict/cacheName}}"] [=string/is=] not |cacheName|, [=continue=].
@@ -3237,18 +3248,19 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                           Note: This only creates a ServiceWorkerGlobalScope because CORS checks require that. It is not expected that implementations will actually create a ServiceWorkerGlobalScope here.
 
                           1. If |response|'s [=response/type=] is "`opaque`", and [=cross-origin resource policy check=] with |globalObject|'s [=environment settings object/origin=], |globalObject|, "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then return null.
+                          1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to {{RouterSourceEnum/"cache"}}.
                           1. Return |response|.
                   1. Return null.
               1. Else if |source| is {{RouterSourceEnum/"race-network-and-fetch-handler"}}, and |request|'s [=request/method=] is \`<code>GET</code>\` then:
                   1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
-                  1. Let |queue| be an empty [=queue=] of [=/response=].
+                  1. Let |queue| be an empty [=queue=] of tuple of a [=/response=] and a [=RouterSourceEnum/used route=].
                   1. Let |raceFetchController| be null.
                   1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
                   1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                           1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
                               1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
-                              1. [=queue/Enqueue=] |raceNetworkRequestResponse| to |queue|.
+                              1. [=queue/Enqueue=] |raceNetworkRequestResponse| as [=/response=] and {{RouterSourceEnum/"network"}} as [=RouterSourceEnum/used route=] to |queue|.
                           1. Otherwise, set |raceResponse|'s [=race response/value=] to a [=network error=].
                   1. [=If aborted=] and |raceFetchController| is not null, then:
                       1. [=fetch controller/Abort=] |raceFetchController|.
@@ -3257,9 +3269,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Run the following substeps [=in parallel=]:
                       1. Let |fetchHandlerResponse| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
                       1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
-                      1. [=queue/Enqueue=] |fetchHandlerResponse| to |queue|.
+                      1. [=queue/Enqueue=] |fetchHandlerResponse| as [=/response=] and {{RouterSourceEnum/"fetch-event"}} as [=RouterSourceEnum/used route=] to |queue|.
                   1. Wait until |queue| is not empty.
-                  1. Return the result of [=dequeue=] |queue|.
+                  1. Let |result| be the result of [=dequeue=] |queue|.
+                  1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to [=result/used route=] in |result|.
+                  1. Return the [=result/response=] in |result|.
               1. Assert: |source| is "{{RouterSourceEnum/fetch-event}}"
       1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
 
@@ -3278,6 +3292,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
                   1. If |navigationPreloadResponse|'s [=response/type=] is "`error`", reject |preloadResponse| with a `TypeError` and terminate these substeps.
                   1. Associate |preloadResponseObject| with |navigationPreloadResponse|.
+                  1. If |timingInfo|'s [=service worker timing info/worker final router source=]is set to {{RouterSourceEnum/"network"}}, Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to {{RouterSourceEnum/"fetch-event"}}.
                   1. Resolve |preloadResponse| with |preloadResponseObject|.
           1. [=If aborted=], then:
               1. Let |deserializedError| be the result of [=deserialize a serialized abort reason=] given null and |workerRealm|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3272,7 +3272,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. [=queue/Enqueue=] |fetchHandlerResponse| as [=/response=] and {{RouterSourceEnum/"fetch-event"}} as [=RouterSourceEnum/used route=] to |queue|.
                   1. Wait until |queue| is not empty.
                   1. Let |result| be the result of [=dequeue=] |queue|.
-                  1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to [=result/used route=] in |result|
+                  1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to [=result/used route=] in |result|.
                   1. Return the [=result/response=] in |result|.
               1. Assert: |source| is "{{RouterSourceEnum/fetch-event}}"
       1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2565,7 +2565,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
         Note: Keep this definition in sync with [=fetch a classic worker-imported script=].
 
-  A <dfn id="dfn-race-result">race result</dfn> is a [=tuple=] of a [=race result/race response=] and [=/used route=].
+  A <dfn id="dfn-race-result">race result</dfn> is a [=tuple=] of a [=race result/race response=] and [=race result/used route=].
 
   A [=/race result=] has an associated <dfn export for="race result">race response</dfn> (a [=/response=]).
 


### PR DESCRIPTION
This PR adds the new fields for the static routing API and the getter steps. This will be later exposed to the resource timing API. It has been discussed in https://github.com/w3c/resource-timing/issues/389.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/quasi-mod/ServiceWorker/pull/1769.html" title="Last updated on May 28, 2025, 1:58 AM UTC (ca79de3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1769/b7bbcea...quasi-mod:ca79de3.html" title="Last updated on May 28, 2025, 1:58 AM UTC (ca79de3)">Diff</a>