### PR TITLE
Update QuotaExceededError usage

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -2310,7 +2310,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                     1. Resolve |promise| with a new {{Cache}} object that represents |value|.
                     1. Abort these steps.
             1. Let |cache| be a new [=request response list=].
-            1. [=map/Set=] the [=relevant name to cache map=][|cacheName|] to |cache|. If this cache write operation failed due to exceeding the granted quota limit, reject |promise| with a "{{QuotaExceededError}}" {{DOMException}} and abort these steps.
+            1. [=map/Set=] the [=relevant name to cache map=][|cacheName|] to |cache|. If this cache write operation failed due to exceeding the granted quota limit, reject |promise| with a {{QuotaExceededError}} and abort these steps.
             1. Resolve |promise| with a new {{Cache}} object that represents |cache|.
         1. Return |promise|.
     </section>
@@ -4071,7 +4071,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                   1. [=list/For each=] |requestResponse| of |requestResponses|:
                       1. [=list/Remove=] the [=list/item=] whose value matches |requestResponse| from |cache|.
                   1. [=list/Append=] |operation|'s [=cache batch operation/request=]/|operation|'s [=cache batch operation/response=] to |cache|.
-                  1. If the cache write operation in the previous two steps failed due to exceeding the granted quota limit, <a>throw</a> a "{{QuotaExceededError}}" {{DOMException}}.
+                  1. If the cache write operation in the previous two steps failed due to exceeding the granted quota limit, <a>throw</a> a {{QuotaExceededError}}.
                   1. [=list/Append=] |operation|'s [=cache batch operation/request=]/|operation|'s [=cache batch operation/response=] to |addedItems|.
               1. [=Append=] |operation|'s [=cache batch operation/request=]/|operation|'s [=cache batch operation/response=] to |resultList|.
           1. Return |resultList|.


### PR DESCRIPTION
QuotaExceededError is graduating from being a DOMException name into a new error class, in https://github.com/whatwg/webidl/pull/1465. Update creation sites to reflect this.

For now, the quota and requested properties are left at their default (null). Future work could include setting them in an informative fashion.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/domenic/ServiceWorker/pull/1782.html" title="Last updated on Jul 8, 2025, 4:38 AM UTC (b3968ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1782/3d83bed...domenic:b3968ee.html" title="Last updated on Jul 8, 2025, 4:38 AM UTC (b3968ee)">Diff</a>