### PR TITLE
Editorial: use a dedicated parallel queue for the Clients API

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1386,13 +1386,22 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     The user agent *must* create a {{Clients}} object when a {{ServiceWorkerGlobalScope}} object is created and associate it with that object.
 
+    The user agent has an associated <dfn>service worker clients parallel queue map</dfn>, a [=map=] whose [=map/keys=] are [=storage key=]s and whose [=map/values=] are [=parallel queue=]s. Each such [=parallel queue=] is used to serialize {{Clients}} operations that access [=/service worker clients=] with the corresponding [=storage key=].
+
+    The <dfn>service worker clients parallel queue</dfn> for a [=storage key=] |key| is the result of running the following steps:
+
+        1. If [=service worker clients parallel queue map=][|key|] does not [=map/exist=], then [=map/set=] [=service worker clients parallel queue map=][|key|] to a new [=parallel queue=].
+        1. Return [=service worker clients parallel queue map=][|key|].
+
+    The <dfn>relevant service worker clients parallel queue</dfn> for a {{Clients}} object is the [=service worker clients parallel queue=] for the {{Clients}} object's [=relevant global object=]'s [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=]'s [=service worker registration/storage key=].
+
     <section algorithm="clients-get">
       <h4 id="clients-get">{{Clients/get(id)}}</h4>
 
       The <dfn method for="Clients"><code>get(|id|)</code></dfn> method steps are:
 
         1. Let |promise| be a new <a>promise</a>.
-        1. Run these substeps <a>in parallel</a>:
+        1. [=queue/Enqueue=] the following steps to [=this=]'s [=relevant service worker clients parallel queue=]:
             1. For each [=/service worker client=] |client| where the result of running [=obtain a storage key=] given |client| [=storage key/equals=] the associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=]'s [=service worker registration/storage key=]:
                 1. If |client|'s [=environment/id=] is not |id|, [=continue=].
                 1. Wait for either |client|'s [=environment/execution ready flag=] to be set or for |client|'s [=discarded flag=] to be set.
@@ -1409,7 +1418,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       The <dfn method for="Clients"><code>matchAll(|options|)</code></dfn> method steps are:
 
         1. Let |promise| be [=a new promise=].
-        1. Run the following steps [=in parallel=]:
+        1. [=queue/Enqueue=] the following steps to [=this=]'s [=relevant service worker clients parallel queue=]:
             1. Let |targetClients| be a new [=list=].
             1. For each [=/service worker client=] |client| where the result of running [=obtain a storage key=] given |client| [=storage key/equals=] the associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=]'s [=service worker registration/storage key=]:
                 1. If |client|'s [=environment/execution ready flag=] is unset or |client|'s [=discarded flag=] is set, [=continue=].
@@ -1469,7 +1478,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. If no {{Window}} in this [=/origin=] has [=transient activation=], return a <a>promise</a> rejected with an "{{InvalidAccessError}}" {{DOMException}}.
         1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
         1. Let |promise| be a new <a>promise</a>.
-        1. Run these substeps <a>in parallel</a>:
+        1. [=queue/Enqueue=] the following steps to [=this=]'s [=relevant service worker clients parallel queue=]:
             1. Let |newContext| be a new [=top-level browsing context=].
             1. [=Queue a task=] to run the following steps on |newContext|'s {{Window}} object's [=environment settings object=]'s [=responsible event loop=] using the [=user interaction task source=]:
                 1. *HandleNavigate*: [=Navigate=] |newContext| to |url| with [=navigate/exceptionsEnabled=] true, and <i>[=navigate/historyHandling=]</i> "<code>replace</code>".
@@ -1492,7 +1501,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
         1. If the [=ServiceWorkerGlobalScope/service worker=] is not an <a>active worker</a>, return a <a>promise</a> rejected with an "{{InvalidStateError}}" {{DOMException}}.
         1. Let |promise| be a new <a>promise</a>.
