### PR TITLE
Editorial: "Update Service Worker Extended Events Set" minor fix

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3707,7 +3707,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       : Input
       :: |worker|, a [=/service worker=]
-      :: |event|, an [=event=]
+      :: |event|, an {{ExtendableEvent}}
       : Output
       :: None
 


### PR DESCRIPTION
The "Update Service Worker Extended Events Set" algorithm stores the input event into the "set of extended events", which is defined as a set of ExtendableEvent objects. To be consistent with this definition and how the algorithm is called (always with ExtendableEvent or its subclasses), this change updates the input type from Event to ExtendableEvent.

Bug: #1196


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1813.html" title="Last updated on Jan 23, 2026, 8:44 AM UTC (44a2a24)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1813/3ff30ad...yoshisatoyanagisawa:44a2a24.html" title="Last updated on Jan 23, 2026, 8:44 AM UTC (44a2a24)">Diff</a>