### PR TITLE
Editorial: queue a task in Cache API

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2030,14 +2030,14 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. Let |promise| be [=a new promise=].
         1. Run these substeps [=in parallel=]:
             1. Let |p| be the result of running the algorithm specified in {{Cache/matchAll(request, options)}} method with |request| and |options|.
-            1. Wait until |p| settles.
+            1. Wait until |p| settles.          
             1. If |p| rejects with an exception, then:
-                1. Reject |promise| with that exception.
+                1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to reject |promise| with that exception.
             1. Else if |p| resolves with an array, |responses|, then:
                 1. If |responses| is an empty array, then:
-                    1. Resolve |promise| with undefined.
+                    1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to resolve |promise| with undefined.
                 1. Else:
-                    1. Resolve |promise| with the first element of |responses|.
+                    1. [=Queue a task=] on |promise|'s [=relevant settings object=]'s [=responsible event loop=], using the [=DOM manipulation task source=], to resolve |promise| with the first element of |responses|.
         1. Return |promise|.
     </section>
 
@@ -2065,7 +2065,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                 1. [=list/For each=] |requestResponse| of |requestResponses|:
                     1. Add a copy of |requestResponse|'s response to |responses|.
             1. [=list/For each=] |response| of |responses|:
-                1. If |response|'s [=response/type=] is "`opaque`" and [=cross-origin resource policy check=] with |promise|'s [=relevant settings object=]'s [=environment settings object/origin=], |promise|'s [=relevant settings object=], "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then reject |promise| with a `TypeError` and abort these steps.
+                1. If |response|'s [=response/type=] is "`opaque`" and [=cross-origin resource policy check=] with |promise|'s [=relevant settings object=]'s [=environment settings object/origin=], |promise|'s [=relevant settings object=], "", and |response|'s [=filtered response/internal response=] returns <b>blocked</b>, then:
+                    1. [=Queue a task=], on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to perform the following steps:
+                        1. Reject |promise| with a `TypeError`.
+                        1. Abort these steps.
             1. [=Queue a task=], on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to perform the following steps:
                 1. Let |responseList| be a [=list=].
                 1. [=list/For each=] |response| of |responses|:


### PR DESCRIPTION
Updates to:
- [cache-match](https://w3c.github.io/ServiceWorker/#dom-cache-match) — wrap each resolve/reject path in a `Queue a task` on the promise's responsible event loop.
- [cache-matchall](https://w3c.github.io/ServiceWorker/#dom-cache-matchall) — wrap the CORS-check `TypeError` rejection in a `Queue a task` with an abort step.

Both methods resolved/rejected the promise directly from an "in parallel" block, which violates the "don't touch JS objects from parallel" rule.

This is part 5/6 of #1740. Split out from #1755 for focused review.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/monica-ch/ServiceWorker/pull/1837.html" title="Last updated on Jul 16, 2026, 9:04 PM UTC (b867686)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1837/e91ddff...monica-ch:b867686.html" title="Last updated on Jul 16, 2026, 9:04 PM UTC (b867686)">Diff</a>