-        1. Run the following substeps <a>in parallel</a>:
+        1. [=queue/Enqueue=] the following steps to [=this=]'s [=relevant service worker clients parallel queue=]:
             1. For each [=/service worker client=] |client| where the result of running [=obtain a storage key=] given |client| [=storage key/equals=] the [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=]'s [=service worker registration/storage key=]:
                 1. If |client|'s [=environment/execution ready flag=] is unset or |client|'s [=discarded flag=] is set, [=continue=].
                 1. If |client| is not a [=secure context=], [=continue=].

--- a/index.bs
+++ b/index.bs
@@ -1385,18 +1385,21 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     The user agent *must* create a {{Clients}} object when a {{ServiceWorkerGlobalScope}} object is created and associate it with that object.
 
+    Each {{Clients}} object has an associated <dfn>Clients parallel queue</dfn> (a [=parallel queue=]) used to serialize the {{Clients}} object's operations.
+
     <section algorithm="clients-get">
       <h4 id="clients-get">{{Clients/get(id)}}</h4>
 
       The <dfn method for="Clients"><code>get(|id|)</code></dfn> method steps are:
 
         1. Let |promise| be a new <a>promise</a>.
-        1. Run these substeps <a>in parallel</a>:
+        1. [=queue/Enqueue=] the following steps to [=this=]'s [=Clients parallel queue=]:
             1. For each [=/service worker client=] |client| where the result of running [=obtain a storage key=] given |client| [=storage key/equals=] the associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=]'s [=service worker registration/storage key=]:
                 1. If |client|'s [=environment/id=] is not |id|, [=continue=].
                 1. Wait for either |client|'s [=environment/execution ready flag=] to be set or for |client|'s [=discarded flag=] to be set.
                 1. If |client|'s [=environment/execution ready flag=] is set, then invoke [=Resolve Get Client Promise=] with |client| and |promise|, and abort these steps.
-            1. Resolve |promise| with undefined.
+            1. [=Queue a task=] to run the following steps on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=]:
+                1. Resolve |promise| with undefined.
         1. Return |promise|.
     </section>
 
@@ -1406,7 +1409,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
       The <dfn method for="Clients"><code>matchAll(|options|)</code></dfn> method steps are:
 
         1. Let |promise| be [=a new promise=].
-        1. Run the following steps [=in parallel=]:
+        1. [=queue/Enqueue=] the following steps to [=this=]'s [=Clients parallel queue=]:
             1. Let |targetClients| be a new [=list=].
             1. For each [=/service worker client=] |client| where the result of running [=obtain a storage key=] given |client| [=storage key/equals=] the associated [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=]'s [=service worker registration/storage key=]:
                 1. If |client|'s [=environment/execution ready flag=] is unset or |client|'s [=discarded flag=] is set, [=continue=].
@@ -1466,7 +1469,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. If no {{Window}} in this [=/origin=] has [=transient activation=], return a <a>promise</a> rejected with an "{{InvalidAccessError}}" {{DOMException}}.
         1. Let |serviceWorkerEventLoop| be the [=current global object=]'s [=event loop=].
         1. Let |promise| be a new <a>promise</a>.
-        1. Run these substeps <a>in parallel</a>:
+        1. [=queue/Enqueue=] the following steps to [=this=]'s [=Clients parallel queue=]:
             1. Let |newContext| be a new [=top-level browsing context=].
             1. [=Queue a task=] to run the following steps on |newContext|'s {{Window}} object's [=environment settings object=]'s [=responsible event loop=] using the [=user interaction task source=]:
                 1. *HandleNavigate*: [=Navigate=] |newContext| to |url| with [=navigate/exceptionsEnabled=] true, and <i>[=navigate/historyHandling=]</i> "<code>replace</code>".
@@ -1489,7 +1492,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
         1. If the [=ServiceWorkerGlobalScope/service worker=] is not an <a>active worker</a>, return a <a>promise</a> rejected with an "{{InvalidStateError}}" {{DOMException}}.
         1. Let |promise| be a new <a>promise</a>.
