### PR TITLE
Teach ExtendableMessageEvent to work with origins.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1847,6 +1847,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       <h4 id="extendablemessage-event-lasteventid">{{ExtendableMessageEvent/lastEventId|event.lastEventId}}</h4>
 
       The <dfn attribute for="ExtendableMessageEvent">lastEventId</dfn> attribute *must* return the value it was initialized to. When the object is created, this attribute *must* be initialized to the empty string.
+
+      Objects implementing the {{ExtendableMessageEvent}} interface's [=extract an origin=] steps are to return [=this=]'s [=ExtendableMessageEvent/origin=] if it is an [=/origin=]; otherwise null.
     </section>
 
     <section>

--- a/index.bs
+++ b/index.bs
@@ -100,6 +100,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
         urlPrefix: interaction.html
             text: visibilityState; for: Document; url: page-visibility
     type: dfn
+        urlPrefix: comms.html
+            text: concept-MessageEvent-origin; url: concept-messageevent-origin
         urlPrefix: syntax.html
             text: delay the load event; for: document; url: delay-the-load-event
         urlPrefix: browsers.html
@@ -515,15 +517,15 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                         <dt>Otherwise</dt>
                         <dd>a new {{Client}} object that represents |incumbentGlobal|'s associated worker</dd>
                     </dl>
