### PR TITLE
Handle Fetch: Use correct storage key for subresource requests

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -3241,7 +3241,12 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Else if |source| is {{RouterSourceEnum/"cache"}}, or |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=], then:
                   1. If |shouldSoftUpdate| is true, then [=in parallel=] run the [=Soft Update=] algorithm with |registration|.
                   1. Set |timingInfo|’s [=service worker timing info/worker cache lookup start=] to the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
-                  1. Let |caches| be the result of running [=obtain a local storage bottle map=] with |reservedClient| and "<code>caches</code>".
+                  1. Let |environment| be null.
+                  1. If |request| is a <a>non-subresource request</a>, then:
+                      1. Set |environment| to |reservedClient|.
+                  1. Else:
+                      1. Set |environment| to |client|.
+                  1. Let |caches| be the result of running [=obtain a local storage bottle map=] with |environment| and "<code>caches</code>".
                   1. [=map/For each=] |cacheName| &#x2192; |cache| of |caches|.
                       1. If |source|["{{RouterSourceDict/cacheName}}"] [=map/exists=] and |source|["{{RouterSourceDict/cacheName}}"] [=string/is=] not |cacheName|, [=continue=].
                       1. Let |requestResponses| be the result of running [=Query Cache=] with |request|, a new {{CacheQueryOptions}}, and |cache|.


### PR DESCRIPTION
This change corrects the cache resolution logic within the Handle Fetch algorithm when the router source is RouterSourceEnum/"cache".

The Problem:
Previously, the algorithm always used reservedClient to resolve the storage key, regardless of the request type. However, reservedClient is only valid for top-level navigation requests and is not available for subresource requests. This could lead to accessing the incorrect cache storage during subresource fetches.

The Fix:
Logic has been added to differentiate between a non-subresource request and a subresource request.
- For a non-subresource request: It continues to use reservedClient as before.
- For a subresource request: It now uses the client associated with the request object.

This ensures that the correct storage key, based on the requesting client, is used for subresource requests.

Fixes: https://github.com/w3c/ServiceWorker/issues/1784


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1790.html" title="Last updated on Sep 5, 2025, 2:09 AM UTC (d0832ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1790/953b6d3...yoshisatoyanagisawa:d0832ba.html" title="Last updated on Sep 5, 2025, 2:09 AM UTC (d0832ba)">Diff</a>