### PR TITLE
Set request's initiator and destination to empty string in cache.addA…

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2099,7 +2099,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                 1. [=list/For each=] |fetchController| of |fetchControllers|, [=fetch controller/abort=] |fetchController|.
                 1. Return [=a promise rejected with=] a `TypeError`.
             1. If |r|'s [=request/client=]'s [=environment settings object/global object=] is a {{ServiceWorkerGlobalScope}} object, set |request|'s [=service-workers mode=] to "`none`".
-            1. Set |r|'s [=request/initiator=] to "`fetch`" and [=request/destination=] to "`subresource`".
+            1. Set |r|'s [=request/initiator=] and [=request/destination=] to the empty string.
             1. Add |r| to |requestList|.
             1. Let |responsePromise| be [=a new promise=].
             1. Run the following substeps [=in parallel=]:

--- a/index.bs
+++ b/index.bs
@@ -2099,7 +2099,6 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                 1. [=list/For each=] |fetchController| of |fetchControllers|, [=fetch controller/abort=] |fetchController|.
                 1. Return [=a promise rejected with=] a `TypeError`.
             1. If |r|'s [=request/client=]'s [=environment settings object/global object=] is a {{ServiceWorkerGlobalScope}} object, set |request|'s [=service-workers mode=] to "`none`".
-            1. Set |r|'s [=request/initiator=] and [=request/destination=] to the empty string.
             1. Add |r| to |requestList|.
             1. Let |responsePromise| be [=a new promise=].
             1. Run the following substeps [=in parallel=]:


### PR DESCRIPTION
As pointed out in https://github.com/w3c/ServiceWorker/issues/1718, "fetch" is not a valid value for a request's initiator, and "subresource" is not a valid destination in the Fetch specification.

Following the discussion in the issue, `cache.addAll()` should function the same as if a script ran `fetch()` directly. Therefore, both initiator and destination should be set to the empty string.

Fixes #1718


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1822.html" title="Last updated on Apr 8, 2026, 12:19 PM UTC (51a9972)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1822/c9b4790...yoshisatoyanagisawa:51a9972.html" title="Last updated on Apr 8, 2026, 12:19 PM UTC (51a9972)">Diff</a>