### PR TITLE
Less fragile |fetchController| termination check

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3263,9 +3263,11 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Let |queue| be an empty [=queue=] of [=race result=].
                   1. Let |raceFetchController| be null.
                   1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
-                  1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
+                  1. Let |fetchControllerAborted| be false.
+                  1. Run the following substeps [=in parallel=], but [=abort when=] |fetchControllerAborted| is true:
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                           1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
+                          1. If |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then |fetchControllerAborted| is true.
                           1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
                               1. Let |raceNetworkResult| be a [=race result=] whose [=race result/routed response=] is |raceNetworkRequestResponse| and [=race result/used route=] is {{RouterSourceEnum/"network"}}.
                               1. [=queue/Enqueue=] |raceNetworkResult| to |queue|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3304,6 +3304,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
                   To [=fetch/processResponse=] for |navigationPreloadResponse|, run these substeps:
 
+                  1. If |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", abort these steps.
                   1. If |navigationPreloadResponse|'s [=response/type=] is "`error`", reject |preloadResponse| with a `TypeError` and terminate these substeps.
                   1. Associate |preloadResponseObject| with |navigationPreloadResponse|.
                   1. Resolve |preloadResponse| with |preloadResponseObject|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3266,7 +3266,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Run the following substeps [=in parallel=]:
                       1. If |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then set |raceResponse| to a [=race response=] whose [=race response/value=] is null, and abort these steps.
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
-                          1. [=Abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>".
+                          1. Run these steps, but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>".
                           1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
                           1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
                               1. Let |raceNetworkResult| be a [=race result=] whose [=race result/routed response=] is |raceNetworkRequestResponse| and [=race result/used route=] is {{RouterSourceEnum/"network"}}.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3263,8 +3263,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Let |queue| be an empty [=queue=] of [=race result=].
                   1. Let |raceFetchController| be null.
                   1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
-                  1. Let |fetchControllerAborted| be false.
-                  1. Run the following substeps [=in parallel=], but [=abort when=] |fetchControllerAborted| is true:
+                  1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                           1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
                           1. If |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then |fetchControllerAborted| is true.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3263,16 +3263,17 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. Let |queue| be an empty [=queue=] of [=race result=].
                   1. Let |raceFetchController| be null.
                   1. Let |raceResponse| be a [=race response=] whose [=race response/value=] is "<code>pending</code>".
-                  1. Run the following substeps [=in parallel=], but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>":
+                  1. Run the following substeps [=in parallel=]:
+                      1. If |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then set |raceResponse| to a [=race response=] whose [=race response/value=] is null, and abort these steps.
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
+                          1. [=Abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>".
                           1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
-                          1. If |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then |fetchControllerAborted| is true.
                           1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
                               1. Let |raceNetworkResult| be a [=race result=] whose [=race result/routed response=] is |raceNetworkRequestResponse| and [=race result/used route=] is {{RouterSourceEnum/"network"}}.
                               1. [=queue/Enqueue=] |raceNetworkResult| to |queue|.
-                  1. [=If aborted=] and |raceFetchController| is not null, then:
-                      1. [=fetch controller/Abort=] |raceFetchController|.
-                      1. Set |raceResponse| to a [=race response=] whose [=race response/value=] is null.
+                          1. [=If aborted=] and |raceFetchController| is not null, then:
+                              1. [=fetch controller/Abort=] |raceFetchController|.
+                              1. Set |raceResponse| to a [=race response=] whose [=race response/value=] is null.
                   1. Resolve |preloadResponse| with undefined.
                   1. Run the following substeps [=in parallel=]:
                       1. Let |fetchHandlerResponse| be the result of [=Create Fetch Event and Dispatch=] with |request|, |registration|, |useHighResPerformanceTimers|, |timingInfo|, |workerRealm|, |reservedClient|, |preloadResponse|, and |raceResponse|.
@@ -3304,7 +3305,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
                   To [=fetch/processResponse=] for |navigationPreloadResponse|, run these substeps:
 
-                  1. If |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", abort these steps.
                   1. If |navigationPreloadResponse|'s [=response/type=] is "`error`", reject |preloadResponse| with a `TypeError` and terminate these substeps.
                   1. Associate |preloadResponseObject| with |navigationPreloadResponse|.
                   1. Resolve |preloadResponse| with |preloadResponseObject|.

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3267,10 +3267,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                       1. If |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>", then set |raceResponse| to a [=race response=] whose [=race response/value=] is null, and abort these steps.
                       1. Set |raceFetchController| to the result of calling [=fetch=] given |request|, with [=fetch/processResponse=] set to the following steps given a [=/response=] |raceNetworkRequestResponse|:
                           1. Run these steps, but [=abort when=] |fetchController|'s [=fetch controller/state=] is "<code>terminated</code>" or "<code>aborted</code>".
-                          1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
-                          1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
-                              1. Let |raceNetworkResult| be a [=race result=] whose [=race result/routed response=] is |raceNetworkRequestResponse| and [=race result/used route=] is {{RouterSourceEnum/"network"}}.
-                              1. [=queue/Enqueue=] |raceNetworkResult| to |queue|.
+                              1. Set |raceResponse|'s [=race response/value=] to |raceNetworkRequestResponse|.
+                              1. If |raceNetworkRequestResponse|'s [=response/status=] is [=ok status=], then:
+                                  1. Let |raceNetworkResult| be a [=race result=] whose [=race result/routed response=] is |raceNetworkRequestResponse| and [=race result/used route=] is {{RouterSourceEnum/"network"}}.
+                                  1. [=queue/Enqueue=] |raceNetworkResult| to |queue|.
                           1. [=If aborted=] and |raceFetchController| is not null, then:
                               1. [=fetch controller/Abort=] |raceFetchController|.
                               1. Set |raceResponse| to a [=race response=] whose [=race response/value=] is null.


### PR DESCRIPTION
This is a follow up of https://github.com/w3c/ServiceWorker/pull/1777#discussion_r2141544666.
It originally https://github.com/w3c/ServiceWorker/pull/1779, but closed by mistake.

https://infra.spec.whatwg.org/#abort-when adds the check each time the step is executed. However, there is only a step between and the abort-when and if-aborted, it should be less effective abort than we expect. Let me add a step inside the callback in case.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1780.html" title="Last updated on Jun 18, 2025, 5:18 AM UTC (153f7fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1780/a402c93...yoshisatoyanagisawa:153f7fb.html" title="Last updated on Jun 18, 2025, 5:18 AM UTC (153f7fb)">Diff</a>