-        1. Run the following substeps <a>in parallel</a>:
+        1. [=queue/Enqueue=] the following steps to [=this=]'s [=Clients parallel queue=]:
             1. For each [=/service worker client=] |client| where the result of running [=obtain a storage key=] given |client| [=storage key/equals=] the [=ServiceWorkerGlobalScope/service worker=]'s [=containing service worker registration=]'s [=service worker registration/storage key=]:
                 1. If |client|'s [=environment/execution ready flag=] is unset or |client|'s [=discarded flag=] is set, [=continue=].
                 1. If |client| is not a [=secure context=], [=continue=].
@@ -1503,7 +1506,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                     1. Invoke <a>Handle Service Worker Client Unload</a> with |client| as the argument.
                     1. Set |client|'s <a>active service worker</a> to [=ServiceWorkerGlobalScope/service worker=].
                     1. Invoke <a>Notify Controller Change</a> algorithm with |client| as the argument.
-            1. Resolve |promise| with undefined.
+            1. [=Queue a task=] to run the following steps on |promise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=]:
+                1. Resolve |promise| with undefined.
         1. Return |promise|.
     </section>
   </section>


### PR DESCRIPTION
Closes #1840. Follow-up to #1755.

Give each {{Clients}} object a dedicated parallel queue and route the operations on {{Clients}} through it, so operations on the same {{Clients}} object do not race with each other (e.g. `matchAll` iterating over service worker clients while `claim` is mutating their [=active service worker=]).

## Changes

- Add a `<dfn export for="Clients">Clients parallel queue</dfn>` (a [=parallel queue=]) attached to each {{Clients}} object, following the same pattern as the `name to cache map parallel queue` introduced in #1838.
- Route the following method algorithms through it, replacing their existing top-level `Run … in parallel` block:
    - {{Clients/get(id)}}
    - {{Clients/matchAll(options)}}
    - {{Clients/openWindow(url)}}
    - {{Clients/claim()}}
- Wrap the two remaining bare `Resolve |promise| with undefined.` steps (in `get()` and `claim()`) in `Queue a task` on `|promise|`'s [=responsible event loop=] using the [=DOM manipulation task source=], matching the pattern already used in `matchAll()` and consistent with the queue-a-task refactor from #1755.

Total change: **+10 / −6** in `index.bs`, one commit.

## Rationale

Yoshi flagged this concern during #1755 review:

> I just wondered what happens if one of the service worker clients has been removed or gets execution ready flag during the sub step execution, and suggest to run Clients API algorithm within the dedicated parallel queue to prevent unexpected modifications to clients.

#1836 landed the queue-a-task-for-resolve fixes for these methods. This PR delivers the sibling parallel-queue work that was explicitly deferred in the [split plan](https://github.com/w3c/ServiceWorker/pull/1755#issuecomment-4963401716).

## Out of scope

- {{Client/postMessage(message, options)}} — lives on {{Client}}, not {{Clients}}, and does a single-client lookup rather than iterating the full client list. Can be a further follow-up if needed.
- {{WindowClient/focus()}} and {{WindowClient/navigate(url)}} — already skip the `in parallel` block entirely and use `Queue a task` on the client's own event loop, so no parallel-queue treatment is meaningful for them.

## Related

- #1755 — parent (queue-a-task refactor)
- #1836 — Clients API queue-a-task-for-resolve (merged)
- #1740 — original missing-tasks-in-parallel issue
- #1172 — umbrella "Carefully audit all uses of 'in parallel' in the spec"
- #1838 — sibling PR (CacheStorage-level parallel queue), same dfn pattern
- #1841 — sibling PR (per-cache parallel queue), same dfn pattern


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/monica-ch/ServiceWorker/pull/1842.html" title="Last updated on Aug 18, 2026, 9:16 PM UTC (73a7c0b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1842/9e9fe27...monica-ch:73a7c0b.html" title="Last updated on Aug 18, 2026, 9:16 PM UTC (73a7c0b)">Diff</a>