### PR TITLE
Editorial: the Create Fetch Event and Dispatch output returns null

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3296,7 +3296,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       :: |preloadResponse|, a [=promise=]
       :: |raceResponse|, a [=race response=] or null
       : Output
-      :: a [=/response=]
+      :: a [=/response=] or null
 
       1. Let |response| be null.
       1. Let |eventCanceled| be false.


### PR DESCRIPTION
A minor editorial fix to clarify that the Create Fetch Event and Dispatch algorithm may return null.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sisidovski/ServiceWorker/pull/1778.html" title="Last updated on Jun 11, 2025, 2:57 AM UTC (b3102a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1778/1d795e2...sisidovski:b3102a8.html" title="Last updated on Jun 11, 2025, 2:57 AM UTC (b3102a8)">Diff</a>