### PR TITLE
Update links to Payment Handler's events

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1912,16 +1912,16 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           <td>(See <a href="https://wicg.github.io/background-sync/spec/#fire-a-sync-event">Firing a sync event</a>.)</td>
         </tr>
         <tr>
-          <td><a href="https://w3c.github.io/payment-handler/#the-canmakepaymentevent">canmakepayment</a></td>
-          <td><a href="https://w3c.github.io/payment-handler/#dom-canmakepaymentevent">CanMakePaymentEvent</a></td>
+          <td><a href="https://w3c.github.io/web-based-payment-handler/#the-canmakepaymentevent">canmakepayment</a></td>
+          <td><a href="https://w3c.github.io/web-based-payment-handler/#dom-canmakepaymentevent">CanMakePaymentEvent</a></td>
           <td>[=Functional event|Functional=]</td>
-          <td>(See <a href="https://w3c.github.io/payment-handler/#dfn-handling-a-canmakepaymentevent">Handling a CanMakePaymentEvent</a>.)</td>
+          <td>(See <a href="https://w3c.github.io/web-based-payment-handler/#dfn-handling-a-canmakepaymentevent">Handling a CanMakePaymentEvent</a>.)</td>
         </tr>
         <tr>
-          <td><a href="https://w3c.github.io/payment-handler/#the-paymentrequestevent">paymentrequest</a></td>
-          <td><a href="https://w3c.github.io/payment-handler/#dom-paymentrequestevent">PaymentRequestEvent</a></td>
+          <td><a href="https://w3c.github.io/web-based-payment-handler/#the-paymentrequestevent">paymentrequest</a></td>
+          <td><a href="https://w3c.github.io/web-based-payment-handler/#dom-paymentrequestevent">PaymentRequestEvent</a></td>
           <td>[=Functional event|Functional=]</td>
-          <td>(See <a href="https://w3c.github.io/payment-handler/#dfn-handling-a-paymentrequestevent">Handling a PaymentRequestEvent</a>.)</td>
+          <td>(See <a href="https://w3c.github.io/web-based-payment-handler/#dfn-handling-a-paymentrequestevent">Handling a PaymentRequestEvent</a>.)</td>
         </tr>
         <tr>
           <td><dfn event><code>message</code></dfn></td>


### PR DESCRIPTION
Shortname of the Payment Handler spec changed from `payment-handler` to `web-based-payment-handler`. This adjusts the links accordingly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/pull/1816.html" title="Last updated on Feb 19, 2026, 9:21 AM UTC (b4136d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1816/c680622...b4136d1.html" title="Last updated on Feb 19, 2026, 9:21 AM UTC (b4136d1)">Diff</a>