### PR TITLE
Editorial: export "Fire Functional Event" arguments

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3616,15 +3616,15 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. Return false.
   </section>
 
-  <section algorithm>
+  <section algorithm="Fire Functional Event">
     <h3 id="fire-functional-event-algorithm"><dfn export lt="Fire Functional Event|Fire a functional event">Fire Functional Event</dfn></h3>
 
       : Input
-      :: |eventName|, a string
-      :: |eventConstructor|, an event constructor that extends {{ExtendableEvent}}
-      :: |registration|, a [=/service worker registration=]
-      :: |initialization|, optional property initialization for |event|, constructed from |eventConstructor|
-      :: |postDispatchSteps|, optional steps to run on the [=service worker registration/active worker=]'s event loop, with |dispatchedEvent| set to the instance of |eventConstructor| that was [=dispatched=].
+      :: <dfn export for="Fire Functional Event">|eventName|</dfn>, a string
+      :: <dfn export for="Fire Functional Event">|eventConstructor|</dfn>, an event constructor that extends {{ExtendableEvent}}
+      :: <dfn export for="Fire Functional Event">|registration|</dfn>, a [=/service worker registration=]
+      :: <dfn export for="Fire Functional Event">|initialization|</dfn>, optional property initialization for |event|, constructed from |eventConstructor|
+      :: <dfn export for="Fire Functional Event">|postDispatchSteps|</dfn>, optional steps to run on the [=service worker registration/active worker=]'s event loop, with |dispatchedEvent| set to the instance of |eventConstructor| that was [=dispatched=].
       : Output
       :: None
 


### PR DESCRIPTION
To allow callers to refer arguments with their names, this change exports them.

Bug: https://github.com/w3c/ServiceWorker/issues/1808


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1809.html" title="Last updated on Nov 26, 2025, 7:10 AM UTC (fca6f2e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1809/a6ed7c8...yoshisatoyanagisawa:fca6f2e.html" title="Last updated on Nov 26, 2025, 7:10 AM UTC (fca6f2e)">Diff</a>