### PR TITLE
Editorial: remove unnecessary CacheStorage global object definition

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -1952,7 +1952,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A <dfn id="dfn-name-to-cache-map">name to cache map</dfn> is an <a>ordered map</a> whose [=map/entry=] consists of a [=map/key=] (a string that represents the name of a [=request response list=]) and a [=map/value=] (a [=request response list=]).
 
-    The <dfn>relevant name to cache map</dfn> for a {{CacheStorage}} object is the [=name to cache map=] associated with the result of running [=obtain a local storage bottle map=] with the object's associated [=CacheStorage/global object=]'s [=environment settings object=] and "<code>caches</code>".
+    The <dfn>relevant name to cache map</dfn> for a {{CacheStorage}} object is the [=name to cache map=] associated with the result of running [=obtain a local storage bottle map=] with the object's [=relevant settings object=] and "<code>caches</code>".
   </section>
 
   <section>
@@ -2258,9 +2258,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     Note: {{CacheStorage}} interface is designed to largely conform to <a lt="map objects">ECMAScript 6 Map objects</a> but entirely async, and with additional convenience methods. The methods, <code>clear</code>, <code>forEach</code>, <code>entries</code> and <code>values</code>, are intentionally excluded from the scope of the first version resorting to the ongoing discussion about the async iteration by TC39.
 
-    The user agent *must* create a {{CacheStorage}} object when a {{Window}} object or a {{WorkerGlobalScope}} object is created and associate it with that <dfn for="CacheStorage">global object</dfn>.
+    The user agent *must* create a {{CacheStorage}} object when a {{Window}} object or a {{WorkerGlobalScope}} object is created and associate it with that [=global object=].
 
-    A {{CacheStorage}} object represents the [=name to cache map=] associated with the result of running [=obtain a local storage bottle map=] with its associated [=CacheStorage/global object=]'s [=environment settings object=] and "<code>caches</code>". Multiple separate objects implementing the {{CacheStorage}} interface across documents and workers can all be associated with the same [=name to cache map=] simultaneously.
+    A {{CacheStorage}} object represents the [=name to cache map=] associated with the result of running [=obtain a local storage bottle map=] with its [=relevant settings object=] and "<code>caches</code>". Multiple separate objects implementing the {{CacheStorage}} interface across documents and workers can all be associated with the same [=name to cache map=] simultaneously.
 
     <section algorithm="cache-storage-match">
       <h4 id="cache-storage-match">{{CacheStorage/match(request, options)}}</h4>


### PR DESCRIPTION
This patch removes the specific definition of the global object for CacheStorage and replaces the incorrect and redundant reference to the environment settings object with a more direct reference to the relevant settings object.

Fixes https://github.com/w3c/ServiceWorker/issues/1791