### PR TITLE
[Editorial] Use MessageEvent for ServiceWorkerContainer message and messageerror

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -940,12 +940,12 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         </tr>
         <tr>
           <td><dfn event id="service-worker-container-message-event"><code>message</code></dfn></td>
-          <td>{{Event}}</td>
+          <td>{{MessageEvent}}</td>
           <td>The [=ServiceWorkerContainer/service worker client=] receives a message from a [=/service worker=]. See {{Client/postMessage(message, options)}}.</td>
         </tr>
         <tr>
           <td><dfn event id="service-worker-container-messageerror-event"><code>messageerror</code></dfn></td>
-          <td>{{Event}}</td>
+          <td>{{MessageEvent}}</td>
           <td>The [=ServiceWorkerContainer/service worker client=] is sent a message that cannot be deserialized from a [=/service worker=]. See {{Client/postMessage(message, options)}}.</td>
         </tr>
       </tbody>


### PR DESCRIPTION
The events table for `ServiceWorkerContainer` listed the `Event` interface
for both the `message` and `messageerror` events, but the `Client.postMessage`
algorithm in §4.5.3 dispatches both events using `MessageEvent` here in https://w3c.github.io/ServiceWorker/#client-postmessage

This PR updates the table to match the algorithm:

- `message`: `Event` → `MessageEvent`
- `messageerror`: `Event` → `MessageEvent`

This PR fixes #1301


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/monica-ch/ServiceWorker/pull/1825.html" title="Last updated on Jun 5, 2026, 11:52 PM UTC (e8a84c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1825/28e78e7...monica-ch:e8a84c1.html" title="Last updated on Jun 5, 2026, 11:52 PM UTC (e8a84c1)">Diff</a>