### PR TITLE
Fetch module service worker scripts with same-origin credentials

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2787,7 +2787,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
           : "<code>classic</code>"
           :: <a>Fetch a classic worker script</a> given |job|’s <a lt="URL serializer">serialized</a> [=job/script url=], |job|’s [=job/client=], "<code>serviceworker</code>", and the to-be-created <a>environment settings object</a> for this service worker.
           : "<code>module</code>"
-          :: <a>Fetch a module worker script graph</a> given |job|’s <a lt="URL serializer">serialized</a> [=job/script url=], |job|’s [=job/client=], "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a>environment settings object</a> for this service worker.
+          :: <a>Fetch a module worker script graph</a> given |job|’s <a lt="URL serializer">serialized</a> [=job/script url=], |job|’s [=job/client=], "<code>serviceworker</code>", "<code>same-origin</code>", and the to-be-created <a>environment settings object</a> for this service worker.
 
           Issue: Using the to-be-created [=environment settings object=] rather than a concrete [=environment settings object=]. This is used due to the unique processing model of service workers compared to the processing model of other [=web workers=]. The script fetching algorithms of HTML standard originally designed for other [=web workers=] require an [=environment settings object=] of the execution environment, but service workers fetch a script separately in the [=Update=] algorithm before the script later runs multiple times through the [=Run Service Worker=] algorithm.
 


### PR DESCRIPTION
Fixes #1365.

The Update algorithm passed `"omit"` as the credentials mode when fetching
module service worker scripts. HTML changed module scripts to default to
`"same-origin"` in [whatwg/html@5fabb58](https://github.com/whatwg/html/commit/5fabb5830630723a6b0db13844cacda1d17aa50a), and service workers
don't expose a way to opt back into `"omit"`.

This change updates the call to `fetch a module worker script graph` to
pass `"same-origin"`, aligning the spec with HTML and with shipping
browser behavior.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/monica-ch/ServiceWorker/pull/1829.html" title="Last updated on Jun 19, 2026, 4:57 PM UTC (d951274)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1829/28e78e7...monica-ch:d951274.html" title="Last updated on Jun 19, 2026, 4:57 PM UTC (d951274)">Diff</a>