### PR TITLE
Editorial: remove nested Queue a task around message dispatch in Client.postMessage

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1283,10 +1283,10 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
                 1. Let |source| be the result of [=getting the service worker object=] that represents |contextObject|'s [=relevant global object=]'s [=ServiceWorkerGlobalScope/service worker=] in |targetClient|.
                 1. Let |deserializeRecord| be <a abstract-op>StructuredDeserializeWithTransfer</a>(|serializeWithTransferResult|, |destination|'s [=relevant Realm=]).
 
-                    If this throws an exception, catch it, [=queue a task=] on |targetClient|'s [=responsible event loop=], using the [=DOM manipulation task source=], to [=fire an event=] named {{ServiceWorkerContainer/messageerror!!event}} at |destination|, using {{MessageEvent}}, with its [=MessageEvent/origin=] initialized to |origin| and the {{MessageEvent/source}} attribute initialized to |source|, and then abort these steps.
+                    If this throws an exception, catch it, [=fire an event=] named {{ServiceWorkerContainer/messageerror!!event}} at |destination|, using {{MessageEvent}}, with its [=MessageEvent/origin=] initialized to |origin| and the {{MessageEvent/source}} attribute initialized to |source|, and then abort these steps.
                 1. Let |messageClone| be |deserializeRecord|.\[[Deserialized]].
                 1. Let |newPorts| be a new [=frozen array type|frozen array=] consisting of all {{MessagePort}} objects in |deserializeRecord|.\[[TransferredValues]], if any.
-                1. [=Queue a task=] on |targetClient|'s [=responsible event loop=], using the [=DOM manipulation task source=], to [=Dispatch|Dispatch an event=] named {{Window/message!!event}} at |destination|, using {{MessageEvent}}, with its [=MessageEvent/origin=] initialized to |origin|, the {{MessageEvent/source}} attribute initialized to |source|, the {{MessageEvent/data}} attribute initialized to |messageClone|, and the {{MessageEvent/ports}} attribute initialized to |newPorts|.
+                1. [=Dispatch|Dispatch an event=] named {{Window/message!!event}} at |destination|, using {{MessageEvent}}, with its [=MessageEvent/origin=] initialized to |origin|, the {{MessageEvent/source}} attribute initialized to |source|, the {{MessageEvent/data}} attribute initialized to |messageClone|, and the {{MessageEvent/ports}} attribute initialized to |newPorts|.
     </section>
 
     <section>


### PR DESCRIPTION
Follow-up to #1836. Addresses [@asutherland's comment](https://github.com/w3c/ServiceWorker/pull/1836#issuecomment-3252891569).

`Client.postMessage`'s `fire messageerror` and `Dispatch message` steps already run inside `Add a task ... to |destination|'s client message queue`, which runs on `|targetClient|`'s event loop. #1836 added an inner `Queue a task on |targetClient|'s responsible event loop, using the DOM manipulation task source` around each step, which:

- **Requeues to the same event loop** the outer task already put us on — no crossing to do.
- **Changes the task source** from the client message queue's source to DOM manipulation, losing the ordering guarantees `postMessage` needs.
- **Splits one delivery into two tasks**, letting other event-loop work interleave between deserialization and dispatch.

This PR removes the two inner wrappers. `Clients.get` and `Clients.claim` from #1836 are unchanged.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/monica-ch/ServiceWorker/pull/1844.html" title="Last updated on Aug 5, 2026, 10:20 PM UTC (4968a23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1844/9e9fe27...monica-ch:4968a23.html" title="Last updated on Aug 5, 2026, 10:20 PM UTC (4968a23)">Diff</a>