### PR TITLE
Editorial: queue a task in ServiceWorkerGlobalScope.skipWaiting

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1137,7 +1137,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. Run the following substeps <a>in parallel</a>:
             1. Set [=ServiceWorkerGlobalScope/service worker=]'s <a>skip waiting flag</a>.
             1. Invoke [=Try Activate=] with [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=].
-            1. Resolve |promise| with undefined.
+            1. [=Queue a task=] on [=ServiceWorkerGlobalScope/service worker=]'s [=responsible event loop=], to resolve |promise| with undefined.
         1. Return |promise|.
     </section>
 


### PR DESCRIPTION
Update to [service-worker-global-scope-skipwaiting](https://w3c.github.io/ServiceWorker/#dom-serviceworkerglobalscope-skipwaiting).

`skipWaiting()` resolved its promise directly from an "in parallel" block, which violates the "don't touch JS objects from parallel" rule. Wrap the resolve in a `Queue a task` on the service worker's responsible event loop.

This is part 3/6 of #1740. Split out from #1755 for focused review.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/monica-ch/ServiceWorker/pull/1835.html" title="Last updated on Jul 16, 2026, 9:01 PM UTC (f59630f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1835/e91ddff...monica-ch:f59630f.html" title="Last updated on Jul 16, 2026, 9:01 PM UTC (f59630f)">Diff</a>