### PR TITLE
Clarify cache access in Handle Fetch

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3241,7 +3241,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Else if |source| is {{RouterSourceEnum/"cache"}}, or |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=], then:
                   1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
                   1. Set |timingInfo|’s [=service worker timing info/worker cache lookup start=] to the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
-                  1. Let |caches| be the result of running [=obtain a local storage bottle map=] with |reservedClient|, "<code>local</code>", and "<code>caches</code>".
+                  1. Let |caches| be the result of running [=obtain a local storage bottle map=] with |reservedClient| and "<code>caches</code>".
                   1. [=map/For each=] |cacheName| &#x2192; |cache| of |caches|.
                       1. If |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=] and |source|["{{RouterSourceDict/cacheName}}"] [=string/is=] not |cacheName|, [=continue=].
                       1. Let |requestResponses| be the result of running [=Query Cache=] with |request|, a new {{CacheQueryOptions}}, and |cache|.


### PR DESCRIPTION
The previous wording "the registration’s storage key’s name to cache map" was ambiguous. This change clarifies the mechanism for accessing caches during a fetch event handled by a service worker.

Specifically, it replaces the ambiguous phrase with a direct call to "obtain a local storage bottle map" from the Storage specification, using the reserved client's environment. This makes the process of retrieving the cache map explicit and aligns the specification with modern storage standards.

This addresses the issue raised in https://github.com/w3c/ServiceWorker/issues/1784


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1786.html" title="Last updated on Aug 28, 2025, 9:27 AM UTC (d6532a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1786/83a8993...yoshisatoyanagisawa:d6532a5.html" title="Last updated on Aug 28, 2025, 9:27 AM UTC (d6532a5)">Diff</a>