-                1. Let |origin| be the [=serialization of an origin|serialization=] of |incumbentSettings|'s [=environment settings object/origin=].
+                1. Let |origin| be |incumbentSettings|'s [=environment settings object/origin=].
                 1. Let |destination| be the {{ServiceWorkerGlobalScope}} object associated with |serviceWorker|.
                 1.  Let |deserializeRecord| be <a abstract-op>StructuredDeserializeWithTransfer</a>(|serializeWithTransferResult|, |destination|'s [=global object/Realm=]).
 
-                    If this throws an exception, let |e| be the result of [=creating an event=] named {{ServiceWorkerGlobalScope/messageerror!!event}}, using {{ExtendableMessageEvent}}, with the {{ExtendableMessageEvent/origin}} attribute initialized to |origin| and the {{ExtendableMessageEvent/source}} attribute initialized to |source|.
+                    If this throws an exception, let |e| be the result of [=creating an event=] named {{ServiceWorkerGlobalScope/messageerror!!event}}, using {{ExtendableMessageEvent}}, with its [=ExtendableMessageEvent/origin=] initialized to |origin| and the {{ExtendableMessageEvent/source}} attribute initialized to |source|.
                 1. Else:
                     1. Let |messageClone| be |deserializeRecord|.\[[Deserialized]].
                     1. Let |newPorts| be a new [=frozen array type|frozen array=] consisting of all {{MessagePort}} objects in |deserializeRecord|.\[[TransferredValues]], if any, maintaining their relative order.
-                    1. Let |e| be the result of [=creating an event=] named {{ServiceWorkerGlobalScope/message!!event}}, using {{ExtendableMessageEvent}}, with the {{ExtendableMessageEvent/origin}} attribute initialized to |origin|, the {{ExtendableMessageEvent/source}} attribute initialized to |source|, the {{ExtendableMessageEvent/data}} attribute initialized to |messageClone|, and the {{ExtendableMessageEvent/ports}} attribute initialized to |newPorts|.
+                    1. Let |e| be the result of [=creating an event=] named {{ServiceWorkerGlobalScope/message!!event}}, using {{ExtendableMessageEvent}}, with its [=ExtendableMessageEvent/origin=] initialized to |origin|, the {{ExtendableMessageEvent/source}} attribute initialized to |source|, the {{ExtendableMessageEvent/data}} attribute initialized to |messageClone|, and the {{ExtendableMessageEvent/ports}} attribute initialized to |newPorts|.
                 1. [=Dispatch=] |e| at |destination|.
                 1. Invoke [=Update Service Worker Extended Events Set=] with |serviceWorker| and |e|.
     </section>
@@ -1276,14 +1278,14 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
             1. If |targetClient| is null, return.
             1. Let |destination| be the {{ServiceWorkerContainer}} object whose associated [=ServiceWorkerContainer/service worker client=] is |targetClient|.
             1. Add a [=task=] that runs the following steps to |destination|'s [=ServiceWorkerContainer/client message queue=]:
-                1. Let |origin| be the [=serialization of an origin|serialization=] of |sourceSettings|'s [=environment settings object/origin=].
+                1. Let |origin| be |sourceSettings|'s [=environment settings object/origin=].
                 1. Let |source| be the result of [=getting the service worker object=] that represents |contextObject|'s [=relevant global object=]'s [=ServiceWorkerGlobalScope/service worker=] in |targetClient|.
                 1. Let |deserializeRecord| be <a abstract-op>StructuredDeserializeWithTransfer</a>(|serializeWithTransferResult|, |destination|'s [=relevant Realm=]).
 
-                    If this throws an exception, catch it, [=fire an event=] named {{ServiceWorkerContainer/messageerror!!event}} at |destination|, using {{MessageEvent}}, with the {{MessageEvent/origin}} attribute initialized to |origin| and the {{MessageEvent/source}} attribute initialized to |source|, and then abort these steps.
+                    If this throws an exception, catch it, [=fire an event=] named {{ServiceWorkerContainer/messageerror!!event}} at |destination|, using {{MessageEvent}}, with its [=concept-MessageEvent-origin|origin=] initialized to |origin| and the {{MessageEvent/source}} attribute initialized to |source|, and then abort these steps.
                 1. Let |messageClone| be |deserializeRecord|.\[[Deserialized]].
                 1. Let |newPorts| be a new [=frozen array type|frozen array=] consisting of all {{MessagePort}} objects in |deserializeRecord|.\[[TransferredValues]], if any.
-                1. [=Dispatch|Dispatch an event=] named {{Window/message!!event}} at |destination|, using {{MessageEvent}}, with the {{MessageEvent/origin}} attribute initialized to |origin|, the {{MessageEvent/source}} attribute initialized to |source|, the {{MessageEvent/data}} attribute initialized to |messageClone|, and the {{MessageEvent/ports}} attribute initialized to |newPorts|.
+                1. [=Dispatch|Dispatch an event=] named {{Window/message!!event}} at |destination|, using {{MessageEvent}}, with its [=concept-MessageEvent-origin|origin=] initialized to |origin|, the {{MessageEvent/source}} attribute initialized to |source|, the {{MessageEvent/data}} attribute initialized to |messageClone|, and the {{MessageEvent/ports}} attribute initialized to |newPorts|.
     </section>
 
     <section>
@@ -1819,6 +1821,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       };
     </pre>
 
+    Each {{ExtendableMessageEvent}} has an <dfn for="ExtendableMessageEvent">origin</dfn> (an [=/origin=], a string, or null), initially null.
+
     [=/Service workers=] define the <a method lt="waitUntil()" for="ExtendableEvent">extendable</a> {{ServiceWorkerGlobalScope/message!!event}} event to allow extending the lifetime of the event. For the {{ServiceWorkerGlobalScope/message!!event}} event, [=/service workers=] use the {{ExtendableMessageEvent}} interface which extends the {{ExtendableEvent}} interface.
 
     <section>
@@ -1830,7 +1834,15 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
     <section>
       <h4 id="extendablemessage-event-origin">{{ExtendableMessageEvent/origin|event.origin}}</h4>
 
-      The <dfn attribute for="ExtendableMessageEvent">origin</dfn> attribute *must* return the value it was initialized to. When the object is created, this attribute *must* be initialized to the empty string. It represents the [=environment settings object/origin=] of the [=/service worker client=] that sent the message.
+      The <dfn attribute for="ExtendableMessageEvent">origin</dfn> attribute represents the [=environment settings object/origin=] of the [=/service worker client=] that sent the message.
+
+      The {{ExtendableMessageEvent/origin}} getter steps are:
+
+      1. If [=this=]'s [=ExtendableMessageEvent/origin=] is an [=/origin=], then return the [=serialization of an origin|serialization=] of [=this=]'s [=ExtendableMessageEvent/origin=].
+      1. If [=this=]'s [=ExtendableMessageEvent/origin=] is null, then return the empty string.
+      1. Return [=this=]'s [=ExtendableMessageEvent/origin=].
+
+      When the {{ExtendableMessageEvent/origin}} attribute is "initialized" (during {{ExtendableMessageEvent}}'s constructor, for example), the initialization value is placed into the object's [=ExtendableMessageEvent/origin=].
     </section>
 
     <section>

--- a/index.bs
+++ b/index.bs
@@ -100,8 +100,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
         urlPrefix: interaction.html
             text: visibilityState; for: Document; url: page-visibility
     type: dfn
-        urlPrefix: comms.html
-            text: concept-MessageEvent-origin; url: concept-messageevent-origin
         urlPrefix: syntax.html
             text: delay the load event; for: document; url: delay-the-load-event
         urlPrefix: browsers.html
@@ -1282,10 +1280,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                 1. Let |source| be the result of [=getting the service worker object=] that represents |contextObject|'s [=relevant global object=]'s [=ServiceWorkerGlobalScope/service worker=] in |targetClient|.
                 1. Let |deserializeRecord| be <a abstract-op>StructuredDeserializeWithTransfer</a>(|serializeWithTransferResult|, |destination|'s [=relevant Realm=]).
 
-                    If this throws an exception, catch it, [=fire an event=] named {{ServiceWorkerContainer/messageerror!!event}} at |destination|, using {{MessageEvent}}, with its [=concept-MessageEvent-origin|origin=] initialized to |origin| and the {{MessageEvent/source}} attribute initialized to |source|, and then abort these steps.
+                    If this throws an exception, catch it, [=fire an event=] named {{ServiceWorkerContainer/messageerror!!event}} at |destination|, using {{MessageEvent}}, with its [=MessageEvent/origin=] initialized to |origin| and the {{MessageEvent/source}} attribute initialized to |source|, and then abort these steps.
                 1. Let |messageClone| be |deserializeRecord|.\[[Deserialized]].
                 1. Let |newPorts| be a new [=frozen array type|frozen array=] consisting of all {{MessagePort}} objects in |deserializeRecord|.\[[TransferredValues]], if any.
-                1. [=Dispatch|Dispatch an event=] named {{Window/message!!event}} at |destination|, using {{MessageEvent}}, with its [=concept-MessageEvent-origin|origin=] initialized to |origin|, the {{MessageEvent/source}} attribute initialized to |source|, the {{MessageEvent/data}} attribute initialized to |messageClone|, and the {{MessageEvent/ports}} attribute initialized to |newPorts|.
+                1. [=Dispatch|Dispatch an event=] named {{Window/message!!event}} at |destination|, using {{MessageEvent}}, with its [=MessageEvent/origin=] initialized to |origin|, the {{MessageEvent/source}} attribute initialized to |source|, the {{MessageEvent/data}} attribute initialized to |messageClone|, and the {{MessageEvent/ports}} attribute initialized to |newPorts|.
     </section>
 
     <section>


### PR DESCRIPTION
Currently, ExtendableMessageEvent's origin holds a serialized origin. In order for Origin.from(...) to function as intended for sources with opaque origins, we need to hold an origin on ExtendableMessageEvent instead.

This patch adds an "origin" concept to `ExtendableMessageEvent`, and shifts call sites to initialize that value with an origin whenever possible. It also adds "extract an origin" steps to return the stored origin when present, and to return null in cases where the object was initialized with an untrusted origin representation (e.g., when its constructor is called with a ExtendableMessageEventInit dictionary).

This replicates whatwg/html#11993's work on `MessageEvent`, and should fix w3c/ServiceWorker#1820.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mikewest/ServiceWorker/pull/1821.html" title="Last updated on Mar 11, 2026, 9:37 AM UTC (c890bb1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1821/4a9e044...mikewest:c890bb1.html" title="Last updated on Mar 11, 2026, 9:37 AM UTC (c890bb1)">Diff</a>