### PR TITLE
Fix: Ensure timingInfo is returned on network fallback if SW static routing API is used

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3310,6 +3310,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. [=fetch controller/Abort=] |preloadFetchController| with |deserializedError|.
       1. Else, resolve |preloadResponse| with undefined.
       1. Let |fetchResult| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and null.
+      1. If |fetchResult| is null and |timingInfo|'s [=service worker timing info/worker final router source=] is set:
+         1. Assert |timingInfo|'s [=service worker timing info/worker final router source=] is {{RouterSourceEnum/"network"}}.
+          1. Return |timingInfo|.
       1. If |fetchResult| is not null and |fetchResult|'s [=response/service worker timing info=]'s [=service worker timing info/worker final router source=] is set to {{RouterSourceEnum/"network"}}:
         1. Set |fetchResult|'s [=response/service worker timing info=]'s [=service worker timing info/worker final router source=] to {{RouterSourceEnum/"fetch-event"}}.
       1. Return |fetchResult|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3310,11 +3310,12 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. [=fetch controller/Abort=] |preloadFetchController| with |deserializedError|.
       1. Else, resolve |preloadResponse| with undefined.
       1. Let |fetchResult| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and null.
-      1. If |fetchResult| is null and |timingInfo|'s [=service worker timing info/worker final router source=] is set:
-         1. Assert |timingInfo|'s [=service worker timing info/worker final router source=] is {{RouterSourceEnum/"network"}}.
-          1. Return |timingInfo|.
-      1. If |fetchResult| is not null and |fetchResult|'s [=response/service worker timing info=]'s [=service worker timing info/worker final router source=] is set to {{RouterSourceEnum/"network"}}:
-        1. Set |fetchResult|'s [=response/service worker timing info=]'s [=service worker timing info/worker final router source=] to {{RouterSourceEnum/"fetch-event"}}.
+      1. If |timingInfo|'s [=service worker timing info/worker final router source=] is not an empty string:
+          1. Assert |timingInfo|'s [=service worker timing info/worker final router source=] is {{RouterSourceEnum/"network"}}.
+          1. If |fetchResult| is null, then return |timingInfo|.
+          1. Else:
+              1. Assert |fetchResult|'s [=response/service worker timing info=]'s [=service worker timing info/worker final router source=] is {{RouterSourceEnum/"network"}}.
+              1. Set |fetchResult|'s [=response/service worker timing info=]'s [=service worker timing info/worker final router source=] to {{RouterSourceEnum/"fetch-event"}}.
       1. Return |fetchResult|.
   </section>
 


### PR DESCRIPTION
According to the [explainer](https://github.com/WICG/service-worker-static-routing-api/blob/main/resource-timing-api.md#correspondence-of-the-matched-source-type-and-the-actual-source-type), the `worker final router source` should be `'network'` for a network fallback.  The |timingInfo| is returned to make that happen.