### PR TITLE
Editorial: queue a task in ServiceWorkerContainer.getRegistration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -817,8 +817,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. If the [=environment settings object/origin=] of |clientURL| is not |client|'s [=environment settings object/origin=], return a |promise| rejected with a "{{SecurityError}}" {{DOMException}}.
         1. Let |promise| be a new <a>promise</a>.
         1. Run the following substeps <a>in parallel</a>:
+            1. Let |registration| be the result of running <a>Match Service Worker Registration</a> given |storage key| and |clientURL|.
             1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to run the following steps:
-                1. Let |registration| be the result of running <a>Match Service Worker Registration</a> given |storage key| and |clientURL|.
                 1. If |registration| is null, resolve |promise| with undefined and abort these steps.
                 1. Resolve |promise| with the result of [=getting the service worker registration object=] that represents |registration| in |promise|'s [=relevant settings object=].
         1. Return |promise|.

--- a/index.bs
+++ b/index.bs
@@ -817,9 +817,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. If the [=environment settings object/origin=] of |clientURL| is not |client|'s [=environment settings object/origin=], return a |promise| rejected with a "{{SecurityError}}" {{DOMException}}.
         1. Let |promise| be a new <a>promise</a>.
         1. Run the following substeps <a>in parallel</a>:
-            1. Let |registration| be the result of running <a>Match Service Worker Registration</a> given |storage key| and |clientURL|.
-            1. If |registration| is null, resolve |promise| with undefined and abort these steps.
-            1. Resolve |promise| with the result of [=getting the service worker registration object=] that represents |registration| in |promise|'s [=relevant settings object=].
+            1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to run the following steps:
+                1. Let |registration| be the result of running <a>Match Service Worker Registration</a> given |storage key| and |clientURL|.
+                1. If |registration| is null, resolve |promise| with undefined and abort these steps.
+                1. Resolve |promise| with the result of [=getting the service worker registration object=] that represents |registration| in |promise|'s [=relevant settings object=].
         1. Return |promise|.
     </section>
 


### PR DESCRIPTION
Update to [navigator-service-worker-getRegistration](https://w3c.github.io/ServiceWorker/#dom-serviceworkercontainer-getregistration).

The step running in parallel resolved/rejected the promise directly, which violates the "don't touch JS objects from parallel" rule. Wrap it in a `Queue a task` on the responsible event loop.

This is part 1/6 of #1740. Split out from #1755 for focused review.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/monica-ch/ServiceWorker/pull/1833.html" title="Last updated on Jul 17, 2026, 4:10 PM UTC (55ed06e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1833/e91ddff...monica-ch:55ed06e.html" title="Last updated on Jul 17, 2026, 4:10 PM UTC (55ed06e)">Diff</a>