### PR TITLE
Fix: race-network-and-fetch-handler now uses actual |raceResponse|

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3281,16 +3281,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Wait until |queue| is not empty.
                   1. Let |result| be the result of [=dequeue=] |queue|.
                   1. Let |routedResponse| be |result|'s [=race result/routed response=].
-                  1. If |routedResponse| is null or a [=network error=], then:
-
-                      Note: the [=Create Fetch Event and Dispatch=] return value is queued regardless of its value. Failure response means the raced fetch handler failed.
-
-                      1. Wait until |raceResponse|'s [=race response/value=] is not "<code>pending</code>".
-                      1. Let |fallbackResponse| be |raceResponse|'s [=race response/value=].
-                      1. If |fallbackResponse| is null:
-                          1. Return |timingInfo|.
-                      1. Set |fallbackResponse|'s [=service worker timing info=] to |timingInfo|.
-                      1. Return |fallbackResponse|.
+                  1. If |routedResponse| is null:
+                      1. Return |timingInfo|.
                   1. If |result|'s [=race result/used route=] is {{RouterSourceEnum/"network"}}, then:
                       1. Set |routedResponse|'s [=service worker timing info=] be set to |timingInfo|.
                   1. Set |routedResponse|'s [=service worker timing info=]'s [=service worker timing info/worker final router source=] be set to |result|'s [=race result/used route=].
@@ -3349,6 +3341,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |eventHandled| be null.
       1. Let |handleFetchFailed| be false.
       1. Let |respondWithEntered| be false.
+      1. Let |networkError| be a [=network error=].
+      1. If |raceResponse| is not null:
+          1. Set |networkError|'s [=response/service worker timing info=] to |timingInfo|.
       1. Let |shouldSoftUpdate| be true if any of the following are true, and false otherwise:
           * |request| is a [=non-subresource request=].
           * |request| is a [=subresource request=] and |registration| is [=stale=].
@@ -3408,15 +3403,15 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If |respondWithEntered| is false, then:
           1. If |eventCanceled| is true, then:
               1. If |eventHandled| is not null, then [=reject=] |eventHandled| with a "{{NetworkError}}" {{DOMException}} in |workerRealm|.
-              2. Return a [=network error=].
+              2. Return |networkError|.
           1. If |eventHandled| is not null, then [=resolve=] |eventHandled|.
-          1. If |raceResponse|'s [=race response/value=] is not null, then:
+          1. If |raceResponse| is not null, and |raceResponse|'s [=race response/value=] is not null, then:
               1. Wait until |raceResponse|'s [=race response/value=] is not "<code>pending</code>".
               1. If |raceResponse|'s [=race response/value=] is a [=/response=], return |raceResponse|'s [=race response/value=].
           1. Return null.
       1. If |handleFetchFailed| is true, then:
           1. If |eventHandled| is not null, then [=reject=] |eventHandled| with a "{{NetworkError}}" {{DOMException}} in |workerRealm|.
-          2. Return a [=network error=].
+          2. Return |networkError|.
       1. If |eventHandled| is not null, then [=resolve=] |eventHandled|.
       1. Return |response|.
   </section>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3288,7 +3288,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Wait until any of the following are true:
                       1. |queue| is not empty.
                       1. Both |networkFetchCompleted| and |cacheLookupCompleted| are true.
-                  1. If |queue| is empty, return null.
+                  1. If |queue| is empty, then:
+                      1. If |raceResponse|'s [=race response/value=] is a [=/response=], return |raceResponse|'s [=race response/value=].
+                      1. If |raceResponse|'s [=race response/value=] is a [=network error=], return a [=network error=].
+                  1. Return null.
                   1. Let |result| be the result of [=dequeue=] |queue|.
                   1. Let |routedResponse| be |result|'s [=race result/routed response=].
                   1. If |result|'s [=race result/used route=] is {{RouterSourceEnum/"network"}}, then:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3273,7 +3273,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                               1. [=queue/Enqueue=] |raceNetworkResult| to |queue|.
                           1. Otherwise, set |raceResponse|'s [=race response/value=] to a [=network error=].
                           1. Set |networkFetchResult| to |raceNetworkRequestResponse|.
-                      1. Set |networkFetchCompleted| to true.
+                          1. Set |networkFetchCompleted| to true.
                   1. [=If aborted=] and |raceFetchController| is not null, then:
                       1. [=fetch controller/Abort=] |raceFetchController|.
                       1. Set |raceResponse| to a [=race response=] whose [=race response/value=] is null.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1607,7 +1607,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         "cache",
         "fetch-event",
         "network",
-        "race-network-and-fetch-handler",
+        "race-network-and-fetch-handler"
       };
     </pre>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1600,6 +1600,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       dictionary RouterSourceDict {
         DOMString cacheName;
+        DOMString raceNetworkAndCacheCacheName;
       };
 
       enum RunningStatus { "running", "not-running" };
@@ -1607,7 +1608,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         "cache",
         "fetch-event",
         "network",
-        "race-network-and-fetch-handler"
+        "race-network-and-fetch-handler",
+        "race-network-and-cache"
       };
     </pre>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3265,6 +3265,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Let |queue| be an empty [=queue=] of [=race result=].
                   1. Let |raceFetchController| be null.
                   1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
