### PR TITLE
Add Register a Service Worker algorithm for use by other specifications

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2777,6 +2777,29 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section algorithm>
+    <h3 id="register-a-service-worker-algorithm"><dfn export>Register a Service Worker</dfn></h3>
+
+    Note: Because this algorithm has no calling [=/service worker client=], the [=job/referrer=] is not set by [=Create Job=]. To satisfy the same-origin checks in the [=Register=] algorithm (steps 2 and 3), this algorithm explicitly sets the job's [=job/referrer=] to |scriptURL|. Combined with the same-origin precondition asserted in step 1, this ensures both same-origin checks in [=Register=] pass.
+
+      : Input
+      :: |storageKey|, a [=/storage key=]
+      :: |scriptURL|, a [=/URL=]
+      :: |scopeURL|, a [=/URL=]
+      :: |workerType|, a [=job/worker type=]
+      :: |updateViaCache|, a [=service worker registration/update via cache mode=]
+      : Output
+      :: None
+
+      1. Assert: |scriptURL|'s [=url/origin=] and |scopeURL|'s [=url/origin=] are [=same origin=].
+      1. If the result of running <a>potentially trustworthy origin</a> with |scriptURL|'s [=url/origin=] as the argument is <code>Not Trusted</code>, return.
+      1. Let |job| be the result of running <a>Create Job</a> with *register*, |storageKey|, |scopeURL|, |scriptURL|, null, and null.
+      1. Set |job|'s [=job/worker type=] to |workerType|.
+      1. Set |job|'s [=job/update via cache mode=] to |updateViaCache|.
+      1. Set |job|'s [=job/referrer=] to |scriptURL|.
+      1. Invoke <a>Schedule Job</a> with |job|.
+  </section>
+
+  <section algorithm>
     <h3 id="update-algorithm"><dfn>Update</dfn></h3>
 
       : Input


### PR DESCRIPTION
Part of #1846.

This introduces a new exported algorithm — a stable public surface that external specifications can bind to.

## Change

Adds an exported [`Register a Service Worker`](https://w3c.github.io/ServiceWorker/#register-a-service-worker-algorithm) algorithm so other specifications such as FedCM and Payment Handler can register a service worker without a client-driven flow.

It also extracts the URL checks from [`Start Register`](https://w3c.github.io/ServiceWorker/#start-register-algorithm) into a shared `Validate and Normalize a Service Worker URL` algorithm. Both JavaScript registration and browser-initiated registration now use the same rules:

- remove URL fragments;
- require an HTTP or HTTPS scheme; and
- reject paths containing encoded `/` or `\` characters.

The existing JavaScript behavior is preserved: invalid URLs reject the `register()` promise with `TypeError`, and a missing scope still defaults to the script URL's directory. The exported algorithm is fire-and-forget and returns when validation fails.

## Exported algorithm

**Input:** storage key, script URL, scope URL, worker type, and update-via-cache mode  
**Output:** none

The algorithm validates and normalizes the URLs, requires the script and scope to be same-origin, checks that the script origin is potentially trustworthy, creates a register job with a null client and promise, and schedules it.

Because there is no calling service worker client, the algorithm sets the job's referrer to the normalized script URL. This allows the existing [`Register`](https://w3c.github.io/ServiceWorker/#register-algorithm) same-origin checks to remain the canonical enforcement point.

## Adoption implications

- FedCM (w3c-fedid/FedCM#842) and Payment Handler can use this instead of invoking non-exported job algorithms directly.
- The `(storageKey, scriptURL, scopeURL, workerType, updateViaCache)` signature becomes a stability commitment.
- Registration remains asynchronous and fire-and-forget; no completion or failure signal is returned.

## Related

- #1846 — umbrella issue
- w3c-fedid/FedCM#842 — motivating PR
- #1847 — `Request Soft Update`
- #1849 — `Unregister Service Workers`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/monica-ch/ServiceWorker/pull/1848.html" title="Last updated on Sep 9, 2026, 4:57 AM UTC (e053de5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1848/92aba3b...monica-ch:e053de5.html" title="Last updated on Sep 9, 2026, 4:57 AM UTC (e053de5)">Diff</a>