### PR TITLE
Add new environment settings object field "cross site ancestry" for SameSite cookies work

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3065,8 +3065,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               :: Return |serviceWorker|'s [=service worker/script url=].
               : The [=environment settings object/origin=]
               :: Return its registering [=/service worker client=]'s [=environment settings object/origin=].
-              : The [=environment settings object/cross site ancestry=]
-              :: Return its registering [=/service worker client=]'s [=environment settings object/cross site ancestry=].
+              : The [=environment settings object/has cross-site ancestor=]
+              :: Return its registering [=/service worker client=]'s [=environment settings object/has cross-site ancestor=].
               : The [=environment settings object/policy container=]
               :: Return |workerGlobalScope|'s [=WorkerGlobalScope/policy container=].
               : The [=environment settings object/time origin=]


### PR DESCRIPTION
To define how cookies work correctly, particularly around the SameSite attribute, we need to know whether or not an environment settings object has any cross-site ancestors. This is making sure the ESO definition in ServiceWorkers also defines this member algorithm. 

We will have to land [the PR that adds this to HTML](https://github.com/whatwg/html/pull/11133) before landing this, but it'd be nice to get this approved before we alter HTML so everything goes smoothly.

See https://github.com/whatwg/html/issues/9000 for even broader context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bvandersloot-mozilla/ServiceWorker/pull/1775.html" title="Last updated on Jul 29, 2025, 6:09 PM UTC (433306a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1775/ef029c5...bvandersloot-mozilla:433306a.html" title="Last updated on Jul 29, 2025, 6:09 PM UTC (433306a)">Diff</a>