### PR TITLE
Clone response in Lookup Race Response algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4158,7 +4158,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       1. If |map|[|request|] [=map/exists=], then:
         1. Let |entry| be |map|[|request|].
         1. Wait until |entry|'s [=race response/value=] is not "<code>pending</code>"
-        1. If |entry|'s [=race response/value=] is [=/response=], return |entry|'s [=race response/value=].
+        1. If |entry|'s [=race response/value=] is a [=/response=], return the result of <a for="response">cloning</a> |entry|'s [=race response/value=].
       1. Return null.
   </section>
 </section>


### PR DESCRIPTION
The "Lookup Race Response" algorithm returned a response from the race response map directly. This could lead to issues where a response body is consumed more than once, as a Response object's body cannot be reused across multiple fetch operations.

This change modifies the algorithm to return a clone of the response, aligning with the Fetch specification's standard practice for handling responses that may be used by multiple consumers. This ensures that each fetch handler receives a distinct, readable stream.

See also: https://fetch.spec.whatwg.org/#concept-response-clone


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1811.html" title="Last updated on Dec 9, 2025, 7:39 AM UTC (9a656e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1811/a6ed7c8...yoshisatoyanagisawa:9a656e9.html" title="Last updated on Dec 9, 2025, 7:39 AM UTC (9a656e9)">Diff</a>