+                  1. Let |networkFetchCompleted| be false.
+                  1. Let |fetchHandlerCompleted| be false.
                   1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                           1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
@@ -3272,6 +3274,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                               1. Let |raceNetworkResult| be a [=race result=] whose [=race result/routed response=] is |raceNetworkRequestResponse| and [=race result/used route=] is {{RouterSourceEnum/"network"}}.
                               1. [=queue/Enqueue=] |raceNetworkResult| to |queue|.
                           1. Otherwise, set |raceResponse|'s [=race response/value=] to a [=network error=].
+                      1. Set |networkFetchCompleted| to true.
                   1. [=If aborted=] and |raceFetchController| is not null, then:
                       1. [=fetch controller/Abort=] |raceFetchController|.
                       1. Set |raceResponse| to a [=race response=] whose [=race response/value=] is null.
@@ -3281,7 +3284,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
                       1. Let |raceFetchHandlerResult| be a [=race result=] whose [=race result/routed response=] is |fetchHandlerResponse| and [=race result/used route=] is {{RouterSourceEnum/"fetch-event"}}.
                       1. [=queue/Enqueue=] |raceFetchHandlerResult| to |queue|.
-                  1. Wait until |queue| is not empty.
+                      1. Set |fetchHandlerCompleted| to true.
+                  1. Wait until |queue| is not empty or (|networkFetchCompleted| is true and |fetchHandlerCompleted| is true).
+                  1. If |queue| is empty, return null.
                   1. Let |result| be the result of [=dequeue=] |queue|.
                   1. Let |routedResponse| be |result|'s [=race result/routed response=].
                   1. If |result|'s [=race result/used route=] is {{RouterSourceEnum/"network"}}, then:

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3284,8 +3284,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. [=queue/Enqueue=] |raceFetchHandlerResult| to |queue|.
                       1. Set |fetchHandlerCompleted| to true.
                   1. Wait until any of the following are true:
-                      1. |queue| is not empty.
-                      1. Both |networkFetchCompleted| and |cacheLookupCompleted| are true.
+                      * |queue| is not empty; or
+                      * both |networkFetchCompleted| and |cacheLookupCompleted| are true.
                   1. If |queue| is empty, then:
                       1. If |raceResponse|'s [=race response/value=] is a [=/response=], return |raceResponse|'s [=race response/value=].
                       1. If |raceResponse|'s [=race response/value=] is a [=network error=], return a [=network error=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1600,7 +1600,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       dictionary RouterSourceDict {
         DOMString cacheName;
-        DOMString raceNetworkAndCacheCacheName;
       };
 
       enum RunningStatus { "running", "not-running" };
@@ -1609,7 +1608,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         "fetch-event",
         "network",
         "race-network-and-fetch-handler",
-        "race-network-and-cache"
       };
     </pre>
 

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3263,21 +3263,15 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Let |queue| be an empty [=queue=] of [=race result=].
                   1. Let |raceFetchController| be null.
                   1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
-                  1. Let |networkFetchCompleted| be false.
-                  1. Let |networkFetchResult| be null.
                   1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
+                          1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
                           1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
-                              1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
                               1. Let |raceNetworkResult| be a [=race result=] whose [=race result/routed response=] is |raceNetworkRequestResponse| and [=race result/used route=] is {{RouterSourceEnum/"network"}}.
                               1. [=queue/Enqueue=] |raceNetworkResult| to |queue|.
-                          1. Otherwise, set |raceResponse|'s [=race response/value=] to a [=network error=].
-                          1. Set |networkFetchResult| to |raceNetworkRequestResponse|.
-                          1. Set |networkFetchCompleted| to true.
                   1. [=If aborted=] and |raceFetchController| is not null, then:
                       1. [=fetch controller/Abort=] |raceFetchController|.
                       1. Set |raceResponse| to a [=race response=] whose [=race response/value=] is null.
-                      1. Set |networkFetchCompleted| to true.
                   1. Resolve |preloadResponse| with undefined.
                   1. Run the following substeps [=in parallel=]:
                       1. Let |fetchHandlerResponse| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
@@ -3291,11 +3285,12 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
                       Note: the [=Create Fetch Event and Dispatch=] return value is queued regardless of its value. Failure response means the raced fetch handler failed.
 
-                      1. Wait until |networkFetchCompleted| is true.
-                      1. If |networkFetchResult| is null:
+                      1. Wait until |raceResponse|'s [=race response/value=] is not "<code>pending</code>".
+                      1. Let |fallbackResponse| be |raceResponse|'s [=race response/value=].
+                      1. If |fallbackResponse| is null:
                           1. Return |timingInfo|.
