### PR TITLE
Add Unregister Service Workers algorithm for use by other specifications

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3761,6 +3761,25 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
   </section>
 
   <section algorithm>
+    <h3 id="unregister-service-workers-algorithm"><dfn export>Unregister Service Workers</dfn></h3>
+
+      : Input
+      :: |storageKey|, a [=/storage key=]
+      : Output
+      :: None
+
+      1. Let |scopes| be a new [=list=].
+      1. [=list/For each=] (|entryStorageKey|, |serializedScope|) of [=registration map=]'s [=map/keys=]:
+          1. If |entryStorageKey| is not |storageKey|, [=continue=].
+          1. Let |scopeURL| be the result of <a lt="URL parser">parsing</a> |serializedScope|.
+          1. If |scopeURL| is failure, [=continue=].
+          1. [=list/Append=] |scopeURL| to |scopes|.
+      1. [=list/For each=] |scope| of |scopes|:
+          1. Let |job| be the result of running <a>Create Job</a> with *unregister*, |storageKey|, |scope|, null, null, and null.
+          1. Invoke <a>Schedule Job</a> with |job|.
+  </section>
+
+  <section algorithm>
     <h3 id="set-registration-algorithm"><dfn>Set Registration</dfn></h3>
 
       : Input


### PR DESCRIPTION
Part of #1846.

This introduces a new exported algorithm — a stable public surface that external specifications can bind to.

## Change

Adds an exported [`Unregister Service Workers`](https://w3c.github.io/ServiceWorker/#unregister-service-workers-algorithm) algorithm so other specifications such as FedCM and Payment Handler can schedule unregistration of all service worker registrations for a storage key.

## Algorithm

**Input:** storage key  
**Output:** none

The algorithm:

1. collects the serialized scopes whose storage keys compare equal to the input;
2. parses each scope URL; and
3. creates and schedules an unregister job for each valid scope.

Collecting the scopes before scheduling avoids iterating the registration map while unregister jobs can modify it.

## Completion contract

The algorithm is intentionally fire-and-forget. It does not wait for the unregister jobs to finish, so matching registration-map entries might still exist when it returns.

Waiting for the jobs would only guarantee removal from the registration map. It would not guarantee physical destruction: [`Clear Registration`](https://w3c.github.io/ServiceWorker/#clear-registration-algorithm) can remain delayed while a client uses the registration or the registration's workers have pending lifetime work.

This matches the current FedCM teardown model, which stops dispatching to the identity handler when its declaration is removed and allows the registration itself to be removed asynchronously. Clear-Site-Data similarly invokes service worker unregistration without waiting for its promise.

## Adoption implications

- FedCM (w3c-fedid/FedCM#842) and Payment Handler can use this instead of depending on non-exported job algorithms.
- The operation applies to every registration whose storage key equals the input.
- Callers needing stronger coordination cannot treat return from this algorithm as confirmation of removal.

## Related

- #1846 — umbrella issue
- w3c-fedid/FedCM#842 — motivating PR
- #1847 — `Request Soft Update`
- #1848 — `Register a Service Worker`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/monica-ch/ServiceWorker/pull/1849.html" title="Last updated on Sep 9, 2026, 6:23 PM UTC (55d9288)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ServiceWorker/1849/92aba3b...monica-ch:55d9288.html" title="Last updated on Sep 9, 2026, 6:23 PM UTC (55d9288)">Diff</a>