### PR TITLE
Editorial: queue a task to reject promise in InstallEvent.addRoutes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1639,14 +1639,17 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
             Note: this step is for making |lifetimePromise| always fullfilled to avoid the install event failure.
 
+        1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
         1. [=queue/Enqueue=] the following steps to [=[[service worker queue]]=]:
             1. Let |allRules| be a copy of |serviceWorker|'s [=list of router rules=].
             1.  For each |rule| of |rules|:
                 1. Append |rule| to |allRules|.
 
-            1. If running the [=Check Router Registration Limit=] with |allRules| returns false, reject |promise| with a {{TypeError}}.
+            1. If running the [=Check Router Registration Limit=] with |allRules| returns false, then:
+                1. [=Queue a task=] to run the following steps on |serviceWorkerEventLoop| using the [=DOM manipulation task source=]:
+                    1. Reject |promise| with a {{TypeError}}.
+                1. Abort these steps.
             1. Set |serviceWorker|'s [=service worker/list of router rules=] to |allRules|.
-            1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
             1. [=Queue a task=] to run the following steps on |serviceWorkerEventLoop| using the [=DOM manipulation task source=]:
                 1. Resolve |promise| with undefined.
         1. Return |promise|.


### PR DESCRIPTION
This is a small follow-up related to #1740.

The rejection path inside the `[[service worker queue]]` block of `InstallEvent.addRoutes()` was rejecting |promise| directly from inside the [[service worker queue]] (a parallel queue)". Rejecting a JS promise from a parallel queue crosses the event-loop/parallel boundary and is the same pattern that #1740 flags across the spec.

This PR:

- Wraps the rejection in a `Queue a task` on the service worker's event loop, using the DOM manipulation task source, matching the existing resolve path a few lines below.
- Adds an `Abort these steps.` after the rejection queue so we don't fall through to `Set |serviceWorker|'s list of router rules` and the follow-up resolve on the same promise.
- Hoists `Let |serviceWorkerEventLoop| be the current global object's event loop.` above the `[=queue/Enqueue=]` block so both the reject and resolve tasks can reference it (and so the event loop is captured on the event-loop side, not inside the parallel queue).

Editorial only, no normative behavior change beyond making the failure path stop after rejecting (which it should already do — the previous text would set the rules and resolve after rejecting, which was a bug in the failure path).

This is a follow-up spun out of #1755, InstallEvent.addRoutes had the same reject-in-parallel bug, but sits outside the sections covered by any of those.

Refs: #1740


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/monica-ch/ServiceWorker/pull/1839.html" title="Last updated on Aug 3, 2026, 9:29 PM UTC (40bc41b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1839/e91ddff...monica-ch:40bc41b.html" title="Last updated on Aug 3, 2026, 9:29 PM UTC (40bc41b)">Diff</a>