-                      1. Set |networkFetchResult|'s [=service worker timing info=] to |timingInfo|.
-                      1. Return |networkFetchResult|.
+                      1. Set |fallbackResponse|'s [=service worker timing info=] to |timingInfo|.
+                      1. Return |fallbackResponse|.
                   1. If |result|'s [=race result/used route=] is {{RouterSourceEnum/"network"}}, then:
                       1. Set |routedResponse|'s [=service worker timing info=] be set to |timingInfo|.
                   1. Set |routedResponse|'s [=service worker timing info=]'s [=service worker timing info/worker final router source=] be set to |result|'s [=race result/used route=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3285,7 +3285,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. Let |raceFetchHandlerResult| be a [=race result=] whose [=race result/routed response=] is |fetchHandlerResponse| and [=race result/used route=] is {{RouterSourceEnum/"fetch-event"}}.
                       1. [=queue/Enqueue=] |raceFetchHandlerResult| to |queue|.
                       1. Set |fetchHandlerCompleted| to true.
-                  1. Wait until |queue| is not empty or (|networkFetchCompleted| is true and |fetchHandlerCompleted| is true).
+                  1. Wait until any of the following are true:
+                      1. |queue| is not empty.
+                      1. Both |networkFetchCompleted| and |cacheLookupCompleted| are true.
                   1. If |queue| is empty, return null.
                   1. Let |result| be the result of [=dequeue=] |queue|.
                   1. Let |routedResponse| be |result|'s [=race result/routed response=].

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3264,7 +3264,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Let |raceFetchController| be null.
                   1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
                   1. Let |networkFetchCompleted| be false.
-                  1. Let |fetchHandlerCompleted| be false.
+                  1. Let |networkFetchResult| be null.
                   1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                           1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
@@ -3272,26 +3272,30 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                               1. Let |raceNetworkResult| be a [=race result=] whose [=race result/routed response=] is |raceNetworkRequestResponse| and [=race result/used route=] is {{RouterSourceEnum/"network"}}.
                               1. [=queue/Enqueue=] |raceNetworkResult| to |queue|.
                           1. Otherwise, set |raceResponse|'s [=race response/value=] to a [=network error=].
+                          1. Set |networkFetchResult| to |raceNetworkRequestResponse|.
                       1. Set |networkFetchCompleted| to true.
                   1. [=If aborted=] and |raceFetchController| is not null, then:
                       1. [=fetch controller/Abort=] |raceFetchController|.
                       1. Set |raceResponse| to a [=race response=] whose [=race response/value=] is null.
+                      1. Set |networkFetchCompleted| to true.
                   1. Resolve |preloadResponse| with undefined.
                   1. Run the following substeps [=in parallel=]:
                       1. Let |fetchHandlerResponse| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
                       1. If |fetchHandlerResponse| is not null and not a [=network error=], and |raceFetchController| is not null, [=fetch controller/abort=] |raceFetchController|.
                       1. Let |raceFetchHandlerResult| be a [=race result=] whose [=race result/routed response=] is |fetchHandlerResponse| and [=race result/used route=] is {{RouterSourceEnum/"fetch-event"}}.
                       1. [=queue/Enqueue=] |raceFetchHandlerResult| to |queue|.
-                      1. Set |fetchHandlerCompleted| to true.
-                  1. Wait until any of the following are true:
-                      * |queue| is not empty; or
-                      * both |networkFetchCompleted| and |cacheLookupCompleted| are true.
-                  1. If |queue| is empty, then:
-                      1. If |raceResponse|'s [=race response/value=] is a [=/response=], return |raceResponse|'s [=race response/value=].
-                      1. If |raceResponse|'s [=race response/value=] is a [=network error=], return a [=network error=].
-                  1. Return null.
+                  1. Wait until |queue| is not empty.
                   1. Let |result| be the result of [=dequeue=] |queue|.
                   1. Let |routedResponse| be |result|'s [=race result/routed response=].
+                  1. If |routedResponse| is null or a [=network error=], then:
+
+                      Note: the [=Create Fetch Event and Dispatch=] return value is queued regardless of its value. Failure response means the raced fetch handler failed.
+
+                      1. Wait until |networkFetchCompleted| is true.
+                      1. If |networkFetchResult| is null:
+                          1. Return |timingInfo|.
+                      1. Set |networkFetchResult|'s [=service worker timing info=] to |timingInfo|.
+                      1. Return |networkFetchResult|.
                   1. If |result|'s [=race result/used route=] is {{RouterSourceEnum/"network"}}, then:
                       1. Set |routedResponse|'s [=service worker timing info=] be set to |timingInfo|.
                   1. Set |routedResponse|'s [=service worker timing info=]'s [=service worker timing info/worker final router source=] be set to |result|'s [=race result/used route=].


### PR DESCRIPTION
This pull request originates from the work proposed by @monica-ch in w3c/ServiceWorker#1764, but has been extensively reworked based on review feedback.

This PR corrects response handling for race-network-and-fetch-handler.

**Primary Fix:** The handler now correctly uses the actual fetch response for |raceResponse| instead of a generic [=network error=].
**Minor Improvement:** |timingInfo| is now included in the [=network error=], when returned by [=Create Fetch Event and Dispatch=], which simplifies the calling code.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1777.html" title="Last updated on Jun 12, 2025, 10:51 AM UTC (51832d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1777/ef029c5...yoshisatoyanagisawa:51832d8.html" title="Last updated on Jun 12, 2025, 10:51 AM UTC (51832d8)">Diff</a>