### PR TITLE
Fix: Align Cache API definitions with Storage spec

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1952,9 +1952,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A <dfn id="dfn-name-to-cache-map">name to cache map</dfn> is an <a>ordered map</a> whose [=map/entry=] consists of a [=map/key=] (a string that represents the name of a [=request response list=]) and a [=map/value=] (a [=request response list=]).
 
-    Each [=/storage key=] has an associated [=name to cache map=].
-
-    The <dfn id="dfn-relevant-name-to-cache-map">relevant name to cache map</dfn> is the [=name to cache map=] associated with the [=/storage key=] [=obtain a storage key|obtained=] from [=this=]'s associated [=CacheStorage/global object=]'s [=environment settings object=].
+    The <dfn id="dfn-relevant-name-to-cache-map">relevant name to cache map</dfn> is a [=name to cache map=] obtained as the result of running [=obtain a local storage bottle map=] with [=this=]'s associated [=CacheStorage/global object=]'s [=environment settings object=] and "<code>caches</code>".
   </section>
 
   <section>
@@ -2262,7 +2260,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     The user agent *must* create a {{CacheStorage}} object when a {{Window}} object or a {{WorkerGlobalScope}} object is created and associate it with that <dfn for="CacheStorage">global object</dfn>.
 
-    A {{CacheStorage}} object represents a <a>name to cache map</a> of its associated [=CacheStorage/global object=]'s <a>environment settings object</a>'s [=environment settings object/origin=]. Multiple separate objects implementing the {{CacheStorage}} interface across documents and workers can all be associated with the same <a>name to cache map</a> simultaneously.
+    A {{CacheStorage}} object represents the [=name to cache map=] associated with its associated [=CacheStorage/global object=]'s [=environment settings object=]. Multiple separate objects implementing the {{CacheStorage}} interface across documents and workers can all be associated with the same <a>name to cache map</a> simultaneously.
 
     <section algorithm="cache-storage-match">
       <h4 id="cache-storage-match">{{CacheStorage/match(request, options)}}</h4>

--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1952,7 +1952,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A <dfn id="dfn-name-to-cache-map">name to cache map</dfn> is an <a>ordered map</a> whose [=map/entry=] consists of a [=map/key=] (a string that represents the name of a [=request response list=]) and a [=map/value=] (a [=request response list=]).
 
-    The <dfn id="dfn-relevant-name-to-cache-map">relevant name to cache map</dfn> is a [=name to cache map=] obtained as the result of running [=obtain a local storage bottle map=] with [=this=]'s associated [=CacheStorage/global object=]'s [=environment settings object=] and "<code>caches</code>".
+    The <dfn>relevant name to cache map</dfn> for a {{CacheStorage}} object is the [=name to cache map=] associated with the result of running [=obtain a local storage bottle map=] with the object's associated [=CacheStorage/global object=]'s [=environment settings object=] and "<code>caches</code>".
   </section>
 
   <section>
@@ -2260,7 +2260,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     The user agent *must* create a {{CacheStorage}} object when a {{Window}} object or a {{WorkerGlobalScope}} object is created and associate it with that <dfn for="CacheStorage">global object</dfn>.
 
-    A {{CacheStorage}} object represents the [=name to cache map=] associated with its associated [=CacheStorage/global object=]'s [=environment settings object=]. Multiple separate objects implementing the {{CacheStorage}} interface across documents and workers can all be associated with the same <a>name to cache map</a> simultaneously.
+    A {{CacheStorage}} object represents the [=name to cache map=] associated with the result of running [=obtain a local storage bottle map=] with its associated [=CacheStorage/global object=]'s [=environment settings object=] and "<code>caches</code>". Multiple separate objects implementing the {{CacheStorage}} interface across documents and workers can all be associated with the same [=name to cache map=] simultaneously.
 
     <section algorithm="cache-storage-match">
       <h4 id="cache-storage-match">{{CacheStorage/match(request, options)}}</h4>


### PR DESCRIPTION
This commit clarifies how the Cache API interacts with the underlying storage mechanism, resolving ambiguity that stemmed from previous specification language.

Key changes:
- Removes the direct association between "storage key" and "name to cache map".
- Defines "relevant name to cache map" as being retrieved via the `obtain a local storage bottle map` algorithm from the Storage specification, ensuring alignment.
- Updates the definition of `CacheStorage` to represent the `name to cache map` associated with its `environment settings object`, rather than the `origin`.

This makes the relationship between the ServiceWorker Cache API and the Storage specification explicit and consistent, addressing the core issue raised in https://github.com/w3c/ServiceWorker/issues/1784 and the follow-up work in https://github.com/w3c/ServiceWorker/issues/1788.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1789.html" title="Last updated on Sep 9, 2025, 2:24 AM UTC (45b3847)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1789/3ab2b8a...yoshisatoyanagisawa:45b3847.html" title="Last updated on Sep 9, 2025, 2:24 AM UTC (45b3847)">Diff</a>