### PR TITLE
Editorial: queue a task in Client / Clients API

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1282,10 +1282,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                 1. Let |source| be the result of [=getting the service worker object=] that represents |contextObject|'s [=relevant global object=]'s [=ServiceWorkerGlobalScope/service worker=] in |targetClient|.
                 1. Let |deserializeRecord| be <a abstract-op>StructuredDeserializeWithTransfer</a>(|serializeWithTransferResult|, |destination|'s [=relevant Realm=]).
 
-                    If this throws an exception, catch it, [=fire an event=] named {{ServiceWorkerContainer/messageerror!!event}} at |destination|, using {{MessageEvent}}, with its [=MessageEvent/origin=] initialized to |origin| and the {{MessageEvent/source}} attribute initialized to |source|, and then abort these steps.
+                    If this throws an exception, catch it, [=queue a task=] on |targetClient|'s [=responsible event loop=], using the [=DOM manipulation task source=], to [=fire an event=] named {{ServiceWorkerContainer/messageerror!!event}} at |destination|, using {{MessageEvent}}, with its [=MessageEvent/origin=] initialized to |origin| and the {{MessageEvent/source}} attribute initialized to |source|, and then abort these steps.
                 1. Let |messageClone| be |deserializeRecord|.\[[Deserialized]].
                 1. Let |newPorts| be a new [=frozen array type|frozen array=] consisting of all {{MessagePort}} objects in |deserializeRecord|.\[[TransferredValues]], if any.
-                1. [=Dispatch|Dispatch an event=] named {{Window/message!!event}} at |destination|, using {{MessageEvent}}, with its [=MessageEvent/origin=] initialized to |origin|, the {{MessageEvent/source}} attribute initialized to |source|, the {{MessageEvent/data}} attribute initialized to |messageClone|, and the {{MessageEvent/ports}} attribute initialized to |newPorts|.
+                1. [=Queue a task=] on |targetClient|'s [=responsible event loop=], using the [=DOM manipulation task source=], to [=Dispatch|Dispatch an event=] named {{Window/message!!event}} at |destination|, using {{MessageEvent}}, with its [=MessageEvent/origin=] initialized to |origin|, the {{MessageEvent/source}} attribute initialized to |source|, the {{MessageEvent/data}} attribute initialized to |messageClone|, and the {{MessageEvent/ports}} attribute initialized to |newPorts|.
     </section>
 
     <section>
@@ -1395,8 +1395,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
             1. For each [=/service worker client=] |client| where the result of running [=obtain a storage key=] given |client| [=storage key/equals=] the associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=]'s [=service worker registration/storage key=]:
                 1. If |client|'s [=environment/id=] is not |id|, [=continue=].
                 1. Wait for either |client|'s [=environment/execution ready flag=] to be set or for |client|'s [=discarded flag=] to be set.
-                1. If |client|'s [=environment/execution ready flag=] is set, then invoke [=Resolve Get Client Promise=] with |client| and |promise|, and abort these steps.
-            1. Resolve |promise| with undefined.
+                1. If |client|'s [=environment/execution ready flag=] is set, [=queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to run the following steps:
+                    1. Invoke [=Resolve Get Client Promise=] with |client| and |promise|.
+                    1. Abort these steps.
+            1. [=Queue a task=]  on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to resolve |promise| with undefined.
         1. Return |promise|.
     </section>
 
@@ -1503,7 +1505,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                     1. Invoke <a>Handle Service Worker Client Unload</a> with |client| as the argument.
                     1. Set |client|'s <a>active service worker</a> to [=ServiceWorkerGlobalScope/service worker=].
                     1. Invoke <a>Notify Controller Change</a> algorithm with |client| as the argument.
-            1. Resolve |promise| with undefined.
+            1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=] to resolve |promise| with undefined.
         1. Return |promise|.
     </section>
   </section>


### PR DESCRIPTION
Updates to:
- [client-postmessage-options](https://w3c.github.io/ServiceWorker/#dom-client-postmessage) — queue tasks to fire `messageerror` and dispatch `message` on the target client's responsible event loop.
- [clients-get](https://w3c.github.io/ServiceWorker/#dom-clients-get) — restructured per @yoshisatoyanagisawa's suggestion to queue once and run "invoke Resolve Get Client Promise" + "abort" as substeps; also queues the fall-through resolve.
- [clients-claim](https://w3c.github.io/ServiceWorker/#dom-clients-claim) — queue the final resolve with undefined on the promise's responsible event loop.

All of these resolved/rejected promises or fired events directly from an "in parallel" block, which violates the "don't touch JS objects from parallel" rule.

This is part 4/6 of #1740. Split out from #1755 for focused review.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/monica-ch/ServiceWorker/pull/1836.html" title="Last updated on Jul 16, 2026, 9:02 PM UTC (284e9d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1836/e91ddff...monica-ch:284e9d0.html" title="Last updated on Jul 16, 2026, 9:02 PM UTC (284e9d0)">Diff</a>