### PR TITLE
Do not remove the race response map entry in Lookup Race Response

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4157,7 +4157,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Let |map| be |activeWorker|'s [=service worker/global object=]'s [=race response map=].
       1. If |map|[|request|] [=map/exists=], then:
         1. Let |entry| be |map|[|request|].
-        1. [=map/Remove=] |map|[|request|].
         1. Wait until |entry|'s [=race response/value=] is not "<code>pending</code>"
         1. If |entry|'s [=race response/value=] is [=/response=], return |entry|'s [=race response/value=].
       1. Return null.


### PR DESCRIPTION
This change is based on the discussion in https://github.com/whatwg/fetch/pull/1737. We don't have to remove the entry from the race response map in the lookup-race-response-algorithm, as we don't want to limit de-duplicating the fetch(e.request) call once triggered in the fetch handler. fetch(e.request) can be called multiple times in one fetch handler.

The map entry is removed in [the step 20 of the Create Fetch Event and Dispatch](https://w3c.github.io/ServiceWorker/#ref-for-serviceworkerglobalscope-race-response-map%E2%91%A1:~:text=If%20activeWorker%E2%80%99s%20global%20object%E2%80%99s%20race%20response%20map%5Brequest%5D%20exists%2C%20remove%20activeWorker%E2%80%99s%20global%20object%E2%80%99s%20race%20response%20map%5Brequest%5D.). That ensures that the added entry is removed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sisidovski/ServiceWorker/pull/1807.html" title="Last updated on Nov 25, 2025, 8:50 AM UTC (093a36c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1807/d3e4e3b...sisidovski:093a36c.html" title="Last updated on Nov 25, 2025, 8:50 AM UTC (093a36c)">Diff</a>