### PR TITLE
Remove redundant origin check in unregister algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3723,9 +3723,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       : Output
       :: none
 
-      1. If the [=environment settings object/origin=] of |job|'s [=job/scope url=] is not |job|'s [=job/client=]'s [=environment settings object/origin=], then:
-          1. Invoke [=Reject Job Promise=] with |job| and "{{SecurityError}}" {{DOMException}}.
-          1. Invoke <a>Finish Job</a> with |job| and abort these steps.
       1. Let |registration| be the result of running <a>Get Registration</a> given |job|'s [=job/storage key=] and |job|'s [=job/scope url=].
       1. If |registration| is null, then:
           1. Invoke <a>Resolve Job Promise</a> with |job| and false.


### PR DESCRIPTION
This removes the first step of the Unregister algorithm, which threw a "SecurityError" DOMException if the origin of the job's scope URL did not match the job's client's origin.

This check is redundant because the scope URL is derived directly from the ServiceWorkerRegistration object itself. For this check to fail, the ServiceWorkerRegistration would have had to be exposed in a cross-origin client context, which is already prevented by the platform.

Fixes #1305


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1818.html" title="Last updated on Mar 6, 2026, 9:07 AM UTC (93d977e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1818/5614d6f...yoshisatoyanagisawa:93d977e.html" title="Last updated on Mar 6, 2026, 9:07 AM UTC (93d977e)">Diff</a>