### PR TITLE
Editorial: clarify FetchEvent clientId, resultingClientId, and replacesClientId initialization

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1706,7 +1706,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       <dfn attribute for="FetchEvent"><code>clientId</code></dfn> attribute *must* return the value it was initialized to. When an <a>event</a> is created the attribute *must* be initialized to the empty string.
 
-      Note: {{FetchEvent/clientId}} is the [=environment/id=] of |request|'s [=request/client=] when the [=/request=] has an associated initiating [=/service worker client=]. This is the case for [=subresource requests=], and also for [=non-subresource requests=] that were initiated by an existing client (such as worker script fetches, or a [=navigation request=] initiated by an existing document). It is the empty string when |request|'s [=request/client=] is null (e.g., a top-level [=navigation request=] triggered by the user typing a URL in the address bar). See {{FetchEvent/resultingClientId}} for the environment associated with the resulting document of a [=navigation request=].
+      Note: {{FetchEvent/clientId}} is the [=environment/id=] of |request|'s [=request/client=] when the [=/request=] has an initiating [=/service worker client=], and the empty string otherwise (e.g., a top-level [=navigation request=] with no initiator). See {{FetchEvent/resultingClientId}} for the environment associated with the resulting document of a [=navigation request=].
     </section>
 
     <section>

--- a/index.bs
+++ b/index.bs
@@ -1706,7 +1706,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       <dfn attribute for="FetchEvent"><code>clientId</code></dfn> attribute *must* return the value it was initialized to. When an <a>event</a> is created the attribute *must* be initialized to the empty string.
 
-      Note: {{FetchEvent/clientId}} is the [=environment/id=] of |request|'s [=request/client=] when the [=/request=] has an associated initiating [=/service worker client=]. This is the case for [=subresource requests=], and also for [=non-subresource requests=] that were initiated by an existing client (such as [=worker=] script fetches, or a [=navigation request=] initiated by an existing document). It is the empty string when |request|'s [=request/client=] is null (e.g., a top-level [=navigation request=] triggered by the user typing a URL in the address bar). See {{FetchEvent/resultingClientId}} for the environment associated with the resulting document of a [=navigation request=].
+      Note: {{FetchEvent/clientId}} is the [=environment/id=] of |request|'s [=request/client=] when the [=/request=] has an associated initiating [=/service worker client=]. This is the case for [=subresource requests=], and also for [=non-subresource requests=] that were initiated by an existing client (such as worker script fetches, or a [=navigation request=] initiated by an existing document). It is the empty string when |request|'s [=request/client=] is null (e.g., a top-level [=navigation request=] triggered by the user typing a URL in the address bar). See {{FetchEvent/resultingClientId}} for the environment associated with the resulting document of a [=navigation request=].
     </section>
 
     <section>
@@ -1714,7 +1714,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       <dfn attribute for="FetchEvent"><code>resultingClientId</code></dfn> attribute *must* return the value it was initialized to. When an <a>event</a> is created the attribute *must* be initialized to the empty string.
 
-      Note: {{FetchEvent/resultingClientId}} is |request|'s [=request/reserved client=]'s [=environment/id=], or the empty string for [=subresource requests=], for requests whose [=request/destination=] is {{RequestDestination/"report"}}, or when |request|'s [=request/reserved client=] is null.
+      Note: {{FetchEvent/resultingClientId}} is |request|'s [=request/reserved client=]'s [=environment/id=]. It is the empty string for [=subresource requests=], for requests whose [=request/destination=] is {{RequestDestination/"report"}}, and when |request|'s [=request/reserved client=] is null.
     </section>
 
     <section>

--- a/index.bs
+++ b/index.bs
@@ -1706,7 +1706,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
       <dfn attribute for="FetchEvent"><code>clientId</code></dfn> attribute *must* return the value it was initialized to. When an <a>event</a> is created the attribute *must* be initialized to the empty string.
 
