### PR TITLE
Editorial: queue a task in NavigationPreloadManager

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -979,10 +979,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. Let |promise| be [=a new promise=].
         1. Run the following steps [=in parallel=]:
             1. Let |registration| be [=this=]'s associated [=/service worker registration=].
-            1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to run the following steps:
-                1. If |registration|'s [=active worker=] is null, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
-                1. Set |registration|'s [=navigation preload enabled flag=].
-                1. Resolve |promise| with undefined.
+            1. If |registration|'s [=active worker=] is null, [=queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
+            1. Set |registration|'s [=navigation preload enabled flag=].
+            1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to resolve |promise| with undefined.
         1. Return |promise|.
     </section>
 
@@ -994,10 +993,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. Let |promise| be [=a new promise=].
         1. Run the following steps [=in parallel=]:
             1. Let |registration| be [=this=]'s associated [=/service worker registration=].
-            1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to run the following steps:
-                1. If |registration|'s [=active worker=] is null, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
-                1. Unset |registration|'s [=navigation preload enabled flag=].
-                1. Resolve |promise| with undefined.
+            1. If |registration|'s [=active worker=] is null, [=queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
+            1. Unset |registration|'s [=navigation preload enabled flag=].
+            1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to resolve |promise| with undefined.
         1. Return |promise|.
     </section>
 
@@ -1011,10 +1009,9 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. Let |promise| be [=a new promise=].
         1. Run the following steps [=in parallel=]:
             1. Let |registration| be [=this=]'s associated [=/service worker registration=].
-            1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to run the following steps:
-                1. If |registration|'s [=active worker=] is null, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
-                1. Set |registration|'s [=navigation preload header value=] to |value|.
-                1. Resolve |promise| with undefined.
+            1. If |registration|'s [=active worker=] is null, [=queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
+            1. Set |registration|'s [=navigation preload header value=] to |value|.
+            1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to resolve |promise| with undefined.
         1. Return |promise|.
     </section>
 

--- a/index.bs
+++ b/index.bs
@@ -979,9 +979,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. Let |promise| be [=a new promise=].
         1. Run the following steps [=in parallel=]:
             1. Let |registration| be [=this=]'s associated [=/service worker registration=].
-            1. If |registration|'s [=active worker=] is null, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
-            1. Set |registration|'s [=navigation preload enabled flag=].
-            1. Resolve |promise| with undefined.
+            1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to run the following steps:
+                1. If |registration|'s [=active worker=] is null, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
+                1. Set |registration|'s [=navigation preload enabled flag=].
+                1. Resolve |promise| with undefined.
         1. Return |promise|.
     </section>
 
@@ -993,9 +994,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. Let |promise| be [=a new promise=].
         1. Run the following steps [=in parallel=]:
             1. Let |registration| be [=this=]'s associated [=/service worker registration=].
-            1. If |registration|'s [=active worker=] is null, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
-            1. Unset |registration|'s [=navigation preload enabled flag=].
-            1. Resolve |promise| with undefined.
+            1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to run the following steps:
+                1. If |registration|'s [=active worker=] is null, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
+                1. Unset |registration|'s [=navigation preload enabled flag=].
+                1. Resolve |promise| with undefined.
         1. Return |promise|.
     </section>
 
@@ -1009,9 +1011,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. Let |promise| be [=a new promise=].
         1. Run the following steps [=in parallel=]:
             1. Let |registration| be [=this=]'s associated [=/service worker registration=].
-            1. If |registration|'s [=active worker=] is null, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
-            1. Set |registration|'s [=navigation preload header value=] to |value|.
-            1. Resolve |promise| with undefined.
+            1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to run the following steps:
+                1. If |registration|'s [=active worker=] is null, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}, and abort these steps.
+                1. Set |registration|'s [=navigation preload header value=] to |value|.
+                1. Resolve |promise| with undefined.
         1. Return |promise|.
     </section>
 
@@ -1026,7 +1029,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
             1. Let |state| be a new {{NavigationPreloadState}} dictionary.
             1. If |registration|'s [=navigation preload enabled flag=] is set, set |state|["{{NavigationPreloadState/enabled}}"] to true.
             1. Set |state|["{{NavigationPreloadState/headerValue}}"] to |registration|'s [=navigation preload header value=].
-            1. Resolve |promise| with |state|.
+            1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=] to resolve |promise| with |state|.
         1. Return |promise|.
     </section>
 


### PR DESCRIPTION
Update to [navigation-preload-manager-enable](https://w3c.github.io/ServiceWorker/#dom-navigationpreloadmanager-enable), [navigation-preload-manager-disable](https://w3c.github.io/ServiceWorker/#dom-navigationpreloadmanager-disable), [navigation-preload-manager-setheadervalue](https://w3c.github.io/ServiceWorker/#dom-navigationpreloadmanager-setheadervalue), and [navigation-preload-manager-getstate](https://w3c.github.io/ServiceWorker/#dom-navigationpreloadmanager-getstate).

All four methods resolved/rejected their promises directly from an "in parallel" block, which violates the "don't touch JS objects from parallel" rule. Wrap the promise-touching steps in a `Queue a task` on the responsible event loop.

This is part 2/6 of #1740. Split out from #1755 for focused review.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/monica-ch/ServiceWorker/pull/1834.html" title="Last updated on Jul 17, 2026, 4:16 PM UTC (913c9a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1834/e91ddff...monica-ch:913c9a1.html" title="Last updated on Jul 17, 2026, 4:16 PM UTC (913c9a1)">Diff</a>