### PR TITLE
[Editorial] Use ExtendableMessageEvent for messageerror (minor fix)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1931,7 +1931,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         </tr>
         <tr>
           <td><dfn event><code>messageerror</code></dfn></td>
-          <td>{{MessageEvent}}</td>
+          <td>{{ExtendableMessageEvent}}</td>
           <td>Legacy</td>
           <td>When it was sent a message that cannot be deserialized.</td>
         </tr>


### PR DESCRIPTION
[3.1.4](https://w3c.github.io/ServiceWorker/#service-worker-postmessage) in the spec already uses ExtendableMessageEvent for messageerror. This PR updates messageerror from MessageEvent to the ExtendableMessageEvent  in the  ServiceWorkerGlobalScope table

Bug: [1193](https://github.com/w3c/ServiceWorker/issues/1193)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/monica-ch/ServiceWorker/pull/1814.html" title="Last updated on Jan 26, 2026, 5:02 PM UTC (9714c82)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1814/3ff30ad...monica-ch:9714c82.html" title="Last updated on Jan 26, 2026, 5:02 PM UTC (9714c82)">Diff</a>