-      Note: {{FetchEvent/clientId}} is |request|'s [=request/client=]'s [=environment/id=] for [=subresource requests=], and the empty string otherwise (including for [=non-subresource requests=] such as [=navigation requests=], or when |request|'s [=request/client=] is null). See {{FetchEvent/resultingClientId}} for the environment associated with the resulting document of a [=navigation request=].
+      Note: {{FetchEvent/clientId}} is the [=environment/id=] of |request|'s [=request/client=] when the [=/request=] has an associated initiating [=/service worker client=]. This is the case for [=subresource requests=], and also for [=non-subresource requests=] that were initiated by an existing client (such as [=worker=] script fetches, or a [=navigation request=] initiated by an existing document). It is the empty string when |request|'s [=request/client=] is null (e.g., a top-level [=navigation request=] triggered by the user typing a URL in the address bar). See {{FetchEvent/resultingClientId}} for the environment associated with the resulting document of a [=navigation request=].
     </section>
 
     <section>
@@ -3414,7 +3414,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Initialize |e|’s {{Event/cancelable}} attribute to true.
               1. Initialize |e|’s {{FetchEvent/request}} attribute to |requestObject|.
               1. Initialize |e|’s {{FetchEvent/preloadResponse}} to |preloadResponse|.
-              1. If |request| is a <a>subresource request</a> and |client| is not null, initialize |e|'s {{FetchEvent/clientId}} attribute to |client|'s [=environment/id=].
+              1. If |client| is not null, initialize |e|'s {{FetchEvent/clientId}} attribute to |client|'s [=environment/id=].
               1. If |request| is a <a>non-subresource request</a>, |request|'s [=request/destination=] is not {{RequestDestination/"report"}}, and |reservedClient| is not null, initialize |e|'s {{FetchEvent/resultingClientId}} attribute to |reservedClient|'s [=environment/id=].
               1. If |request| is a <a>navigation request</a>, initialize |e|'s {{FetchEvent/replacesClientId}} attribute to |request|'s [=request/replaces client id=].
               1. Initialize |e|’s {{FetchEvent/handled}} to |eventHandled|.

--- a/index.bs
+++ b/index.bs
@@ -1705,12 +1705,16 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       <h4 id="fetch-event-clientid">{{FetchEvent/clientId|event.clientId}}</h4>
 
       <dfn attribute for="FetchEvent"><code>clientId</code></dfn> attribute *must* return the value it was initialized to. When an <a>event</a> is created the attribute *must* be initialized to the empty string.
+
+      Note: {{FetchEvent/clientId}} is |request|'s [=request/client=]'s [=environment/id=] for [=subresource requests=], and the empty string otherwise (including for [=non-subresource requests=] such as [=navigation requests=], or when |request|'s [=request/client=] is null). See {{FetchEvent/resultingClientId}} for the environment associated with the resulting document of a [=navigation request=].
     </section>
 
     <section>
       <h4 id="fetch-event-resultingclientid">{{FetchEvent/resultingClientId|event.resultingClientId}}</h4>
 
       <dfn attribute for="FetchEvent"><code>resultingClientId</code></dfn> attribute *must* return the value it was initialized to. When an <a>event</a> is created the attribute *must* be initialized to the empty string.
+
+      Note: {{FetchEvent/resultingClientId}} is |request|'s [=request/reserved client=]'s [=environment/id=], or the empty string for [=subresource requests=], for requests whose [=request/destination=] is {{RequestDestination/"report"}}, or when |request|'s [=request/reserved client=] is null.
     </section>
 
     <section>
@@ -3410,9 +3414,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
               1. Initialize |e|’s {{Event/cancelable}} attribute to true.
               1. Initialize |e|’s {{FetchEvent/request}} attribute to |requestObject|.
               1. Initialize |e|’s {{FetchEvent/preloadResponse}} to |preloadResponse|.
-              1. Initialize |e|'s {{FetchEvent/clientId}} attribute to |client|'s [=environment/id=].
-              1. If |request| is a <a>non-subresource request</a> and |request|'s [=request/destination=] is not {{RequestDestination/"report"}}, initialize |e|'s {{FetchEvent/resultingClientId}} attribute to |reservedClient|'s [=environment/id=], and to the empty string otherwise.
-              1. If |request| is a <a>navigation request</a>, initialize |e|'s {{FetchEvent/replacesClientId}} attribute to |request|'s [=request/replaces client id=], and to the empty string otherwise.
+              1. If |request| is a <a>subresource request</a> and |client| is not null, initialize |e|'s {{FetchEvent/clientId}} attribute to |client|'s [=environment/id=].
+              1. If |request| is a <a>non-subresource request</a>, |request|'s [=request/destination=] is not {{RequestDestination/"report"}}, and |reservedClient| is not null, initialize |e|'s {{FetchEvent/resultingClientId}} attribute to |reservedClient|'s [=environment/id=].
+              1. If |request| is a <a>navigation request</a>, initialize |e|'s {{FetchEvent/replacesClientId}} attribute to |request|'s [=request/replaces client id=].
               1. Initialize |e|’s {{FetchEvent/handled}} to |eventHandled|.
               1. Let |timingInfo|'s [=service worker timing info/fetch event dispatch time=] to the [=coarsened shared current time=] given |useHighResPerformanceTimers|.
               1. <a>Dispatch</a> |e| at |activeWorker|'s [=service worker/global object=].


### PR DESCRIPTION
## Summary

Aligns the [Create Fetch Event and Dispatch](https://w3c.github.io/ServiceWorker/#create-fetch-event-and-dispatch-algorithm) algorithm and the `FetchEvent.clientId` / `resultingClientId` attribute definitions with **actual browser behavior** (Chrome, Firefox, Safari) and MDN.

Fixes #1267.

## Changes

### 1. `FetchEvent.clientId` algorithm step

Previously the spec unconditionally initialized `clientId` from `request`'s client, including for navigations. However, all major browsers return an empty string for `clientId` on navigation requests. Per [@wanderview's suggestion](https://github.com/w3c/ServiceWorker/issues/1267#issuecomment-362298501):

> My inclination is to probably implement resultingClientId and keep navigation clientId empty at first.

**Before:**
> If |client| is not null, initialize |e|'s clientId attribute to |client|'s environment id.

**After:**
> If |request| is a subresource request and |client| is not null, initialize |e|'s clientId attribute to |client|'s environment id.

### 2. `FetchEvent.resultingClientId` algorithm step

Adds an explicit `reservedClient` null check and removes the redundant "and to the empty string otherwise" clause (the IDL default already provides `""`).

### 3. `FetchEvent.replacesClientId` algorithm step

Removes the redundant "and to the empty string otherwise" clause for consistency with the sibling attributes.

### 4. Explanatory notes

Added descriptive notes for both `FetchEvent.clientId` and `FetchEvent.resultingClientId` attribute sections, documenting all cases where the value is the empty string. These match MDN's documented behavior.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/monica-ch/ServiceWorker/pull/1832.html" title="Last updated on Jul 17, 2026, 3:59 PM UTC (018917e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1832/e91ddff...monica-ch:018917e.html" title="Last updated on Jul 17, 2026, 3:59 PM UTC (018917e)">Diff</a>