### PR TITLE
Editorial: use a per-cache dedicated parallel queue for Cache API methods

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1962,6 +1962,8 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
     A <dfn id="dfn-request-response-list">request response list</dfn> is a [=list=] of [=tuples=] consisting of a request (a [=/request=]) and a response (a [=/response=]).
 
+    A [=request response list=] has an associated <dfn>request response list parallel queue</dfn> (a [=parallel queue=]) used to serialize reads and writes on the [=request response list=].
+
     The <dfn id="dfn-relevant-request-response-list">relevant request response list</dfn> is the instance that [=this=] represents.
 
     A <dfn id="dfn-name-to-cache-map">name to cache map</dfn> is an <a>ordered map</a> whose [=map/entry=] consists of a [=map/key=] (a string that represents the name of a [=request response list=]) and a [=map/value=] (a [=request response list=]).
@@ -2055,7 +2057,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                 1. Set |r| to the associated [=Request/request=] of the result of invoking the initial value of {{Request}} as constructor with |request| as its argument. If this [=throws=] an exception, return [=a promise rejected with=] that exception.
         1. Let |realm| be [=this=]'s [=relevant realm=].
         1. Let |promise| be [=a new promise=].
-        1. Run these substeps [=in parallel=]:
+        1. [=queue/Enqueue=] the following steps to [=this=]'s [=relevant request response list=]'s [=request response list parallel queue=]:
             1. Let |responses| be an empty [=list=].
             1. If the optional argument |request| is omitted, then:
                 1. [=list/For each=] |requestResponse| of the [=relevant request response list=]:
@@ -2135,7 +2137,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                 1. Increment |index| by one.
             1. Let |realm| be [=this=]'s [=relevant realm=].
             1. Let |cacheJobPromise| be [=a new promise=].
-            1. Run the following substeps [=in parallel=]:
+            1. [=queue/Enqueue=] the following steps to [=this=]'s [=relevant request response list=]'s [=request response list parallel queue=]:
                 1. Let |errorData| be null.
                 1. Invoke [=Batch Cache Operations=] with |operations|. If this [=throws=] an exception, set |errorData| to the exception.
                 1. [=Queue a task=], on |cacheJobPromise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to perform the following substeps:
@@ -2180,7 +2182,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. Let |realm| be [=this=]'s [=relevant realm=].
         1. Return the result of the [=Upon fulfillment|fulfillment=] of |bodyReadPromise|:
             1. Let |cacheJobPromise| be [=a new promise=].
-            1. Return |cacheJobPromise| and run these steps [=in parallel=]:
+            1. Return |cacheJobPromise| and [=queue/Enqueue=] the following steps to [=this=]'s [=relevant request response list=]'s [=request response list parallel queue=]:
                 1. Let |errorData| be null.
                 1. Invoke [=Batch Cache Operations=] with |operations|. If this [=throws=] an exception, set |errorData| to the exception.
                 1. [=Queue a task=], on |cacheJobPromise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to perform the following substeps:
@@ -2207,7 +2209,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
         1. [=list/Append=] |operation| to |operations|.
         1. Let |realm| be [=this=]'s [=relevant realm=].
         1. Let |cacheJobPromise| be [=a new promise=].
-        1. Run the following substeps [=in parallel=]:
+        1. [=queue/Enqueue=] the following steps to [=this=]'s [=relevant request response list=]'s [=request response list parallel queue=]:
             1. Let |errorData| be null.
             1. Let |requestResponses| be the result of running [=Batch Cache Operations=] with |operations|. If this [=throws=] an exception, set |errorData| to the exception.
             1. [=Queue a task=], on |cacheJobPromise|'s [=relevant settings object=]'s [=responsible event loop=] using the [=DOM manipulation task source=], to perform the following substeps:
@@ -2232,7 +2234,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                 1. Set |r| to the associated [=Request/request=] of the result of invoking the initial value of {{Request}} as constructor with |request| as its argument. If this [=throws=] an exception, return [=a promise rejected with=] that exception.
         1. Let |realm| be [=this=]'s [=relevant realm=].
         1. Let |promise| be [=a new promise=].
-        1. Run these substeps [=in parallel=]:
+        1. [=queue/Enqueue=] the following steps to [=this=]'s [=relevant request response list=]'s [=request response list parallel queue=]:
             1. Let |requests| be an empty [=list=].
             1. If the optional argument |request| is omitted, then:
                 1. [=list/For each=] |requestResponse| of the [=relevant request response list=]:


### PR DESCRIPTION
Closes #1841. Follow-up to #1755, sibling to #1838.

Give each [=request response list=] (the internal representation of a {{Cache}} object) a dedicated parallel queue and route the {{Cache}} methods that read or mutate it through the queue, so reads and writes on the same {{Cache}} object are serialized.

## Changes

- Add `<dfn>request response list parallel queue</dfn>` (a [=parallel queue=]) attached to each [=request response list=], following the same pattern that #1838 introduced for the [=name to cache map=].
- Route the following {{Cache}} method algorithms through it, replacing their existing `Run … in parallel` block:
    - {{Cache/matchAll(request, options)}}
    - {{Cache/addAll(requests)}} — only the batch-commit step; the per-request fetch step is left as bare `in parallel` since it does not touch the [=request response list=].
    - {{Cache/put(request, response)}}
    - {{Cache/delete(request, options)}}
    - {{Cache/keys(request, options)}}
- The existing `Queue a task` wrappers around promise resolution / rejection (from #1837) are preserved inside the enqueued steps.

Total change: **+7 / −5** in `index.bs`, one commit.

## Out of scope (deliberately)

- {{Cache/match(request, options)}} — a pure orchestrator that delegates to `matchAll`; enqueueing it too would cause a deadlock (it waits on a promise that can only be settled by another enqueued step). Covered transitively.
- {{Cache/add(request)}} — pure orchestrator that delegates to `addAll`. Same reason.
- {{Cache/addAll}}'s per-request fetch block — only performs [=/fetching=]; does not touch the [=request response list=].

## Rationale

Yoshi flagged this concern during #1755 review:

> The situation should also be the same for the [=cache=] object. I guess each [=cache=] object will have the dedicated parallel queue, and `match()`, `matchAll()`, `add()`, `addAll()`, `put()`, `delete()`, and `keys()` might also executed within the parallel queue for the [=cache=] object.

#1837 landed the queue-a-task-for-resolve fixes for these methods. This PR delivers the sibling per-cache parallel-queue work that was explicitly deferred in the [split plan](https://github.com/w3c/ServiceWorker/pull/1755#issuecomment-4963401716).

## Coordination

The changes here do not overlap textually with the queue-a-task changes in #1837 — that PR only touches the promise resolve/reject lines, this PR only touches the outer `Run in parallel` lines. Either can merge first.

## Related

- #1755 — parent (queue-a-task refactor)
- #1837 — Cache API queue-a-task-for-resolve (open)
- #1838 — sibling PR (CacheStorage `name to cache map` parallel queue), same dfn pattern
- #1740 — original missing-tasks-in-parallel issue
- #1831 — cache/cache-storage forgot to queue a task to resolve promise
- #1172 — umbrella "Carefully audit all uses of 'in parallel' in the spec"
- #1842 — sibling PR (Clients API parallel queue), same dfn pattern


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/monica-ch/ServiceWorker/pull/1843.html" title="Last updated on Aug 4, 2026, 9:16 PM UTC (09f4f7a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1843/e91ddff...monica-ch:09f4f7a.html" title="Last updated on Aug 4, 2026, 9:16 PM UTC (09f4f7a)">Diff</a>