### PR TITLE
NavigationPreloadManager.setHeaderValue should reject invalid header values

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1004,6 +1004,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       The <dfn method for="NavigationPreloadManager"><code>setHeaderValue(|value|)</code></dfn> method steps are:
 
+        1. Let |value| be the result of [=header value/normalizing=] |value|.
+        1. If |value| is not a [=header value=], return [=a promise rejected with=] a {{TypeError}}.
         1. Let |promise| be [=a new promise=].
         1. Run the following steps [=in parallel=]:
             1. Let |registration| be [=this=]'s associated [=/service worker registration=].


### PR DESCRIPTION
This update adds validation for the header value in NavigationPreloadManager.setHeaderValue() to match the Fetch specification's "header value" definition. It now:
1. Normalizes the input value (stripping HTTP whitespace).
2. Rejects the promise with a TypeError if the value contains invalid bytes (including \r, \n, or \0).

Fixes #1000


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoshisatoyanagisawa/ServiceWorker/pull/1827.html" title="Last updated on Jun 16, 2026, 4:50 AM UTC (3123a0c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1827/6de474f...yoshisatoyanagisawa:3123a0c.html" title="Last updated on Jun 16, 2026, 4:50 AM UTC (3123a0c)">Diff</a>