### PR TITLE
Fix: Correct return type and preserve response timing info

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3283,11 +3283,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Let |result| be the result of [=dequeue=] |queue|.
                   1. Let |routedResponse| be |result|'s [=race result/routed response=].
 		  1. If |result|'s [=race result/used route=] is {{RouterSourceEnum/"network"}}, then:
-                    1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to |result|'s [=race result/used route=].
-                    1. Set |routedResponse|'s [=service worker timing info=] be set to |timingInfo|.
-		  1. Else:
-		    1. Assert |result|'s [=race result/used route=] is {{RouterSourceEnum/"fetch-event"}}.
-                    1. Set |routedResponse|'s [=service worker timing info=]'s [=service worker timing info/worker final router source=] be set to |result|'s [=race result/used route=].
+                      1. Set |routedResponse|'s [=service worker timing info=] be set to |timingInfo|.
+                  1. Set |routedResponse|'s [=service worker timing info=]'s [=service worker timing info/worker final router source=] be set to |result|'s [=race result/used route=].
                   1. Return |routedResponse|.
               1. Assert: |source| is "{{RouterSourceEnum/fetch-event}}"
       1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3281,9 +3281,14 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. [=queue/Enqueue=] |raceFetchHandlerResult| to |queue|.
                   1. Wait until |queue| is not empty.
                   1. Let |result| be the result of [=dequeue=] |queue|.
-                  1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to |result|'s [=race result/used route=].
-                  1. Set |result|'s [=service worker timing info=] be set to |timingInfo|.
-                  1. Return |result|'s [=/race response=].
+                  1. Let |routedResponse| be |result|'s [=race result/routed response=].
+		  1. If |result|'s [=race result/used route=] is {{RouterSourceEnum/"network"}}, then:
+                    1. Set |timingInfo|'s [=service worker timing info/worker final router source=] be set to |result|'s [=race result/used route=].
+                    1. Set |routedResponse|'s [=service worker timing info=] be set to |timingInfo|.
+		  1. Else:
+		    1. Assert |result|'s [=race result/used route=] is {{RouterSourceEnum/"fetch-event"}}.
+                    1. Set |routedResponse|'s [=service worker timing info=]'s [=service worker timing info/worker final router source=] be set to |result|'s [=race result/used route=].
+                  1. Return |routedResponse|.
               1. Assert: |source| is "{{RouterSourceEnum/fetch-event}}"
       1. If |request| is a [=navigation request=], |registration|'s [=navigation preload enabled flag=] is set, |request|'s [=request/method=] is \`<code>GET</code>\`, |registration|'s [=active worker=]'s [=set of event types to handle=] [=set/contains=] <code>fetch</code>, and |registration|'s [=active worker=]'s [=all fetch listeners are empty flag=] is not set then:
 


### PR DESCRIPTION
This pull request introduces the following enhancements:

1. Type Correction for race-network-and-fetch-event: Modified the race-network-and-fetch-event algorithm to consistently return the correct value type. This addresses a previous inconsistency where the algorithm could yield a value of a different, incorrect type.
2. Preservation of Response Timing Information: Ensured that timing information within the response, particularly the fetch event dispatch time, is retained when the fetch event's value is utilized. This resolves an issue where such timing data was previously being discarded.